### PR TITLE
Add support for getting an individual gist commit

### DIFF
--- a/lib/Github/Api/Gists.php
+++ b/lib/Github/Api/Gists.php
@@ -49,6 +49,11 @@ class Gists extends AbstractApi
         return $this->get('gists/'.rawurlencode($id).'/commits');
     }
 
+    public function commit($id, $sha)
+    {
+        return $this->get('gists/'.rawurlencode($id).'/'.rawurlencode($sha));
+    }
+
     public function fork($id)
     {
         return $this->post('gists/'.rawurlencode($id).'/fork');

--- a/test/Github/Tests/Api/GistsTest.php
+++ b/test/Github/Tests/Api/GistsTest.php
@@ -17,7 +17,7 @@ class GistsTest extends TestCase
             ->with('gists/starred')
             ->will($this->returnValue($expectedArray));
 
-       $this->assertEquals($expectedArray, $api->all('starred'));
+        $this->assertEquals($expectedArray, $api->all('starred'));
     }
 
     /**
@@ -33,7 +33,7 @@ class GistsTest extends TestCase
             ->with('gists')
             ->will($this->returnValue($expectedArray));
 
-       $this->assertEquals($expectedArray, $api->all());
+        $this->assertEquals($expectedArray, $api->all());
     }
 
     /**
@@ -49,7 +49,7 @@ class GistsTest extends TestCase
             ->with('gists/123')
             ->will($this->returnValue($expectedArray));
 
-       $this->assertEquals($expectedArray, $api->show(123));
+        $this->assertEquals($expectedArray, $api->show(123));
     }
 
     /**
@@ -65,7 +65,7 @@ class GistsTest extends TestCase
             ->with('gists/123/commits')
             ->will($this->returnValue($expectedArray));
 
-       $this->assertEquals($expectedArray, $api->commits(123));
+        $this->assertEquals($expectedArray, $api->commits(123));
     }
 
     /**
@@ -81,7 +81,7 @@ class GistsTest extends TestCase
             ->with('gists/123/abc')
             ->will($this->returnValue($expectedArray));
 
-       $this->assertEquals($expectedArray, $api->commit(123, 'abc'));
+        $this->assertEquals($expectedArray, $api->commit(123, 'abc'));
     }
 
     /**
@@ -97,7 +97,7 @@ class GistsTest extends TestCase
             ->with('gists/123/fork')
             ->will($this->returnValue($expectedArray));
 
-       $this->assertEquals($expectedArray, $api->fork(123));
+        $this->assertEquals($expectedArray, $api->fork(123));
     }
 
     /**
@@ -131,7 +131,7 @@ class GistsTest extends TestCase
             ->with('gists/123/star')
             ->will($this->returnValue($expectedArray));
 
-       $this->assertEquals($expectedArray, $api->check(123));
+        $this->assertEquals($expectedArray, $api->check(123));
     }
 
     /**
@@ -147,7 +147,7 @@ class GistsTest extends TestCase
             ->with('gists/123/star')
             ->will($this->returnValue($expectedArray));
 
-       $this->assertEquals($expectedArray, $api->star(123));
+        $this->assertEquals($expectedArray, $api->star(123));
     }
 
     /**
@@ -163,7 +163,7 @@ class GistsTest extends TestCase
             ->with('gists/123/star')
             ->will($this->returnValue($expectedArray));
 
-       $this->assertEquals($expectedArray, $api->unstar(123));
+        $this->assertEquals($expectedArray, $api->unstar(123));
     }
 
     /**

--- a/test/Github/Tests/Api/GistsTest.php
+++ b/test/Github/Tests/Api/GistsTest.php
@@ -71,6 +71,22 @@ class GistsTest extends TestCase
     /**
      * @test
      */
+    public function shouldShowCommit()
+    {
+        $expectedArray = array('version' => 'abc');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('gists/123/abc')
+            ->will($this->returnValue($expectedArray));
+
+       $this->assertEquals($expectedArray, $api->commit(123, 'abc'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldForkGist()
     {
         $expectedArray = array('id' => '123');


### PR DESCRIPTION
This endpoint isn't documented explicitly, but the URL is provided via the commits API, which looks like `GET /gists/:id/:version`: `/gists/68b7fa1a5e9525b48e60/eb0140454849ac81aa9eae43438875a7f0dcf482`