### PR TITLE
[BUGFIX] Github -> Repos -> Statuses -> Show gives 404

### DIFF
--- a/lib/Github/Api/Repository/Statuses.php
+++ b/lib/Github/Api/Repository/Statuses.php
@@ -22,7 +22,7 @@ class Statuses extends AbstractApi
      */
     public function show($username, $repository, $sha)
     {
-        return $this->get('/repos/'.urlencode($username).'/'.urlencode($repository).'/statuses/'.urlencode($sha));
+        return $this->get('repos/'.urlencode($username).'/'.urlencode($repository).'/statuses/'.urlencode($sha));
     }
 
     /**


### PR DESCRIPTION
If you request a github repo status via api

``` php
$githubClient->api('repository')->statuses()->show(...
```

the HTTP client throws a 404, because the request URL build "//repos/...".
