### PR TITLE
Use StyleCI Bridge

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,14 +1,14 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
-    ->in(__DIR__);
+require __DIR__.'/vendor/autoload.php';
 
-$fixers = array(
-    'long_array_syntax',
-);
+use SLLH\StyleCIBridge\ConfigBridge;
 
-return Symfony\CS\Config\Config::create()
-    ->setUsingCache(true)
-    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
-    ->fixers($fixers)
-    ->finder($finder);
+$config = ConfigBridge::create();
+$config->setUsingCache(true);
+
+if (method_exists($config, 'setRiskyAllowed')) {
+    $config->setRiskyAllowed(true);
+}
+
+return $config;

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "guzzle/guzzle":   "~3.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.0",
+        "sllh/php-cs-fixer-styleci-bridge": "~1.3"
     },
     "suggest": {
         "knplabs/gaufrette": "Needed for optional Gaufrette cache"


### PR DESCRIPTION
I propose you to use StyleCI bridge.

With this tools, you will be free to manage both configuration files for cs-fixer.

This bridge will automatically generate configuration for PHP-CS-Fixer according to `.styleci.yml` configuration.

This will typically avoid this kind of commits: e30fc955f3a422555e5994b1e25b1dd34ef7b709