### PR TITLE
Fix typo in searchLimit call example

### DIFF
--- a/doc/rate_limits.md
+++ b/doc/rate_limits.md
@@ -19,5 +19,5 @@ $coreLimit = $client->api('rate_limit')->getCoreLimit();
 #### Get Search Rate Limit
 
 ```php
-$searchLimit = $client->api('rate_limit)->getSearchLimit');
+$searchLimit = $client->api('rate_limit')->getSearchLimit();
 ```


### PR DESCRIPTION
There was a typo in the documentation, according to the method signature found line 40 in `/lib/Github/Api/RateLimit.php`