### PR TITLE
Add mimetype support to compare() so diff/patches can be fetched

### DIFF
--- a/lib/Github/Api/Repository/Commits.php
+++ b/lib/Github/Api/Repository/Commits.php
@@ -15,9 +15,13 @@ class Commits extends AbstractApi
         return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits', $params);
     }
 
-    public function compare($username, $repository, $base, $head)
+    public function compare($username, $repository, $base, $head, $mediaType = NULL)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/compare/'.rawurlencode($base).'...'.rawurlencode($head));
+        $headers = array();
+        if (NULL !== $mediaType) {
+            $headers['Accept'] = $mediaType;
+        }
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/compare/'.rawurlencode($base).'...'.rawurlencode($head), array(), $headers);
     }
 
     public function show($username, $repository, $sha)


### PR DESCRIPTION
The github API supports using mimetypes on patch/diff requests.  This allows consumers to pull down a patch for a commit.  This is documented at http://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests

This patch gives users access to this feature via the library.
