### PR TITLE
Revert breaking change in HttpClient

### DIFF
--- a/lib/Github/HttpClient/HttpClient.php
+++ b/lib/Github/HttpClient/HttpClient.php
@@ -168,7 +168,7 @@ class HttpClient implements HttpClientInterface
         $request = $this->createRequest($httpMethod, $path);
         $request->addHeaders($headers);
         if (count($parameters) > 0) {
-            $request->setContent(json_encode($parameters));
+            $request->setContent(json_encode($parameters, empty($parameters)? JSON_FORCE_OBJECT : 0));
         }
 
         $hasListeners = 0 < count($this->listeners);


### PR DESCRIPTION
This reverts commit 85c2994e70428f4957858d0c934496e40f3bbc09.

This change breaks issue creation. An array of labels in the parameters to `api('issue')->create()`

```
'labels'=>array('label1','label2)
```

should be encoded as:

```
"labels":{"label1","label2"}
```

but with `JSON_FORCE_OBJECT` it is encoded as

```
"labels":{"0":"label1","1":"label2"}
```

which fails validation and results in 422 Unprocessable Entity.
