### PR TITLE
Use the standard API instead of the legacy API to search for Issues, Repos and Users

### DIFF
--- a/lib/Github/Api/Issue.php
+++ b/lib/Github/Api/Issue.php
@@ -37,18 +37,20 @@ class Issue extends AbstractApi
      *
      * @param string $username   the username
      * @param string $repository the repository
-     * @param string $state      the issue state, can be open or closed
+     * @param string $state      the issue state, can be open, closed or all
      * @param string $keyword    the keyword to filter issues by
      *
      * @return array list of issues found
      */
     public function find($username, $repository, $state, $keyword)
     {
-        if (!in_array($state, array('open', 'closed'))) {
+        if (!in_array($state, array('open', 'closed', 'all'))) {
             $state = 'open';
         }
 
-        return $this->get('legacy/issues/search/'.rawurlencode($username).'/'.rawurlencode($repository).'/'.rawurlencode($state).'/'.rawurlencode($keyword));
+        $url = 'search/issues?q='.rawurlencode($keyword).'+repo:'.rawurlencode($username).'/'.rawurlencode($repository);
+        if ($state!='all') $url .= '+state:'.rawurlencode($state);
+        return $this->get($url);
     }
 
     /**

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -35,7 +35,11 @@ class Repo extends AbstractApi
      */
     public function find($keyword, array $params = array())
     {
-        return $this->get('legacy/repos/search/'.rawurlencode($keyword), array_merge(array('start_page' => 1), $params));
+        $url = 'search/repositories?q='.rawurlencode($keyword);
+        if (isset($params['language'])) $url.= '+language:'.$params['language'];
+        if (isset($params['sort'])) $url.= '&sort='.$params['sort'];
+        if (isset($params['order'])) $url.= '&order='.$params['order'];
+        return $this->get($url);
     }
 
     /**

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -21,7 +21,7 @@ class User extends AbstractApi
      */
     public function find($keyword)
     {
-        return $this->get('legacy/user/search/'.rawurlencode($keyword));
+        return $this->get('search/users?q='.rawurlencode($keyword));
     }
 
     /**

--- a/test/Github/Tests/Api/IssueTest.php
+++ b/test/Github/Tests/Api/IssueTest.php
@@ -164,7 +164,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/issues/search/KnpLabs/php-github-api/open/Invalid%20Commits')
+            ->with('search/issues?q=Invalid%20Commits+repo:KnpLabs/php-github-api+state:open')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->find('KnpLabs', 'php-github-api', 'open', 'Invalid Commits'));
@@ -180,10 +180,26 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/issues/search/KnpLabs/php-github-api/closed/Invalid%20Commits')
+            ->with('search/issues?q=Invalid%20Commits+repo:KnpLabs/php-github-api+state:closed')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->find('KnpLabs', 'php-github-api', 'closed', 'Invalid Commits'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSearchAllIssues()
+    {
+        $expectedArray = array(array('id' => '123'));
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('search/issues?q=Invalid%20Commits+repo:KnpLabs/php-github-api')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->find('KnpLabs', 'php-github-api', 'all', 'Invalid Commits'));
     }
 
     /**
@@ -196,7 +212,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/issues/search/KnpLabs/php-github-api/open/Invalid%20Commits')
+            ->with('search/issues?q=Invalid%20Commits+repo:KnpLabs/php-github-api+state:open')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->find('KnpLabs', 'php-github-api', 'abc', 'Invalid Commits'));

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -33,29 +33,29 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/repos/search/php', array('myparam' => 2, 'start_page' => 1))
+            ->with('search/repositories?q=php')
             ->will($this->returnValue($expectedArray));
 
-        $this->assertEquals($expectedArray, $api->find('php', array('myparam' => 2)));
+        $this->assertEquals($expectedArray, $api->find('php'));
     }
 
     /**
      * @test
      */
-    public function shouldPaginateFoundRepositories()
+    public function shouldSearchRepositoriesWithOptions()
     {
         $expectedArray = array(
-            array('id' => 3, 'name' => 'fork of php'),
-            array('id' => 4, 'name' => 'fork of php-cs')
+            array('id' => 1, 'name' => 'php'),
+            array('id' => 2, 'name' => 'php-cs')
         );
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/repos/search/php', array('start_page' => 2))
+            ->with('search/repositories?q=php+language:javascript&sort=forks&order=asc')
             ->will($this->returnValue($expectedArray));
 
-        $this->assertEquals($expectedArray, $api->find('php', array('start_page' => 2)));
+        $this->assertEquals($expectedArray, $api->find('php',array('language'=>'javascript','sort'=>'forks','order'=>'asc')));
     }
 
     /**

--- a/test/Github/Tests/Api/UserTest.php
+++ b/test/Github/Tests/Api/UserTest.php
@@ -75,7 +75,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/user/search/l3l0')
+            ->with('search/users?q=l3l0')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->find('l3l0'));


### PR DESCRIPTION
We should use the standard API instead of the legacy API:
- The Legacy API will eventually be removed
- In at least one case the legacy API does not work correctly: it only returns open issues even when setting the state to 'closed'

The standard API allows us to add a new value to the state param in the 'find issues' function: if we set this parameter to 'all' it will return both 'open' and 'closed' issues

The format returned by the standard API and the legacy API is different, so this change may be BC-breaking

I would be grateful if you could bump up the tag value if you accept this PR as we need to use it in a dependent project
