### PR TITLE
Fixes GitHub Runtime Exception when message is null

### DIFF
--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -115,7 +115,7 @@ class PullRequest extends AbstractApi
         return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/merge');
     }
 
-    public function merge($username, $repository, $id, $message = null)
+    public function merge($username, $repository, $id, $message = '')
     {
         return $this->put('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/merge', array(
             'commit_message' => $message


### PR DESCRIPTION
Current Github API complains when the commit_message is null.