### PR TITLE
Adding "teams" to the $client->api() function

### DIFF
--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -124,6 +124,11 @@ class Client
                 $api = new Api\Repo($this);
                 break;
 
+            case 'team':
+            case 'teams':
+                $api = new Api\Organization\Teams($this);
+                break;
+
             case 'user':
             case 'users':
                 $api = new Api\User($this);


### PR DESCRIPTION
There is a Teams class but it is not available in the $client->api() function.

This code simply makes the Teams class available.
