### PR TITLE
Add functionality for Organization:Issues

### DIFF
--- a/doc/organization.md
+++ b/doc/organization.md
@@ -7,10 +7,8 @@ Additional APIs:
 * [Members API](organization/members.md)
 * [Teams API](organization/teams.md)
 
-
-Wraps [GitHub Issues API](https://developer.github.com/v3/issues/).
-
 ### List issues in an organization
+[GitHub Issues API](https://developer.github.com/v3/issues/).
 
 ```php
 $issues = $client->api('orgs')->issues('KnpLabs', 'php-github-api', array('state' => 'open'));

--- a/doc/organization.md
+++ b/doc/organization.md
@@ -7,4 +7,22 @@ Additional APIs:
 * [Members API](organization/members.md)
 * [Teams API](organization/teams.md)
 
+
+Wraps [GitHub Issues API](https://developer.github.com/v3/issues/).
+
+### List issues in an organization
+
+```php
+$issues = $client->api('orgs')->issues('KnpLabs', 'php-github-api', array('state' => 'open'));
+```
+You can specify the page number:
+
+```php
+$issues = $client->api('orgs')->issues('KnpLabs', 'php-github-api', array('state' => 'open'), 2);
+```
+
+Returns an array of issues.
+
+
+
 To be written...

--- a/lib/Github/Api/Organization.php
+++ b/lib/Github/Api/Organization.php
@@ -74,4 +74,18 @@ class Organization extends AbstractApi
     {
         return new Teams($this->client);
     }
+
+    /**
+     * @link http://developer.github.com/v3/issues/#list-issues
+     *
+     * @param $organization
+     * @param array $params
+     * @param int $page
+     *
+     * @return array
+     */
+    public function issues($organization, array $params = array(), $page = 1)
+    {
+        return $this->get('orgs/'.rawurlencode($organization).'/issues', array_merge(array('page' => $page), $params));
+    }
 }


### PR DESCRIPTION
Github API has the option of getting the organization's issues. This is very useful to, for example, get all Organization's pull requests. This PR adds that functionality. 

The code is essentially a copy of the issues function for CurrentUser, with a few additions/improvements. 