### PR TITLE
list all organizations

### DIFF
--- a/lib/Github/Api/Organization.php
+++ b/lib/Github/Api/Organization.php
@@ -20,9 +20,9 @@ class Organization extends AbstractApi
      *
      * @return array the organizations
      */
-    public function all()
+    public function all($since = '')
     {
-        return $this->get('organizations');
+        return $this->get('organizations?since='.rawurlencode($since));
     }
 
     /**

--- a/lib/Github/Api/Organization.php
+++ b/lib/Github/Api/Organization.php
@@ -16,6 +16,16 @@ use Github\Api\Organization\Teams;
 class Organization extends AbstractApi
 {
     /**
+     * @link https://developer.github.com/v3/orgs/#list-all-organizations
+     *
+     * @return array the organizations
+     */
+    public function all()
+    {
+        return $this->get('organizations');
+    }
+
+    /**
      * Get extended information about an organization by its name.
      *
      * @link http://developer.github.com/v3/orgs/#get

--- a/test/Github/Tests/Api/OrganizationTest.php
+++ b/test/Github/Tests/Api/OrganizationTest.php
@@ -14,10 +14,10 @@ class OrganizationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('organizations')
+            ->with('organizations?since=1')
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->all());
+        $this->assertEquals($expectedValue, $api->all(1));
     }
 
     /**

--- a/test/Github/Tests/Api/OrganizationTest.php
+++ b/test/Github/Tests/Api/OrganizationTest.php
@@ -7,6 +7,22 @@ class OrganizationTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllOrganizations()
+    {
+        $expectedValue = array(array('login' => 'KnpLabs'));
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('organizations')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->all());
+    }
+
+    /**
+     * @test
+     */
     public function shouldShowOrganization()
     {
         $expectedArray = array('id' => 1, 'name' => 'KnpLabs');


### PR DESCRIPTION
implements https://developer.github.com/v3/orgs/#list-all-organizations 

Not sure if this is very useful for github.com, but we use this api method in our Enterprise setup to automate organization permissions. 