### PR TITLE
Doc update: getting all hooks should use all() method instead

### DIFF
--- a/doc/repos.md
+++ b/doc/repos.md
@@ -157,7 +157,7 @@ $client->api('repo')->hooks()->remove('username', 'reponame', $id);
 > Requires [authentication](security.md).
 
 ```php
-$client->api('repo')->hooks()->show('username', 'reponame');
+$client->api('repo')->hooks()->all('username', 'reponame');
 ```
 
 ### Get the collaborators for a repository


### PR DESCRIPTION
Just a little document update that might help others. Replaced show() with all() to get all hooks in a given repo.

- `all()` method to get list of all hooks.
- `show()` for specific method passing 3rd argument which is the repo ID

[Source](https://github.com/KnpLabs/php-github-api/blob/master/lib/Github/Api/Repository/Hooks.php)