### PR TITLE
Supported api versions makes no sense

### DIFF
--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -307,22 +307,8 @@ class Client
         if (!array_key_exists($name, $this->options)) {
             throw new InvalidArgumentException(sprintf('Undefined option called: "%s"', $name));
         }
-        $supportedApiVersions = $this->getSupportedApiVersions();
-        if ('api_version' == $name && !in_array($value, $supportedApiVersions)) {
-            throw new InvalidArgumentException(sprintf('Invalid API version ("%s"), valid are: %s', $name, implode(', ', $supportedApiVersions)));
-        }
 
         $this->options[$name] = $value;
-    }
-
-    /**
-     * Returns an array of valid API versions supported by this client.
-     *
-     * @return array
-     */
-    public function getSupportedApiVersions()
-    {
-        return array('v3', 'beta');
     }
 
     /**


### PR DESCRIPTION
I want to use the "moondragon" version, but can't because of this restriction which looks wrong imo.