### PR TITLE
Missing word in user doc

### DIFF
--- a/doc/users.md
+++ b/doc/users.md
@@ -95,7 +95,7 @@ $client->api('current_user')->follow()->follow('symfony');
 
 Returns an array of followed users.
 
-### Unfollow a
+### Unfollow a user
 
 > Requires [authentication](security.md).
 


### PR DESCRIPTION
The word 'user' had been missed off a heading.