### PR TITLE
Added $params param to PullRequest->all() to enable per_page

### DIFF
--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -26,7 +26,7 @@ class PullRequest extends AbstractApi
      */
     public function all($username, $repository, $state = null, array $params=array())
     {
-    	$params['state'] = $state;
+        $params['state'] = $state;
         return $this->get('repos/'.urlencode($username).'/'.urlencode($repository).'/pulls', $params);
     }
 


### PR DESCRIPTION
We have more than 30 open pull requests and I needed the ability to pass in `per_page`
