### PR TITLE
Add repository stargazers support

### DIFF
--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -12,6 +12,7 @@ use Github\Api\Repository\Releases;
 use Github\Api\Repository\Forks;
 use Github\Api\Repository\Hooks;
 use Github\Api\Repository\Labels;
+use Github\Api\Repository\Stargazers;
 use Github\Api\Repository\Statuses;
 
 /**
@@ -307,6 +308,18 @@ class Repo extends AbstractApi
     public function forks()
     {
         return new Forks($this->client);
+    }
+
+    /**
+     * Manage the stargazers of a repository.
+     *
+     * @link https://developer.github.com/v3/activity/starring/#list-stargazers
+     *
+     * @return Stargazers
+     */
+    public function stargazers()
+    {
+        return new Stargazers($this->client);
     }
 
     /**

--- a/lib/Github/Api/Repository/Stargazers.php
+++ b/lib/Github/Api/Repository/Stargazers.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Github\Api\Repository;
+
+use Github\Api\AbstractApi;
+
+/**
+ * @link   https://developer.github.com/v3/activity/starring/#list-stargazers
+ * @author Nicolas Dupont <nicolas@akeneo.com>
+ */
+class Stargazers extends AbstractApi
+{
+    /**
+     * Configure the body type
+     *
+     * @see https://developer.github.com/v3/activity/starring/#alternative-response-with-star-creation-timestamps
+     *
+     * @param string $bodyType
+     */
+    public function configure($bodyType = null)
+    {
+        if ('star' === $bodyType) {
+            $this->client->setHeaders(
+                array(
+                    'Accept' => sprintf('application/vnd.github.%s.star+json', $this->client->getOption('api_version'))
+                )
+            );
+        }
+    }
+
+    public function all($username, $repository)
+    {
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/stargazers');
+    }
+}

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -468,6 +468,16 @@ class RepoTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetStargazersApiObject()
+    {
+        $api = $this->getApiMock();
+
+        $this->assertInstanceOf('Github\Api\Repository\Stargazers', $api->stargazers());
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetReleasesApiObject()
     {
         $api = $this->getApiMock();

--- a/test/Github/Tests/Api/Repository/StargazersTest.php
+++ b/test/Github/Tests/Api/Repository/StargazersTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Github\Tests\Api\Repository;
+
+use Github\Tests\Api\TestCase;
+
+class StargazersTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllRepositoryStargazers()
+    {
+        $expectedValue = array(array('login' => 'nidup'));
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('repos/KnpLabs/php-github-api/stargazers')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllRepositoryStargazersWithAlternativeResponse()
+    {
+        $expectedValue = array(array('starred_at' => '2013-10-01T13:22:01Z', 'user' => array('login' => 'nidup')));
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('repos/KnpLabs/php-github-api/stargazers')
+            ->will($this->returnValue($expectedValue));
+        $api->configure('star');
+
+        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
+    }
+
+    protected function getApiClass()
+    {
+        return 'Github\Api\Repository\Stargazers';
+    }
+}


### PR DESCRIPTION
This PR adds the support of ```/repos/:owner/:repo/stargazers``` with both default and alternative response format cf https://developer.github.com/v3/activity/starring/#list-stargazers

For headers configuration, I took inspiration from existing API as Github\Api\Repository\Comments.

Let me know if i missed something.