### PR TITLE
use ETag to decrease rate limit hits

### DIFF
--- a/lib/Github/HttpClient/Cache/CacheInterface.php
+++ b/lib/Github/HttpClient/Cache/CacheInterface.php
@@ -14,9 +14,23 @@ interface CacheInterface
     /**
      * @param string $id The id of the cached resource
      *
+     * @return bool if present
+     */
+    public function has($id);
+
+    /**
+     * @param string $id The id of the cached resource
+     *
      * @return null|integer The modified since timestamp
      */
     public function getModifiedSince($id);
+
+    /**
+     * @param string $id The id of the cached resource
+     *
+     * @return null|string The ETag value
+     */
+    public function getETag($id);
 
     /**
      * @param string $id The id of the cached resource

--- a/lib/Github/HttpClient/Cache/FilesystemCache.php
+++ b/lib/Github/HttpClient/Cache/FilesystemCache.php
@@ -43,6 +43,17 @@ class FilesystemCache implements CacheInterface
         if (false === @file_put_contents($this->getPath($id), serialize($response))) {
             throw new \InvalidArgumentException(sprintf('Cannot put content in file "%s"', $this->getPath($id)));
         }
+        if (false === @file_put_contents($this->getPath($id).'.etag', $response->getHeader('ETag'))) {
+            throw new \InvalidArgumentException(sprintf('Cannot put content in file "%s"', $this->getPath($id).'.etag'));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        return file_exists($this->getPath($id));
     }
 
     /**
@@ -50,11 +61,16 @@ class FilesystemCache implements CacheInterface
      */
     public function getModifiedSince($id)
     {
-        if (file_exists($this->getPath($id))) {
+        if ($this->has($id)) {
             return filemtime($this->getPath($id));
         }
+    }
 
-        return null;
+    public function getETag($id)
+    {
+        if (file_exists($this->getPath($id).'.etag')) {
+            return file_get_contents($this->getPath($id).'.etag');
+        }
     }
 
     /**

--- a/lib/Github/HttpClient/Cache/GaufretteCache.php
+++ b/lib/Github/HttpClient/Cache/GaufretteCache.php
@@ -41,6 +41,15 @@ class GaufretteCache implements CacheInterface
     public function set($id, Response $response)
     {
         $this->filesystem->write($id, serialize($response), true);
+        $this->filesystem->write($id.'.etag', $response->getHeader('ETag'), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        $this->filesystem->has($id);
     }
 
     /**
@@ -50,6 +59,13 @@ class GaufretteCache implements CacheInterface
     {
         if ($this->filesystem->has($id)) {
             return $this->filesystem->mtime($id);
+        }
+    }
+
+    public function getETag($id)
+    {
+        if ($this->filesystem->has($id)) {
+            return $this->filesystem->read($id.'.etag');
         }
     }
 }

--- a/lib/Github/HttpClient/CachedHttpClient.php
+++ b/lib/Github/HttpClient/CachedHttpClient.php
@@ -46,12 +46,11 @@ class CachedHttpClient extends HttpClient
     {
         $response = parent::request($path, $body, $httpMethod, $headers, $options);
 
-        $key = trim($this->options['base_url'].$path, '/');
         if (304 == $response->getStatusCode()) {
-            return $this->getCache()->get($key);
+            return $this->getCache()->get($path);
         }
 
-        $this->getCache()->set($key, $response);
+        $this->getCache()->set($path, $response);
 
         return $response;
     }
@@ -72,6 +71,12 @@ class CachedHttpClient extends HttpClient
             $request->addHeader(
                 'If-Modified-Since',
                 sprintf('%s GMT', $modifiedAt->format('l, d-M-y H:i:s'))
+            );
+        }
+        if ($etag = $this->getCache()->getETag($path)) {
+            $request->addHeader(
+                'If-None-Match',
+                $etag
             );
         }
 


### PR DESCRIPTION
Since a certain time, github doesn't seem to use date based http cache headers.
It seems however, that they look at etags.

this PR adds etag headers in addition to existing dates headers.
