### PR TITLE
Do not report validation errors as rate limits

### DIFF
--- a/lib/Github/HttpClient/Listener/ErrorListener.php
+++ b/lib/Github/HttpClient/Listener/ErrorListener.php
@@ -41,7 +41,7 @@ class ErrorListener
         if ($response->isClientError() || $response->isServerError()) {
             $remaining = (string) $response->getHeader('X-RateLimit-Remaining');
 
-            if (null !== $remaining && 1 > $remaining && 'rate_limit' !== substr($request->getResource(), 1, 10)) {
+            if (null != $remaining && 1 > $remaining && 'rate_limit' !== substr($request->getResource(), 1, 10)) {
                 throw new ApiLimitExceedException($this->options['api_limit']);
             }
 


### PR DESCRIPTION
When receiving a validation error (as in #86) there is no `X-RateLimit-Remaining` header included with the response. That is quite confusing.

Here `$remaining` when cast to a string is set to "" (empty string). This does not strictly equal `null` and thus a `ApiLimitExceedException` is thrown.

This change fixes this behavior.

cURL requests/responses:

```
# Request:
POST /repos/kasperg/release-asset-test/releases/92217/assets?name=test2.txt HTTP/1.1
Host: uploads.github.com
0: Accept: application/vnd.github.v3+json
1: User-Agent: php-github-api (http://github.com/KnpLabs/php-github-api)
Content-Type: text/plain, text/plain
User-Agent: Guzzle/3.7.4 curl/7.30.0 PHP/5.3.27
Authorization: Basic SomePassword
Content-Length: 14

{"body":"122"}

# Response:
HTTP/1.1 422 status code 422
Cache-Control: no-cache
Content-Length: 214
Content-Type: application/json; charset=utf-8
X-Content-Type-Options: nosniff
X-Github-Media-Type: github.beta; format=json
X-Github-Request-Id: a6633df9-4dff-11e3-800a-0be28f962e12
Date: Fri, 15 Nov 2013 14:10:15 GMT

{"message":"Validation Failed","request_id":"a6633df9-4dff-11e3-800a-0be28f962e12","documentation_url":"http://developer.github.com/v3","errors":[{"resource":"ReleaseAsset","code":"already_exists","field":"name"}]}
```
