### PR TITLE
Move ref attribute in the url in archive function

### DIFF
--- a/lib/Github/Api/Repository/Contents.php
+++ b/lib/Github/Api/Repository/Contents.php
@@ -224,10 +224,14 @@ class Contents extends AbstractApi
         if (!in_array($format, array('tarball', 'zipball'))) {
             $format = 'tarball';
         }
+        
+        $url = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/'.rawurlencode($format);
+        
+        if (null !== $reference) {
+            $url .= '/'.rawurlencode($reference);
+        }
 
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/'.rawurlencode($format), array(
-            'ref' => $reference
-        ));
+        return $this->get($url);
     }
 
     /**


### PR DESCRIPTION
On the GitHub API (https://developer.github.com/v3/repos/contents/#get-archive-link), the parameter ```ref``` must be defined in the url if necessary.

When I try to download the archive from a specific branch with the current version, I still get the content of the master branch.