### PR TITLE
Added delete support to the Github/Api/Repo

### DIFF
--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -87,6 +87,20 @@ class Repo extends AbstractApi
     }
 
     /**
+     * Delete a repository
+     * @link http://developer.github.com/v3/repos/
+     *
+     * @param  string  $username         the user who owns the repository
+     * @param  string  $repository       the name of the repository
+     *
+     * @return mixed                     null on success, arrray on error with 'message'
+     */
+    public function delete($username, $repository)
+    {
+        return parent::delete('repos/'.urlencode($username).'/'.urlencode($repository));
+    }
+
+    /**
      * Manage the collaborators of a repository
      * @link http://developer.github.com/v3/repos/collaborators/
      *

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -269,7 +269,36 @@ class RepoTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->update('l3l0Repo', 'test', array('description' => 'test', 'homepage' => 'http://l3l0.eu')));
     }
+    
+    /** 
+     * @test
+     */
+    public function shouldDelete()
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('l3l0Repo', 'test')
+            ->will($this->returnValue(null));
 
+        $this->assertNull($api->delete('l3l0Repo', 'test'));
+    }
+
+    /** 
+     * @test
+     */
+    public function shouldNotDelete()
+    {
+        $expectedArray = array('message'=>'Not Found');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('l3l0Repo', 'uknown-repo')
+            ->will($this->returnValue(array('message'=>'Not Found')));
+
+        $this->assertEquals($expectedArray, $api->delete('l3l0Repo', 'uknown-repo'));
+    }
     /**
      * @test
      */


### PR DESCRIPTION
First of all, I was a little bit confused that although in the docs the `Repo::delete('user','repo)` was mentioned I could not find it in the object.
Secondly, response is `null` or I am doing something wrong.
