### PR TITLE
Add rate limit endpoint

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -15,6 +15,7 @@ APIs:
   * [Teams](organization/teams.md)
 * [Pull Requests](pull_requests.md)
   * [Comments](pull_request/comments.md)
+* [Rate Limits](rate_limits.md)
 * [Repositories](repos.md)
   * [Contents](repo/contents.md)
   * [Releases](repo/releases.md)

--- a/doc/rate_limits.md
+++ b/doc/rate_limits.md
@@ -1,0 +1,23 @@
+## Rate Limit API
+[Back to the navigation](README.md)
+
+Get Rate Limit
+Wraps [GitHub Rate Limit API](http://developer.github.com/v3/rate_limit/).
+
+#### Get All Rate Limits.
+
+```php
+$rateLimits = $github->api('rate_limit')->getRateLimits();
+```
+
+#### Get Core Rate Limit
+
+```php
+$coreLimit = $github->api('rate_limit')->getCoreLimit();
+```
+
+#### Get Search Rate Limit
+
+```php
+$searchLimit = $github->api('rate_limit)->getSearchLimit');
+```

--- a/lib/Github/Api/RateLimit.php
+++ b/lib/Github/Api/RateLimit.php
@@ -28,6 +28,7 @@ class RateLimit extends AbstractApi
     public function getCoreLimit()
     {
         $response = $this->getRateLimits();
+        
         return $response['resources']['core']['limit'];
     }
 
@@ -39,6 +40,7 @@ class RateLimit extends AbstractApi
     public function getSearchLimit()
     {
         $response = $this->getRateLimits();
+        
         return $response['resources']['search']['limit'];
     }
 }

--- a/lib/Github/Api/RateLimit.php
+++ b/lib/Github/Api/RateLimit.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Github\Api;
+
+/**
+ * Get rate limits
+ *
+ * @link   https://developer.github.com/v3/rate_limit/
+ * @author Jeff Finley <quickliketurtle@gmail.com>
+ */
+class RateLimit extends AbstractApi
+{
+
+    /**
+     * Get rate limits
+     *
+     * @return \Guzzle\Http\EntityBodyInterface|mixed|string
+     */
+    public function getRateLimits()
+    {
+        return $this->get('rate_limit');
+    }
+
+    /**
+     * Get core rate limit
+     *
+     * @return integer
+     */
+    public function getCoreLimit()
+    {
+        $response = $this->getRateLimits();
+        return $response['resources']['core']['limit'];
+    }
+
+    /**
+     * Get search rate limit
+     *
+     * @return integer
+     */
+    public function getSearchLimit()
+    {
+        $response = $this->getRateLimits();
+        return $response['resources']['search']['limit'];
+    }
+
+}

