### PR TITLE
Fixed the api version

### DIFF
--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -82,7 +82,7 @@ class Client
         'timeout'     => 10,
 
         'api_limit'   => 5000,
-        'api_version' => 'beta',
+        'api_version' => 'v3',
 
         'cache_dir'   => null
     );


### PR DESCRIPTION
The api version in the http client itself is `v3`, so something's wrong somwhere.