### PR TITLE
Added missing features in the labels API

### DIFF
--- a/doc/issue/labels.md
+++ b/doc/issue/labels.md
@@ -12,6 +12,33 @@ $labels = $client->api('issue')->labels()->all('KnpLabs', 'php-github-api');
 List all project labels by username and repo.
 Returns an array of project labels.
 
+### Create a label
+
+```php
+$labels = $client->api('issue')->labels()->create('KnpLabs', 'php-github-api', array(
+    'name' => 'Bug',
+    'color' => 'FFFFFF',
+));
+```
+
+Create a new label in the repository.
+
+### Update a label
+
+```php
+$labels = $client->api('issue')->labels()->update('KnpLabs', 'php-github-api', 'Enhancement', 'Feature', 'FFFFFF');
+```
+
+Update the label name and color.
+
+### Delete a label
+
+```php
+$labels = $client->api('issue')->labels()->deleteLabel('KnpLabs', 'php-github-api', 'Bug');
+```
+
+Delete a new label from the repository.
+
 ### Add a label on an issue
 
 > Requires [authentication](../security.md).

--- a/lib/Github/Api/Issue/Labels.php
+++ b/lib/Github/Api/Issue/Labels.php
@@ -33,6 +33,11 @@ class Labels extends AbstractApi
         return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels', $params);
     }
 
+    public function deleteLabel($username, $repository, $label)
+    {
+        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label));
+    }
+
     public function add($username, $repository, $issue, $labels)
     {
         if (is_string($labels)) {

--- a/lib/Github/Api/Issue/Labels.php
+++ b/lib/Github/Api/Issue/Labels.php
@@ -4,6 +4,7 @@ namespace Github\Api\Issue;
 
 use Github\Api\AbstractApi;
 use Github\Exception\InvalidArgumentException;
+use Github\Exception\MissingArgumentException;
 
 /**
  * @link   http://developer.github.com/v3/issues/labels/

--- a/lib/Github/Api/Issue/Labels.php
+++ b/lib/Github/Api/Issue/Labels.php
@@ -38,6 +38,16 @@ class Labels extends AbstractApi
         return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label));
     }
 
+    public function update($username, $repository, $label, $newName, $color)
+    {
+        $params = array(
+            'name' => $newName,
+            'color' => $color,
+        );
+
+        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label), $params);
+    }
+
     public function add($username, $repository, $issue, $labels)
     {
         if (is_string($labels)) {

--- a/test/Github/Tests/Api/Issue/LabelsTest.php
+++ b/test/Github/Tests/Api/Issue/LabelsTest.php
@@ -6,7 +6,6 @@ use Github\Tests\Api\TestCase;
 
 class LabelsTest extends TestCase
 {
-
     /**
      * @test
      */
@@ -74,6 +73,22 @@ class LabelsTest extends TestCase
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldDeleteLabel()
+    {
+        $expectedValue = array('someOutput');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('repos/KnpLabs/php-github-api/labels/foo')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->deleteLabel('KnpLabs', 'php-github-api', 'foo'));
     }
 
     /**

--- a/test/Github/Tests/Api/Issue/LabelsTest.php
+++ b/test/Github/Tests/Api/Issue/LabelsTest.php
@@ -94,6 +94,23 @@ class LabelsTest extends TestCase
     /**
      * @test
      */
+    public function shouldUpdateLabel()
+    {
+        $expectedValue = array(array('name' => 'bar', 'color' => 'FFF'));
+        $data = array('name' => 'bar', 'color' => 'FFF');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('patch')
+            ->with('repos/KnpLabs/php-github-api/labels/foo', $data)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 'foo', 'bar', 'FFF'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldRemoveLabel()
     {
         $expectedValue = array('someOutput');


### PR DESCRIPTION
Added:

- updating a label + tests + documentation
- deleting a label + tests + documentation
- documentation for creating a label

I had trouble naming the `deleteLabel()` function since `delete()` already exist and is protected (it's for triggering a HTTP DELETE call)… So I called the method `deleteLabel()`, which is definitely not perfect but `remove()` already exists for remove a label *from an issue*.

Feedback welcome!