### PR TITLE
Add support for the combined view of commit statuses

### DIFF
--- a/lib/Github/Api/Repository/Statuses.php
+++ b/lib/Github/Api/Repository/Statuses.php
@@ -22,7 +22,21 @@ class Statuses extends AbstractApi
      */
     public function show($username, $repository, $sha)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/statuses/'.rawurlencode($sha));
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/statuses');
+    }
+
+    /**
+     * @link https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+     *
+     * @param string $username
+     * @param string $repository
+     * @param string $sha
+     *
+     * @return array
+     */
+    public function combined($username, $repository, $sha)
+    {
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/status');
     }
 
     /**

--- a/test/Github/Tests/Api/Repository/StatusesTest.php
+++ b/test/Github/Tests/Api/Repository/StatusesTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Github\Tests\Api\Repository;
+
+use Github\Tests\Api\TestCase;
+
+class StatusesTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldShowCommitStatuses()
+    {
+        $expectedValue = array(
+            array('state' => 'success', 'context' => 'Travis'),
+            array('state' => 'pending', 'context' => 'Travis')
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('repos/KnpLabs/php-github-api/commits/commitSHA123456/statuses')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 'commitSHA123456'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowCombinedCommitStatuses()
+    {
+        $expectedValue = array(
+            array(
+                'state' => 'success',
+                'statuses' => array(
+                    array(
+                        'state' => 'success',
+                        'context' => 'Travis'
+                    ),
+                    array(
+                        'state' => 'success',
+                        'context' => 'Jenkins'
+                    )
+                )
+            )
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('repos/KnpLabs/php-github-api/commits/commitSHA123456/status')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->combined('KnpLabs', 'php-github-api', 'commitSHA123456'));
+    }
+
+    /**
+     * @test
+     * @expectedException Github\Exception\MissingArgumentException
+     */
+    public function shouldNotCreateWithoutStatus()
+    {
+        $data = array();
+
+        $api = $this->getApiMock();
+        $api->expects($this->never())
+            ->method('post');
+
+        $api->create('KnpLabs', 'php-github-api', 'commitSHA123456', $data);
+    }
+
+    /**
+     * @test 
+     */
+    public function shouldCreateCommitStatus()
+    {
+        $expectedValue = array('state' => 'success');
+        $data = array('state' => 'success');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('repos/KnpLabs/php-github-api/statuses/commitSHA123456', $data)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', 'commitSHA123456', $data));
+    }
+
+    protected function getApiClass()
+    {
+        return 'Github\Api\Repository\Statuses';
+    }
+}


### PR DESCRIPTION
Add the combined status support,
- https://developer.github.com/changes/2014-07-09-status-contexts-are-official/
- https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref

And replace the legacy route of https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref by the new one
