### PR TITLE
Authentication with AUTH_URL_TOKEN bug fix

### DIFF
--- a/lib/Github/HttpClient/Listener/AuthListener.php
+++ b/lib/Github/HttpClient/Listener/AuthListener.php
@@ -86,7 +86,7 @@ class AuthListener implements ListenerInterface
                 }
 
                 $url  = $request->getUrl();
-                $url .= '?'.utf8_encode(http_build_query(array('access_token' => $this->options['tokenOrLogin']), '', '&'));
+                $url .= (false === strpos($url, '?') ? '?' : '&').utf8_encode(http_build_query(array('access_token' => $this->options['tokenOrLogin']), '', '&'));
 
                 $request->fromUrl(new Url($url));
                 break;


### PR DESCRIPTION
If user authenticates with AUTH_URL_TOKEN and request parameter are not empty access_token must be appended by `&` (and not `?`)
