### PR TITLE
Update dead link

### DIFF
--- a/doc/organization.md
+++ b/doc/organization.md
@@ -1,7 +1,7 @@
 ## Organization API
 [Back to the navigation](README.md)
 
-Wraps [GitHub Organization API](http://developer.github.com/v3/organization/).
+Wraps [GitHub Organization API](http://developer.github.com/v3/orgs/).
 
 Additional APIs:
 * [Members API](organization/members.md)


### PR DESCRIPTION
 Update dead link that point to github organizations documentation