### PR TITLE
Add fall back message for custom error messages

### DIFF
--- a/lib/Github/HttpClient/Listener/ErrorListener.php
+++ b/lib/Github/HttpClient/Listener/ErrorListener.php
@@ -71,10 +71,14 @@ class ErrorListener implements ListenerInterface
                                 $errors[] = sprintf('Field "%s" already exists, for resource "%s"', $error['field'], $error['resource']);
                                 break;
 
+                            default:
+                                $errors[] = $error['message'];
+                                break;
+
                         }
                     }
 
-                    throw new ValidationFailedException('Validation Failed:' . implode(', ', $errors), 422);
+                    throw new ValidationFailedException('Validation Failed: ' . implode(', ', $errors), 422);
                 }
             }
 


### PR DESCRIPTION
Github also throws `custom` error messages and the switch doesn't catch it.

```
[errors] => Array
(
    [0] => Array
    (
        [code] => custom
        [resource] => Repository
        [field] => name
        [message] => name can't be private. You are over your quota.
    )
)
```

Adding a `default` fixes this.
