### PR TITLE
Allow to provide parameters for PullRequests list

### DIFF
--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -25,10 +25,11 @@ class PullRequest extends AbstractApi
      */
     public function all($username, $repository, array $params = array())
     {
-		$parameters = array_merge(array(
-		    'page' => 1,
-		    'per_page' => 30
-		), $params);
+        $parameters = array_merge(array(
+            'page' => 1,
+            'per_page' => 30
+        ), $params);
+
         return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls', $parameters);
     }
 

--- a/test/Github/Tests/Api/PullRequestTest.php
+++ b/test/Github/Tests/Api/PullRequestTest.php
@@ -33,7 +33,7 @@ class PullRequestTest extends TestCase
             ->with('repos/ezsystems/ezpublish/pulls', array('state' => 'open', 'per_page' => 30, 'page' => 1))
             ->will($this->returnValue($expectedArray));
 
-        $this->assertEquals($expectedArray, $api->all('ezsystems', 'ezpublish', array('state' => 'open'));
+        $this->assertEquals($expectedArray, $api->all('ezsystems', 'ezpublish', array('state' => 'open')));
     }
 
     /**
@@ -49,7 +49,7 @@ class PullRequestTest extends TestCase
             ->with('repos/ezsystems/ezpublish/pulls', array('state' => 'closed', 'per_page' => 30, 'page' => 1))
             ->will($this->returnValue($expectedArray));
 
-        $this->assertEquals($expectedArray, $api->all('ezsystems', 'ezpublish', array('state' => 'closed'));
+        $this->assertEquals($expectedArray, $api->all('ezsystems', 'ezpublish', array('state' => 'closed')));
     }
 
     /**


### PR DESCRIPTION
According to the [API documentation](https://developer.github.com/v3/pulls/#list-pull-requests) of the v3 API a sort can be added and some other parameters not yet supported by this library. I have changed the "all" function to allow parameters to be given.
