### PR TITLE
Fix: validate composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
     "require-dev": {
         "phpunit/phpunit": ">=3.7"
     },
-    "require-dev": {
-        "phpunit/phpunit":  ">=3.6.0"
-    },
     "suggest": {
         "knplabs/gaufrette": "Needed for optional Gaufrette cache"
     },


### PR DESCRIPTION
Removed duplicate "require-dev" key, assuming the later version of PHPUnit was wanted.
