### PR TITLE
Fix Git Show path call

### DIFF
--- a/lib/Github/Api/GitData/Commits.php
+++ b/lib/Github/Api/GitData/Commits.php
@@ -13,7 +13,7 @@ class Commits extends AbstractApi
 {
     public function show($username, $repository, $sha)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha));
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/commits/'.rawurlencode($sha));
     }
 
     public function create($username, $repository, array $params)


### PR DESCRIPTION
The path to github api to return a commit information should be
GET /repos/:owner/:repo/git/commits/:sha
according to http://developer.github.com/v3/git/commits/ 
