### PR TITLE
Closes #177 - use the magic __call method for IDE completion

### DIFF
--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -4,6 +4,7 @@ namespace Github;
 
 use Github\Api\ApiInterface;
 use Github\Exception\InvalidArgumentException;
+use Github\Exception\BadMethodCallException;
 use Github\HttpClient\HttpClient;
 use Github\HttpClient\HttpClientInterface;
 

--- a/lib/Github/Exception/BadMethodCallException.php
+++ b/lib/Github/Exception/BadMethodCallException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Github\Exception;
+
+/**
+ * BadMethodCallException
+ *
+ * @author James Brooks <jbrooksuk@me.com>
+ */
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
+{
+
+}

--- a/test/Github/Tests/ClientTest.php
+++ b/test/Github/Tests/ClientTest.php
@@ -4,6 +4,7 @@ namespace Github\Tests;
 
 use Github\Client;
 use Github\Exception\InvalidArgumentException;
+use Github\Exception\BadMethodCallException;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -143,6 +144,16 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Client();
         $client->api('do_not_exist');
+    }
+
+    /**
+     * @test
+     * @expectedException BadMethodCallException
+     */
+    public function shouldNotGetMagicApiInstance()
+    {
+        $client = new Client();
+        $client->doNotExist();
     }
 
     public function getApiClassesProvider()


### PR DESCRIPTION
All of the new methods are camelCase. They have all of the same aliases too.
