### PR TITLE
Added way to sort user repositories

### DIFF
--- a/test/Github/Tests/Api/UserTest.php
+++ b/test/Github/Tests/Api/UserTest.php
@@ -97,7 +97,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users/l3l0/repos?sort=full_name')
+            ->with('users/l3l0/repos')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->repositories('l3l0'));


### PR DESCRIPTION
I missed the option to sort a  user repository. Updated it the User.php class 
