### PR TITLE
Use remove method for repo delete in docs

### DIFF
--- a/doc/repos.md
+++ b/doc/repos.md
@@ -76,7 +76,7 @@ Updates and returns the repository named 'my-new-repo' that is owned by 'usernam
 > Requires [authentication](security.md).
 
 ```php
-$client->api('repo')->delete('username', 'my-new-repo'); // Get the deletion token
+$client->api('repo')->remove('username', 'my-new-repo'); // Get the deletion token
 ```
 
 Deletes the my-new-repo repository.


### PR DESCRIPTION
Calling delete on an instance of Repo calls delete from the parent class. The parent class delete method doesn't expect the arguments being passed in the format the old example uses. Example should use `remove` instead of `delete`.
