### PR TITLE
Add an exception interface

### DIFF
--- a/lib/Github/Exception/ErrorException.php
+++ b/lib/Github/Exception/ErrorException.php
@@ -7,7 +7,7 @@ namespace Github\Exception;
  *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
-class ErrorException extends \ErrorException
+class ErrorException extends \ErrorException implements ExceptionInterface
 {
 
 }

--- a/lib/Github/Exception/ExceptionInterface.php
+++ b/lib/Github/Exception/ExceptionInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Github\Exception;
+
+interface ExceptionInterface
+{
+
+}

--- a/lib/Github/Exception/InvalidArgumentException.php
+++ b/lib/Github/Exception/InvalidArgumentException.php
@@ -7,7 +7,7 @@ namespace Github\Exception;
  *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
-class InvalidArgumentException extends \InvalidArgumentException
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 
 }

--- a/lib/Github/Exception/RuntimeException.php
+++ b/lib/Github/Exception/RuntimeException.php
@@ -7,7 +7,7 @@ namespace Github\Exception;
  *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
-class RuntimeException extends \RuntimeException
+class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 
 }


### PR DESCRIPTION
This feature make possible to catch all php-github-api exceptions without catching anything not php-github-api specific and ease the use of handling exceptions.
