### PR TITLE
Force "object"-form when posting json

### DIFF
--- a/lib/Github/HttpClient/HttpClient.php
+++ b/lib/Github/HttpClient/HttpClient.php
@@ -168,7 +168,7 @@ class HttpClient implements HttpClientInterface
         $request = $this->createRequest($httpMethod, $path);
         $request->addHeaders($headers);
         if (count($parameters) > 0) {
-            $request->setContent(json_encode($parameters));
+            $request->setContent(json_encode($parameters, JSON_FORCE_OBJECT));
         }
 
         $hasListeners = 0 < count($this->listeners);


### PR DESCRIPTION
When POSTing with no/empty content, we should send `{}` instead of `[]`, otherwise Github doesn't like it:

```
Github\Exception\ErrorException (400): Body should be a JSON Hash
```
