### PR TITLE
Don't send an emtpy ref to the client

### DIFF
--- a/lib/Github/Api/AbstractApi.php
+++ b/lib/Github/Api/AbstractApi.php
@@ -69,6 +69,9 @@ abstract class AbstractApi implements ApiInterface
         if (null !== $this->perPage && !isset($parameters['per_page'])) {
             $parameters['per_page'] = $this->perPage;
         }
+        if (array_key_exists('ref', $parameters) && is_null($parameters['ref'])) {
+            unset($parameters['ref']);
+        }
         $response = $this->client->getHttpClient()->get($path, $parameters, $requestHeaders);
 
         return ResponseMediator::getContent($response);

--- a/test/Github/Tests/Api/AbstractApiTest.php
+++ b/test/Github/Tests/Api/AbstractApiTest.php
@@ -3,6 +3,7 @@
 namespace Github\Tests\Api;
 
 use Github\Api\AbstractApi;
+use Guzzle\Http\Message\Response;
 
 class AbstractApiTest extends \PHPUnit_Framework_TestCase
 {
@@ -111,6 +112,26 @@ class AbstractApiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedArray, $api->delete('/path', array('param1' => 'param1value'), array('option1' => 'option1value')));
     }
 
+    /**
+     * @test
+     */
+    public function shouldNotPassEmptyRefToClient()
+    {
+        $expectedResponse = new Response('value');
+
+        $httpClient = $this->getHttpMock();
+        $httpClient
+            ->expects($this->any())
+            ->method('get')
+            ->with('/path', array())
+            ->will($this->returnValue($expectedResponse));
+        $client = $this->getClientMock();
+        $client->setHttpClient($httpClient);
+
+        $api = new ExposedAbstractApiTestInstance($client);
+        $api->get('/path', array('ref' => null));
+    }
+
     protected function getAbstractApiObject($client)
     {
         return new AbstractApiTestInstance($client);
@@ -191,5 +212,16 @@ class AbstractApiTestInstance extends AbstractApi
     public function delete($path, array $parameters = array(), $requestHeaders = array())
     {
         return $this->client->getHttpClient()->delete($path, $parameters, $requestHeaders);
+    }
+}
+
+class ExposedAbstractApiTestInstance extends AbstractApi
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function get($path, array $parameters = array(), $requestHeaders = array())
+    {
+        return parent::get($path, $parameters, $requestHeaders);
     }
 }


### PR DESCRIPTION
The api will return `404 Not Found` when sending an empty ref.

As this is default behavior in most of the Api classes I added a check to remove this value if it equals null.

ex invalid call:
`curl -i https://api.github.com/repos/KnpLabs/php-github-api/contents/lib?ref=`
