### PR TITLE
Implement listing all labels, and creating labels

### DIFF
--- a/lib/Github/Api/Issue/Labels.php
+++ b/lib/Github/Api/Issue/Labels.php
@@ -11,9 +11,25 @@ use Github\Exception\InvalidArgumentException;
  */
 class Labels extends AbstractApi
 {
-    public function all($username, $repository, $issue)
+    public function all($username, $repository, $issue = null)
     {
+        if ($issue === null) {
+            return $this->get('repos/'.urlencode($username).'/'.urlencode($repository).'/labels');
+        }
+
         return $this->get('repos/'.urlencode($username).'/'.urlencode($repository).'/issues/'.urlencode($issue).'/labels');
+    }
+
+    public function create($username, $repository, array $params)
+    {
+        if (!isset($params['name'])) {
+            throw new MissingArgumentException('name');
+        }
+        if (!isset($params['color'])) {
+            $params['color'] = 'FFFFFF';
+        }
+
+        return $this->post('repos/'.urlencode($username).'/'.urlencode($repository).'/labels', $params);
     }
 
     public function add($username, $repository, $issue, $labels)

--- a/test/Github/Tests/Api/Issue/LabelsTest.php
+++ b/test/Github/Tests/Api/Issue/LabelsTest.php
@@ -6,6 +6,26 @@ use Github\Tests\Api\TestCase;
 
 class LabelsTest extends TestCase
 {
+
+    /**
+     * @test
+     */
+    public function shouldGetProjectLabels()
+    {
+        $expectedValue = array(
+            array('name' => 'l3l0repo'),
+            array('name' => 'other'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('repos/KnpLabs/php-github-api/labels', array())
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
+    }
+
     /**
      * @test
      */
@@ -20,6 +40,40 @@ class LabelsTest extends TestCase
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', '123'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateLabel()
+    {
+        $expectedValue = array(array('name' => 'label', 'color' => 'FFFFFF'));
+        $data = array('name' => 'label');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('repos/KnpLabs/php-github-api/labels', $data + array('color' => 'FFFFFF'))
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateLabelWithColor()
+    {
+        $expectedValue = array(array('name' => 'label', 'color' => '111111'));
+        $data = array('name' => 'label', 'color' => '111111');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('repos/KnpLabs/php-github-api/labels', $data)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
     }
 
     /**


### PR DESCRIPTION
I'm not sure if I've missed a different interface - but this allows the following syntax to work, [from the docs](https://github.com/KnpLabs/php-github-api/blob/master/doc/issue/labels.md#list-project-labels):

``` php
$labels = $client->api('issue')->labels()->all('KnpLabs', 'php-github-api');
```

Also add an interface for creating labels.
