### PR TITLE
PHPDoc Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ phpunit.xml
 composer.lock
 composer.phar
 vendor/*
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ phpunit.xml
 composer.lock
 composer.phar
 vendor/*
+.idea/

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -110,7 +110,7 @@ class Client
      *
      * @throws InvalidArgumentException
      *
-     * @return ApiInterface
+     * @return Api\CurrentUser|Api\Deployment|Api\Enterprise|Api\GitData|Api\Gists|Api\Issue|Api\Markdown|Api\Notification|Api\Organization|Api\PullRequest|Api\RateLimit|Api\Repo|Api\Search|Api\Organization\Teams|Api\User|Api\Authorizations|Api\Meta
      */
     public function api($name)
     {


### PR DESCRIPTION
Previously, the PHPDoc on Client.php:113 (for api function) showed an improper return type. I simply added all the possible return types.
This is important in specific IDE's the chain "rockets" together.
Went from this:
![image](https://cloud.githubusercontent.com/assets/6721355/12084182/8a971834-b275-11e5-9121-87dd1bb68bbc.png)

To this:
![image](https://cloud.githubusercontent.com/assets/6721355/12084193/a2e38346-b275-11e5-9c10-24a4f853c613.png)
