### PR TITLE
Fixes bug where supplied option for timeout was ignored in constructor.

### DIFF
--- a/lib/Github/HttpClient/HttpClient.php
+++ b/lib/Github/HttpClient/HttpClient.php
@@ -55,7 +55,8 @@ class HttpClient implements HttpClientInterface
     public function __construct(array $options = array(), ClientInterface $client = null)
     {
         $client = $client ?: new Curl();
-        $client->setTimeout($this->options['timeout']);
+        $timeout = isset($options['timeout']) ? $options['timeout'] : $this->options['timeout'];
+        $client->setTimeout($timeout);
         $client->setVerifyPeer(false);
 
         $this->options = array_merge($this->options, $options);


### PR DESCRIPTION
I noticed the constructor always setting the default timeout option ignoring the supplied value.
