### PR TITLE
Fixed the API calls for watching and unwatching a repo

### DIFF
--- a/doc/repos.md
+++ b/doc/repos.md
@@ -148,16 +148,18 @@ $client->api('repo')->collaborators()->remove('username', 'reponame', 'KnpLabs')
 
 Remove the 'username' collaborator from the 'reponame' repository.
 
-### Watch and unwatch a repository
+### Subscribe to and unsubscribe from a repository
 
 > Requires [authentication](security.md).
 
 ```php
-$client->api('current_user')->watchers()->watch('ornicar', 'php-github-api');
-$client->api('current_user')->watchers()->unwatch('ornicar', 'php-github-api');
+$client->api('current_user')->watchers()->subscribe('ornicar', 'php-github-api');
+$client->api('current_user')->watchers()->unsubscribe('ornicar', 'php-github-api');
 ```
 
-Watches or unwatches the 'php-github-api' repository owned by 'ornicar' and returns the repository.
+Subscribes to, or unsubscribes from, the 'php-github-api' repository owned by 'ornicar' and returns the repository.
+
+These methods were previously called watch() and unwatch(); those methods are deprecated, but are still present in the library, and perform exactly as subscribe() and unsubscribe(), respectively.
 
 ### Fork a repository
 

--- a/lib/Github/Api/CurrentUser/Watchers.php
+++ b/lib/Github/Api/CurrentUser/Watchers.php
@@ -48,7 +48,7 @@ class Watchers extends AbstractApi
      */
     public function watch($username, $repository)
     {
-        return $this->put('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->subscribe($username, $repository);
     }
 
     /**
@@ -62,7 +62,7 @@ class Watchers extends AbstractApi
      */
     public function unwatch($username, $repository)
     {
-        return $this->delete('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->unsubscribe($username, $repository);
     }
 
     /**

--- a/lib/Github/Api/CurrentUser/Watchers.php
+++ b/lib/Github/Api/CurrentUser/Watchers.php
@@ -19,7 +19,7 @@ class Watchers extends AbstractApi
      */
     public function all($page = 1)
     {
-        return $this->get('user/watched', array(
+        return $this->get('user/subscriptions', array(
             'page' => $page
         ));
     }
@@ -34,7 +34,7 @@ class Watchers extends AbstractApi
      */
     public function check($username, $repository)
     {
-        return $this->get('user/watched/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->get('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
     /**
@@ -47,7 +47,7 @@ class Watchers extends AbstractApi
      */
     public function watch($username, $repository)
     {
-        return $this->put('user/watched/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->put('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
     /**
@@ -60,6 +60,6 @@ class Watchers extends AbstractApi
      */
     public function unwatch($username, $repository)
     {
-        return $this->delete('user/watched/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->delete('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 }

--- a/lib/Github/Api/CurrentUser/Watchers.php
+++ b/lib/Github/Api/CurrentUser/Watchers.php
@@ -39,7 +39,7 @@ class Watchers extends AbstractApi
 
     /**
      * Make the authenticated user watch a repository
-     * @deprecated The new command is subscribe(), not watch()
+     * @deprecated use subscribe()
      * @link https://developer.github.com/v3/activity/watching/
      *
      * @param  string $username   the user who owns the repo
@@ -53,7 +53,7 @@ class Watchers extends AbstractApi
 
     /**
      * Make the authenticated user unwatch a repository
-     * @deprecated The new command is unsubscribe(), not unwatch()
+     * @deprecated use unsubscribe()
      * @link https://developer.github.com/v3/activity/watching/
      *
      * @param  string $username   the user who owns the repo

--- a/lib/Github/Api/CurrentUser/Watchers.php
+++ b/lib/Github/Api/CurrentUser/Watchers.php
@@ -5,14 +5,14 @@ namespace Github\Api\CurrentUser;
 use Github\Api\AbstractApi;
 
 /**
- * @link   http://developer.github.com/v3/repos/watching/
+ * @link   https://developer.github.com/v3/activity/watching/
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
 class Watchers extends AbstractApi
 {
     /**
      * List repositories watched by the authenticated user
-     * @link http://developer.github.com/v3/repos/watching/
+     * @link https://developer.github.com/v3/activity/watching/
      *
      * @param  integer $page
      * @return array
@@ -26,7 +26,7 @@ class Watchers extends AbstractApi
 
     /**
      * Check that the authenticated user watches a repository
-     * @link http://developer.github.com/v3/repos/watching/
+     * @link https://developer.github.com/v3/activity/watching/
      *
      * @param  string $username   the user who owns the repo
      * @param  string $repository the name of the repo
@@ -39,7 +39,8 @@ class Watchers extends AbstractApi
 
     /**
      * Make the authenticated user watch a repository
-     * @link http://developer.github.com/v3/repos/watching/
+     * @deprecated The new command is subscribe(), not watch()
+     * @link https://developer.github.com/v3/activity/watching/
      *
      * @param  string $username   the user who owns the repo
      * @param  string $repository the name of the repo
@@ -52,13 +53,40 @@ class Watchers extends AbstractApi
 
     /**
      * Make the authenticated user unwatch a repository
-     * @link http://developer.github.com/v3/repos/watching/
+     * @deprecated The new command is unsubscribe(), not unwatch()
+     * @link https://developer.github.com/v3/activity/watching/
      *
      * @param  string $username   the user who owns the repo
      * @param  string $repository the name of the repo
      * @return array
      */
     public function unwatch($username, $repository)
+    {
+        return $this->delete('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
+    }
+
+    /**
+     * Make the authenticated user subscribe to a repository
+     * @link https://developer.github.com/v3/activity/watching/
+     *
+     * @param  string $username   the user who owns the repo
+     * @param  string $repository the name of the repo
+     * @return array
+     */
+    public function subscribe($username, $repository)
+    {
+        return $this->put('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
+    }
+
+    /**
+     * Make the authenticated user unsubscribe from a repository
+     * @link https://developer.github.com/v3/activity/watching/
+     *
+     * @param  string $username   the user who owns the repo
+     * @param  string $repository the name of the repo
+     * @return array
+     */
+    public function unsubscribe($username, $repository)
     {
         return $this->delete('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
     }

--- a/test/Github/Tests/Api/CurrentUser/WatchersTest.php
+++ b/test/Github/Tests/Api/CurrentUser/WatchersTest.php
@@ -19,7 +19,7 @@ class WatchersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/watched')
+            ->with('user/subscriptions')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all());
@@ -33,7 +33,7 @@ class WatchersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/watched/l3l0/test')
+            ->with('user/subscriptions/l3l0/test')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->check('l3l0', 'test'));
@@ -47,7 +47,7 @@ class WatchersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('user/watched/l3l0/test')
+            ->with('user/subscriptions/l3l0/test')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->watch('l3l0', 'test'));
@@ -61,10 +61,38 @@ class WatchersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('user/watched/l3l0/test')
+            ->with('user/subscriptions/l3l0/test')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->unwatch('l3l0', 'test'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSubscribeUser()
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('user/subscriptions/l3l0/test')
+            ->will($this->returnValue(null));
+
+        $this->assertNull($api->subscribe('l3l0', 'test'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUnsubscribeUser()
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('user/subscriptions/l3l0/test')
+            ->will($this->returnValue(null));
+
+        $this->assertNull($api->unsubscribe('l3l0', 'test'));
     }
 
     protected function getApiClass()


### PR DESCRIPTION
As per https://developer.github.com/v3/activity/watching/, it seems the "watched" part of the URL to handle watching and unwatching a repo should be "subscriptions" instead.  The updated URL (in this pull request) worked fine for me; the original one didn't.