### PR TITLE
add support for retrieving current_user subscriptions

### DIFF
--- a/lib/Github/Api/CurrentUser.php
+++ b/lib/Github/Api/CurrentUser.php
@@ -120,4 +120,12 @@ class CurrentUser extends AbstractApi
             'page' => $page
         ));
     }
+    
+    /**
+     *  @link https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
+     */
+    public function subscriptions()
+    {
+        return $this->get('user/subscriptions');
+    }
 }


### PR DESCRIPTION
I am not sure about paging support here? `watched` has some paging stuff, but `repositories` not?

Cheers!