### PR TITLE
When checking for authMethod

### DIFF
--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -220,13 +220,9 @@ class Client
             throw new InvalidArgumentException('You need to specify authentication method!');
         }
 
-        if (null === $authMethod && in_array($password, array(self::AUTH_URL_TOKEN, self::AUTH_URL_CLIENT_ID, self::AUTH_HTTP_PASSWORD, self::AUTH_HTTP_TOKEN))) {
+        if (null === $authMethod && in_array($password, array(self::AUTH_URL_TOKEN, self::AUTH_URL_CLIENT_ID, self::AUTH_HTTP_PASSWORD, self::AUTH_HTTP_TOKEN))){
             $authMethod = $password;
             $password   = null;
-        }
-
-        if (null === $authMethod) {
-            $authMethod = self::AUTH_HTTP_PASSWORD;
         }
 
         $this->getHttpClient()->authenticate($tokenOrLogin, $password, $authMethod);


### PR DESCRIPTION
When authMethod is AUTH_HTTP_PASSWORD you also need a password. So password can never be empty, hence the removed if statement will never be reached.