### PR TITLE
Add new Organization management methods and tweak caching.

### DIFF
--- a/lib/Github/Api/Organization/Members.php
+++ b/lib/Github/Api/Organization/Members.php
@@ -10,7 +10,7 @@ use Github\Api\AbstractApi;
  */
 class Members extends AbstractApi
 {
-    public function all($organization, $type = null, $filter = 'all')
+    public function all($organization, $type = null, $filter = 'all', $role = null)
     {
         $parameters = array();
         $path = 'orgs/'.rawurlencode($organization).'/';
@@ -18,6 +18,9 @@ class Members extends AbstractApi
             $path .= 'members';
             if (null !== $filter) {
                 $parameters['filter'] = $filter;
+            }
+            if (null !== $role) {
+                $parameters['role'] = $role;
             }
         } else {
             $path .= 'public_members';

--- a/lib/Github/Api/Organization/Members.php
+++ b/lib/Github/Api/Organization/Members.php
@@ -44,6 +44,11 @@ class Members extends AbstractApi
         return $this->get('orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));
     }
 
+    public function addMember($team, $username)
+    {
+        return $this->put('orgs/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+    }
+
     public function publicize($organization, $username)
     {
         return $this->put('orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));

--- a/lib/Github/Api/Organization/Members.php
+++ b/lib/Github/Api/Organization/Members.php
@@ -34,6 +34,11 @@ class Members extends AbstractApi
         return $this->get('orgs/'.rawurlencode($organization).'/members/'.rawurlencode($username));
     }
 
+    public function member($organization, $username)
+    {
+        return $this->get('orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
+    }
+
     public function check($organization, $username)
     {
         return $this->get('orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));

--- a/lib/Github/Api/Organization/Members.php
+++ b/lib/Github/Api/Organization/Members.php
@@ -44,9 +44,9 @@ class Members extends AbstractApi
         return $this->get('orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));
     }
 
-    public function addMember($team, $username)
+    public function addMember($organization, $username)
     {
-        return $this->put('orgs/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        return $this->put('orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
     }
 
     public function publicize($organization, $username)

--- a/lib/Github/HttpClient/CachedHttpClient.php
+++ b/lib/Github/HttpClient/CachedHttpClient.php
@@ -68,7 +68,7 @@ class CachedHttpClient extends HttpClient
             return $cacheResponse;
         }
 
-        if ($httpMethod == 'GET') {
+        if (in_array($httpMethod, array('GET', 'HEAD'), true)) {
             $this->getCache()->set($this->id, $response);
         }
 

--- a/lib/Github/HttpClient/CachedHttpClient.php
+++ b/lib/Github/HttpClient/CachedHttpClient.php
@@ -68,7 +68,9 @@ class CachedHttpClient extends HttpClient
             return $cacheResponse;
         }
 
-        $this->getCache()->set($this->id, $response);
+        if ($httpMethod == 'GET') {
+            $this->getCache()->set($this->id, $response);
+        }
 
         return $response;
     }


### PR DESCRIPTION
I needed the ability to retrieve just the admins from an Organization as well as get a single member's status within an Organization.

This can be done via:
`GitHub::organization()->members()->all($orgName, null, 'all', 'admin')`
and
`GitHub::organization()->members()->member($orgName)`

I also wanted to be able to add/invite a user/member to an Organization.  In testing this, I found that caching the PUT request to GitHub resulted in ResponseExceptions as the API would return a 421 response to the request check.  The most logical fix was to restrict caching to GET requests only as the other request types all should affect changes at GitHub and therefore render the idea of caching for them moot.