### PR TITLE
Show error message if exists

### DIFF
--- a/lib/Github/HttpClient/Listener/ErrorListener.php
+++ b/lib/Github/HttpClient/Listener/ErrorListener.php
@@ -70,7 +70,11 @@ class ErrorListener
                                 break;
 
                             case 'invalid':
-                                $errors[] = sprintf('Field "%s" is invalid, for resource "%s"', $error['field'], $error['resource']);
+                                if (isset($error['message'])) {
+                                    $errors[] = sprintf('Field "%s" is invalid, for resource "%s": "%s"', $error['field'], $error['resource'], $error['message']);
+                                } else {
+                                    $errors[] = sprintf('Field "%s" is invalid, for resource "%s"', $error['field'], $error['resource']);
+                                }
                                 break;
 
                             case 'already_exists':


### PR DESCRIPTION
Actually, with this invalid API call: https://api.github.com/search/code?q=preset

We get the following message:

```
Validation Failed: Field "q" is invalid, for resource "Search"
```

This is not very explicit. This PR add the message field if exists.