### PR TITLE
Add Gist API support for pagination

### DIFF
--- a/lib/Github/Api/Gists.php
+++ b/lib/Github/Api/Gists.php
@@ -14,13 +14,15 @@ use Github\Exception\MissingArgumentException;
  */
 class Gists extends AbstractApi
 {
-    public function all($type = null)
+    public function all($type = null, $page = 1)
     {
+        $params = array('page' => $page);
+
         if (!in_array($type, array('public', 'starred'))) {
-            return $this->get('gists');
+            return $this->get('gists', $params);
         }
 
-        return $this->get('gists/'.rawurlencode($type));
+        return $this->get('gists/'.rawurlencode($type), $params);
     }
 
     public function show($number)

--- a/test/Github/Tests/Api/GistsTest.php
+++ b/test/Github/Tests/Api/GistsTest.php
@@ -39,6 +39,22 @@ class GistsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetPagedGists()
+    {
+        $expectedArray = array(array('id' => '123'));
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('gists', array('page' => 2))
+            ->will($this->returnValue($expectedArray));
+
+       $this->assertEquals($expectedArray, $api->all(null, 2));
+    }
+
+    /**
+     * @test
+     */
     public function shouldShowGist()
     {
         $expectedArray = array('id' => '123');


### PR DESCRIPTION
Add support for an additional param, allowing you to paginate the Gist results.