### PR TITLE
Add 'Get a release by tag name' functionality

### DIFF
--- a/doc/repo/releases.md
+++ b/doc/repo/releases.md
@@ -16,6 +16,12 @@ $releases = $client->api('repo')->releases()->all('twbs', 'bootstrap');
 $release = $client->api('repo')->releases()->show('twbs', 'bootstrap', $id);
 ```
 
+### List one release by tag name
+
+```php
+$release = $client->api('repo')->releases()->showTag('twbs', 'bootstrap', $tag);
+```
+
 ### Create a release
 ```php
 $release = $client->api('repo')->releases()->create('twbs', 'bootstrap', array('tag_name' => 'v1.1'));

--- a/lib/Github/Api/Repository/Releases.php
+++ b/lib/Github/Api/Repository/Releases.php
@@ -40,6 +40,20 @@ class Releases extends AbstractApi
     }
 
     /**
+     * Get a release by tag name in selected repository
+     *
+     * @param  string  $username         the user who owns the repo
+     * @param  string  $repository       the name of the repo
+     * @param  string  $tag              the name of the tag
+     *
+     * @return array
+     */
+    public function showTag($username, $repository, $tag)
+    {
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/tags/'.rawurlencode($tag));
+    }
+
+    /**
      * Create new release in selected repository
      *
      * @param  string  $username

--- a/test/Github/Tests/Api/Repository/ReleasesTest.php
+++ b/test/Github/Tests/Api/Repository/ReleasesTest.php
@@ -42,6 +42,22 @@ class ReleasesTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetSingleRepositoryReleaseByTag()
+    {
+        $expectedValue = array('releaseData');
+        $tag = '1.0.0';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('repos/KnpLabs/php-github-api/releases/tags/'.$tag)
+            ->will($this->returnValue($expectedValue));
+        $this->assertEquals($expectedValue, $api->showTag('KnpLabs', 'php-github-api', $tag));
+    }
+
+    /**
+     * @test
+     */
     public function shouldCreateRepositoryRelease()
     {
         $expectedValue = array('newReleaseData');


### PR DESCRIPTION
This lets you get the release by the tag name instead of the release ID.