### PR TITLE
Adds implementation of GitHub Enterprise suspend / unsuspend user

### DIFF
--- a/lib/Github/Api/Enterprise.php
+++ b/lib/Github/Api/Enterprise.php
@@ -4,6 +4,7 @@ namespace Github\Api;
 
 use Github\Api\Enterprise\Stats;
 use Github\Api\Enterprise\License;
+use Github\Api\Enterprise\Users;
 
 /**
  * Getting information about a GitHub Enterprise instance.
@@ -28,5 +29,13 @@ class Enterprise extends AbstractApi
     public function license()
     {
         return new License($this->client);
+    }
+
+    /**
+     * @return Users
+     */
+    public function users()
+    {
+        return new Users($this->client);
     }
 }

--- a/lib/Github/Api/Enterprise/Users.php
+++ b/lib/Github/Api/Enterprise/Users.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Github\Api\Enterprise;
+
+use Github\Api\AbstractApi;
+
+class Users extends AbstractApi
+{
+    /**
+     * Suspend a user
+     *
+     * @param string $username the username to suspend
+     */
+    public function suspend($username)
+    {
+        $this->put('users/' . rawurlencode($username) . '/suspended');
+    }
+
+    /**
+     * Unsuspend a user
+     *
+     * @param string $username the username to unsuspend
+     */
+    public function unsuspend($username)
+    {
+        $this->delete('users/' . rawurlencode($username) . '/suspended');
+    }
+}


### PR DESCRIPTION
My company just moved to a site license and I had a need for unsuspending many users. I went ahead and did a first-pass implementation of this but there are no tests.  Before merging this, I am completely willing to go write tests; I just did this in a rush and figured I'd contribute the commit.

Thanks! Let me know if you'd like method naming etc. to be changed.