### PR TITLE
Fixing the search endpoint

### DIFF
--- a/lib/Github/Api/Search.php
+++ b/lib/Github/Api/Search.php
@@ -30,7 +30,7 @@ class Search extends AbstractApi
      */
     public function repositories($q, $sort = 'updated', $order = 'desc')
     {
-        return $this->get('/search/repositories', array('q' => $q, 'sort' => $sort, 'order' => $order));
+        return $this->get('search/repositories', array('q' => $q, 'sort' => $sort, 'order' => $order));
     }
 
     /**
@@ -46,7 +46,7 @@ class Search extends AbstractApi
      */
     public function issues($q, $sort = 'updated', $order = 'desc')
     {
-        return $this->get('/search/issues', array('q' => $q, 'sort' => $sort, 'order' => $order));
+        return $this->get('search/issues', array('q' => $q, 'sort' => $sort, 'order' => $order));
     }
 
     /**
@@ -62,7 +62,7 @@ class Search extends AbstractApi
      */
     public function code($q, $sort = 'updated', $order = 'desc')
     {
-        return $this->get('/search/code', array('q' => $q, 'sort' => $sort, 'order' => $order));
+        return $this->get('search/code', array('q' => $q, 'sort' => $sort, 'order' => $order));
     }
 
     /**
@@ -78,6 +78,6 @@ class Search extends AbstractApi
      */
     public function users($q, $sort = 'updated', $order = 'desc')
     {
-        return $this->get('/search/users', array('q' => $q, 'sort' => $sort, 'order' => $order));
+        return $this->get('search/users', array('q' => $q, 'sort' => $sort, 'order' => $order));
     }
 }

--- a/test/Github/Tests/Api/SearchTest.php
+++ b/test/Github/Tests/Api/SearchTest.php
@@ -16,7 +16,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                '/search/repositories',
+                'search/repositories',
                 array('q' => 'query text', 'sort' => 'updated', 'order' => 'desc')
             )
             ->will($this->returnValue($expectedArray));
@@ -36,7 +36,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                '/search/repositories',
+                'search/repositories',
                 array('q' => 'query text', 'sort' => 'created', 'order' => 'asc')
             )
             ->will($this->returnValue($expectedArray));
@@ -59,7 +59,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                '/search/issues',
+                'search/issues',
                 array('q' => 'query text', 'sort' => 'updated', 'order' => 'desc')
             )
             ->will($this->returnValue($expectedArray));
@@ -79,7 +79,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                '/search/issues',
+                'search/issues',
                 array('q' => 'query text', 'sort' => 'created', 'order' => 'asc')
             )
             ->will($this->returnValue($expectedArray));
@@ -102,7 +102,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                '/search/code',
+                'search/code',
                 array('q' => 'query text', 'sort' => 'updated', 'order' => 'desc')
             )
             ->will($this->returnValue($expectedArray));
@@ -122,7 +122,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                '/search/code',
+                'search/code',
                 array('q' => 'query text', 'sort' => 'created', 'order' => 'asc')
             )
             ->will($this->returnValue($expectedArray));
@@ -145,7 +145,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                '/search/users',
+                'search/users',
                 array('q' => 'query text', 'sort' => 'updated', 'order' => 'desc')
             )
             ->will($this->returnValue($expectedArray));
@@ -165,7 +165,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                '/search/users',
+                'search/users',
                 array('q' => 'query text', 'sort' => 'created', 'order' => 'asc')
             )
             ->will($this->returnValue($expectedArray));


### PR DESCRIPTION
* By removing the leading "/", the base path can now be appended.
  * The path being used was /search and not /api/v3/search