### PR TITLE
Add support to get all milestones.

### DIFF
--- a/lib/Github/Api/Issue/Milestones.php
+++ b/lib/Github/Api/Issue/Milestones.php
@@ -13,7 +13,7 @@ class Milestones extends AbstractApi
 {
     public function all($username, $repository, array $params = array())
     {
-        if (isset($params['state']) && !in_array($params['state'], array('open', 'closed'))) {
+        if (isset($params['state']) && !in_array($params['state'], array('open', 'closed', 'all'))) {
             $params['state'] = 'open';
         }
         if (isset($params['sort']) && !in_array($params['sort'], array('due_date', 'completeness'))) {


### PR DESCRIPTION
The GitHub API allows you to retrieve [open, closed, or all milestones](https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository). Add support to retrieve all milestones in addition to just the open or the closed ones.
