### PR TITLE
Fixed archive download by reference

### DIFF
--- a/lib/Github/Api/Repository/Contents.php
+++ b/lib/Github/Api/Repository/Contents.php
@@ -225,9 +225,8 @@ class Contents extends AbstractApi
             $format = 'tarball';
         }
 
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/'.rawurlencode($format), array(
-            'ref' => $reference
-        ));
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/'.rawurlencode($format).
+            ((null !== $reference) ? ('/'.rawurlencode($reference)) : ''));
     }
 
     /**

--- a/test/Github/Tests/Api/Repository/ContentsTest.php
+++ b/test/Github/Tests/Api/Repository/ContentsTest.php
@@ -233,7 +233,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/tarball', array('ref' => null))
+            ->with('repos/KnpLabs/php-github-api/tarball')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->archive('KnpLabs', 'php-github-api', 'someFormat'));
@@ -249,7 +249,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/tarball', array('ref' => null))
+            ->with('repos/KnpLabs/php-github-api/tarball')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->archive('KnpLabs', 'php-github-api', 'tarball'));
@@ -265,10 +265,26 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/zipball', array('ref' => null))
+            ->with('repos/KnpLabs/php-github-api/zipball')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->archive('KnpLabs', 'php-github-api', 'zipball'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFetchZipballArchiveByReference()
+    {
+        $expectedValue = 'zip';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('repos/KnpLabs/php-github-api/zipball/master')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->archive('KnpLabs', 'php-github-api', 'zipball', 'master'));
     }
 
     /**


### PR DESCRIPTION
According to [the API docs](https://developer.github.com/v3/repos/contents/#get-archive-link), the reference should be passed directly as the last URL segment, not as a GET parameter.

Bug triaged by @garak.

Closes #225