### PR TITLE
Fix "Body should be a JSON Array" issue

### DIFF
--- a/lib/Github/HttpClient/HttpClient.php
+++ b/lib/Github/HttpClient/HttpClient.php
@@ -168,7 +168,7 @@ class HttpClient implements HttpClientInterface
         $request = $this->createRequest($httpMethod, $path);
         $request->addHeaders($headers);
         if (count($parameters) > 0) {
-            $request->setContent(json_encode($parameters, JSON_FORCE_OBJECT));
+            $request->setContent(json_encode($parameters, empty($parameters)? JSON_FORCE_OBJECT : 0));
         }
 
         $hasListeners = 0 < count($this->listeners);


### PR DESCRIPTION
The pull request http://github.com/KnpLabs/php-github-api/pull/40 fixed some issues with empty parameters, but caused a regression on other functionalities (see URL for a more detailed explanation).

This modification only forces JSON-objects to be generated when the parameters are empty. This should fix the newly created issues as well as not regress the fix for the previous issue.
