### PR TITLE
[BUGFIX] Empty JSON-Content will be added to request

### DIFF
--- a/lib/Github/HttpClient/HttpClient.php
+++ b/lib/Github/HttpClient/HttpClient.php
@@ -167,7 +167,9 @@ class HttpClient implements HttpClientInterface
 
         $request = $this->createRequest($httpMethod, $path);
         $request->addHeaders($headers);
-        $request->setContent(json_encode($parameters));
+        if (count($parameters) > 0) {
+            $request->setContent(json_encode($parameters));
+        }
 
         $hasListeners = 0 < count($this->listeners);
         if ($hasListeners) {

--- a/test/Github/Tests/HttpClient/HttpClientTest.php
+++ b/test/Github/Tests/HttpClient/HttpClientTest.php
@@ -84,6 +84,23 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
         $httpClient = new HttpClient(array(), $client);
         $httpClient->post($path, $parameters, $headers);
+
+        $this->assertEquals('{"a":"b"}', $httpClient->getLastRequest()->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldDoPOSTRequestWithoutContent()
+    {
+        $path       = '/some/path';
+
+        $client = $this->getBrowserMock();
+
+        $httpClient = new HttpClient(array(), $client);
+        $httpClient->post($path);
+
+        $this->assertEmpty($httpClient->getLastRequest()->getContent());
     }
 
     /**


### PR DESCRIPTION
If you create an POST-Request (e.g. with an forking action) the HTTPClient will be created with a post content "[]".
This can create some problems on requesting path.

At the moment, if you fork a repository with the following code you will get an exception (500 internal server error on github).

``` php
$client = new Github\Client();
$client->getHttpClient();
$client->authenticate('User', 'Password', Github\Client::AUTH_HTTP_PASSWORD);
$client->api('repository')->forks()->create('Github-User-To-Fork', 'Github-User-To-Fork');
```

This is, because the content is set to "[]".
This seems to be a bug at github side. I`ve reported this bug to github api team.
But anyway. To create clean requests, it would be great to set the content to empty, if it is empty.

Solution: Check if the content is empty.
