### PR TITLE
Adding Hooks Api

### DIFF
--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -430,4 +430,88 @@ class Repo extends Api
     {
         return $this->get('repos/'.urlencode($username).'/'.urlencode($repo).'/hooks');
     }
+
+    /**
+     * Get the hooks for selected repository
+     * @link http://developer.github.com/v3/repos/hooks/#get-single-hook
+     *
+     * @param  string  $username         the user who owns the repo
+     * @param  string  $repo             the name of the repo
+     * @param  integer $id               the id of the hook
+     *
+     * @return array
+     */
+    public function getRepoHook($username, $repo, $id)
+    {
+        return $this->get('repos/'.urlencode($username).'/'.urlencode($repo).'/hooks/'.urlencode($id));
+    }
+
+    /**
+     * Add hook informations by username and repo. Requires authentication.
+     * @link http://developer.github.com/v3/repos/hooks/#edit-a-hook
+     *
+     * @param   string  $username         the username
+     * @param   string  $repo             the repo
+     * @param   string  $name             the name of the service that is being called. @see https://api.github.com/hooks for the possible names.
+     * @param   array   $config           an array containing key/value pairs to provide settings for this hook
+     * @param   array   $events           Determines what events the hook is triggered for. Default: ["push"].
+     * @param   boolean $active           Determines whether the hook is actually triggered on pushes.
+     *
+     * @return  array                     information about the issue
+     */
+    public function addRepoHook($username, $repo, $name, $config, $events = array(), $active = true)
+    {
+        return $this->post('repos/'.urlencode($username).'/'.urlencode($repo).'/hooks/', array(
+            'name' => $name,
+            'config' => $config,
+            'events' => $events,
+            'active' => $active
+        ));
+    }
+
+    /**
+     * Update hook informations by username, repo and hook number. Requires authentication.
+     * @link http://developer.github.com/v3/repos/hooks/#edit-a-hook
+     *
+     * @param   string  $username         the username
+     * @param   string  $repo             the repo
+     * @param   string  $id               the hook id
+     * @param   array   $data             key=>value user attributes to update.
+     *
+     * @return  array                     information about the issue
+     */
+    public function updateRepoHook($username, $repo, $id, array $data)
+    {
+        return $this->patch('repos/'.urlencode($username).'/'.urlencode($repo).'/hooks/'.urlencode($id), $data);        
+    }
+
+    /**
+     * Delete a hook in selected repository
+     * @link http://developer.github.com/v3/repos/hooks/#delete-a-hook
+     *
+     * @param  string  $username         the user who owns the repo
+     * @param  string  $repo             the name of the repo
+     * @param  integer $id               the id of the hook
+     *
+     * @return array
+     */
+    public function deleteRepoHook($username, $repo, $id)
+    {
+        return $this->delete('repos/'.urlencode($username).'/'.urlencode($repo).'/hooks/'.urlencode($id));
+    }
+
+    /**
+     * Test a hook in selected repository
+     * @link http://developer.github.com/v3/repos/hooks/#test-a-hook
+     *
+     * @param  string  $username         the user who owns the repo
+     * @param  string  $repo             the name of the repo
+     * @param  integer $id               the id of the hook
+     *
+     * @return array
+     */
+    public function testRepoHook($username, $repo, $id)
+    {
+        return $this->post('repos/'.urlencode($username).'/'.urlencode($repo).'/hooks/'.urlencode($id)."/test");        
+    }
 }


### PR DESCRIPTION
Hey guys,

This isn't complete but I wanted to kick off a discussion. I want to add the [Repo Hooks Api](http://developer.github.com/v3/repos/hooks/) to the library but I'm not 100% sure where.
1. The Repo Hooks Api is listed under Repo (just like Teams is under Organisations) in the Github Docs.
2. The library has getTeams() & addTeams() in the Organisation Api

So based on that I'm assuming the correct spot for the Repo Hook Api methods is in the Repo Api library.

Here's the new methods I plan to implement:
- getRepoHooks() (naming convention based on [Repo::getRepoDownloads()](https://github.com/leevigraham/php-github-api/blob/master/lib/Github/Api/Repo.php#L400)
- deleteRepoHook() (naming convention based on [Repo::deleteRepoDownload()](https://github.com/leevigraham/php-github-api/blob/master/lib/Github/Api/Repo.php#L415)
- getRepoHook()
- addRepoHook()
- editRepoHook()
- testRepoHook()

Also it looks like there is some inconsistency with naming methods. [Repo::getRepoDownloads()](https://github.com/leevigraham/php-github-api/blob/master/lib/Github/Api/Repo.php#L400) vs [Organisation::getTeam()](https://github.com/leevigraham/php-github-api/blob/master/lib/Github/Api/Organization.php#L90)

Thoughts?
