### PR TITLE
Fixing a typo, asc instead of ask

### DIFF
--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -133,7 +133,7 @@ class User extends AbstractApi
      * @param  string $username  the username
      * @param  string $type      role in the repository
      * @param  string $sort      sort by
-     * @param  string $direction direction of sort, ask or desc
+     * @param  string $direction direction of sort, asc or desc
      * @return array             list of the user repositories
      */
     public function repositories($username, $type = 'owner', $sort = 'full_name', $direction = 'asc')


### PR DESCRIPTION
Fixing a typo in a comment.
Sorting order, `asc`, instead of `ask`.
