### PR TITLE
issue 42 - default find param to an empty array

### DIFF
--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -33,7 +33,7 @@ class Repo extends AbstractApi
      *
      * @return array list of found repositories
      */
-    public function find($keyword, array $params)
+    public function find($keyword, array $params = array())
     {
         return $this->get('legacy/repos/search/'.rawurlencode($keyword), array_merge(array('start_page' => 1), $params));
     }


### PR DESCRIPTION
See pull request: https://github.com/KnpLabs/php-github-api/issues/42