--- a/lib/Github/Api/RateLimit.php
+++ b/lib/Github/Api/RateLimit.php
@@ -10,7 +10,6 @@ namespace Github\Api;
  */
 class RateLimit extends AbstractApi
 {
-
     /**
      * Get rate limits
      *
@@ -42,5 +41,4 @@ class RateLimit extends AbstractApi
         $response = $this->getRateLimits();
         return $response['resources']['search']['limit'];
     }
-
 }

--- a/lib/Github/Api/RateLimit.php
+++ b/lib/Github/Api/RateLimit.php
@@ -13,7 +13,7 @@ class RateLimit extends AbstractApi
     /**
      * Get rate limits
      *
-     * @return \Guzzle\Http\EntityBodyInterface|mixed|string
+     * @return array
      */
     public function getRateLimits()
     {

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -29,6 +29,7 @@ use Github\HttpClient\HttpClientInterface;
  * @method Api\PullRequest pr()
  * @method Api\PullRequest pullRequest()
  * @method Api\PullRequest pullRequests()
+ * @method Api\RateLimit ratelimit()
  * @method Api\Repo repo()
  * @method Api\Repo repos()
  * @method Api\Repo repository()
@@ -166,6 +167,11 @@ class Client
             case 'pullRequests':
             case 'pull_requests':
                 $api = new Api\PullRequest($this);
+                break;
+
+            case 'rateLimit':
+            case 'rate_limit':
+                $api = new Api\RateLimit($this);
                 break;
 
             case 'repo':

--- a/test/Github/Tests/Api/RateLimitTest.php
+++ b/test/Github/Tests/Api/RateLimitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Github\Tests\Api;
+
+class RateLimitTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function shouldReturnRateLimitArray()
+    {
+        $expectedArray = [
+            'resources' => [
+                'core' => [
+                    'limit' => 5000,
+                    'remaining' => 4999,
+                    'reset' => 1372700873
+                ],
+                'search' => [
+                    'limit' => 30,
+                    'remaining' => 18,
+                    'reset' => 1372697452
+                ]
+            ]
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('rate_limit')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->getRateLimits());
+    }
+
+    protected function getApiClass()
+    {
+        return 'Github\Api\RateLimit';
+    }
+}

--- a/test/Github/Tests/Api/RateLimitTest.php
+++ b/test/Github/Tests/Api/RateLimitTest.php
@@ -4,26 +4,25 @@ namespace Github\Tests\Api;
 
 class RateLimitTest extends TestCase
 {
-
     /**
      * @test
      */
     public function shouldReturnRateLimitArray()
     {
-        $expectedArray = [
-            'resources' => [
-                'core' => [
+        $expectedArray = array(
+            'resources' => array(
+                'core' => array(
                     'limit' => 5000,
                     'remaining' => 4999,
                     'reset' => 1372700873
-                ],
-                'search' => [
+                ),
+                'search' => array(
                     'limit' => 30,
                     'remaining' => 18,
                     'reset' => 1372697452
-                ]
-            ]
-        ];
+                )
+            )
+        );
 
         $api = $this->getApiMock();
         $api->expects($this->once())
@@ -38,4 +37,5 @@ class RateLimitTest extends TestCase
     {
         return 'Github\Api\RateLimit';
     }
+    
 }

--- a/test/Github/Tests/Api/RateLimitTest.php
+++ b/test/Github/Tests/Api/RateLimitTest.php
@@ -37,5 +37,4 @@ class RateLimitTest extends TestCase
     {
         return 'Github\Api\RateLimit';
     }
-    
 }

--- a/test/Github/Tests/Functional/RateLimitTest.php
+++ b/test/Github/Tests/Functional/RateLimitTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Github\Tests\Functional;
+
+/**
+ * @group functional
+ */
+class RateLimitTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldRetrievedRateLimits()
+    {
+        $response = $this->client->api('rate_limit')->getRateLimits();
+
+        $this->assertArrayHasKey('resources', $response);
+        $this->assertArraySubset(['resources' => ['core' => ['limit' => 60]]], $response);
+
+    }
+
+}

--- a/test/Github/Tests/Functional/RateLimitTest.php
+++ b/test/Github/Tests/Functional/RateLimitTest.php
@@ -15,8 +15,6 @@ class RateLimitTest extends TestCase
         $response = $this->client->api('rate_limit')->getRateLimits();
 
         $this->assertArrayHasKey('resources', $response);
-        $this->assertArraySubset(['resources' => ['core' => ['limit' => 60]]], $response);
-
+        $this->assertArraySubset(array('resources' => array('core' => array('limit' => 60))), $response);
     }
-
 }


### PR DESCRIPTION
Hello, 
I've added the rate_limit endpoint. With the default response, as well as 2 helpers for core rate limit and search rate limit. 

I updated Client.php to allow both rateLimit and rate_limit options. 

I've added a Test with the sample rate_limit response from github, as well as a functional test ( the functional group is excluded now, but you can run the single file manually and it passes ). 

Also added a doc page.

Let me know if there are changed needed. I tried to follow style and naming convention by looking at existing code. 

Thanks. 

