### PR TITLE
Add support for Guzzle from 4.x to 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,19 @@ php:
   - 5.6
   - hhvm
 
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.6
+      env: GUZZLE_VERSION=4.*
+    - php: 5.6
+      env: GUZZLE_VERSION=5.*
+    - php: 5.6
+      env: GUZZLE_VERSION=6.*
+
 before_script:
   - travis_retry composer self-update
+  - if [ "$GUZZLE_VERSION" != "" ]; then composer require "guzzlehttp/guzzle:${GUZZLE_VERSION}" --no-update; fi;
   - travis_retry composer install --no-interaction --prefer-source --dev
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         }
     ],
     "require": {
-        "php":             ">=5.3.2",
+        "php":             "^5.4",
         "ext-curl":        "*",
-        "guzzle/guzzle":   "~3.7"
+        "guzzlehttp/guzzle": "^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/lib/Github/HttpClient/Message/ResponseMediator.php
+++ b/lib/Github/HttpClient/Message/ResponseMediator.php
@@ -2,14 +2,24 @@
 
 namespace Github\HttpClient\Message;
 
-use Guzzle\Http\Message\Response;
 use Github\Exception\ApiLimitExceedException;
+use GuzzleHttp\Message\ResponseInterface;
 
 class ResponseMediator
 {
-    public static function getContent(Response $response)
+    /**
+     * @param \GuzzleHttp\Message\ResponseInterface|\Psr\Http\Message\ResponseInterface $response
+     *
+     * @return mixed
+     */
+    public static function getContent(ResponseInterface $response)
     {
-        $body    = $response->getBody(true);
+        // Guzzle < 6 BC
+        if (!$response instanceof \GuzzleHttp\Message\ResponseInterface && !$response instanceof \Psr\Http\Message\ResponseInterface) {
+            throw new \InvalidArgumentException('Argument 1 of '.__METHOD__.' must be on instance of \GuzzleHttp\Message\ResponseInterface or \Psr\Http\Message\ResponseInterface');
+        }
+
+        $body    = $response->getBody()->getContents();
         $content = json_decode($body, true);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
@@ -19,8 +29,18 @@ class ResponseMediator
         return $content;
     }
 
-    public static function getPagination(Response $response)
+    /**
+     * @param \GuzzleHttp\Message\ResponseInterface|\Psr\Http\Message\ResponseInterface $response $response
+     *
+     * @return array|null
+     */
+    public static function getPagination($response)
     {
+        // Guzzle < 6 BC
+        if (!$response instanceof \GuzzleHttp\Message\ResponseInterface && !$response instanceof \Psr\Http\Message\ResponseInterface) {
+            throw new \InvalidArgumentException('Argument 1 of '.__METHOD__.' must be on instance of \GuzzleHttp\Message\ResponseInterface or \Psr\Http\Message\ResponseInterface');
+        }
+
         $header = (string) $response->getHeader('Link');
 
         if (empty($header)) {
@@ -39,14 +59,24 @@ class ResponseMediator
         return $pagination;
     }
 
-    public static function getApiLimit(Response $response)
+    /**
+     * @param \GuzzleHttp\Message\ResponseInterface|\Psr\Http\Message\ResponseInterface $response $response
+     *
+     * @return string
+     */
+    public static function getApiLimit($response)
     {
+        // Guzzle < 6 BC
+        if (!$response instanceof \GuzzleHttp\Message\ResponseInterface && !$response instanceof \Psr\Http\Message\ResponseInterface) {
+            throw new \InvalidArgumentException('Argument 1 of '.__METHOD__.' must be on instance of \GuzzleHttp\Message\ResponseInterface or \Psr\Http\Message\ResponseInterface');
+        }
+
         $remainingCalls = (string) $response->getHeader('X-RateLimit-Remaining');
 
         if (null !== $remainingCalls && 1 > $remainingCalls) {
             throw new ApiLimitExceedException($remainingCalls);
         }
-        
+
         return $remainingCalls;
     }
 }


### PR DESCRIPTION
Closes #157.

I propose to keep guzzle 3 support for BC and trigger a deprecated error to prevent user that support will be dropped in next major release.

This PR is under progress.