### PR TITLE
Simplify branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }


### PR DESCRIPTION
I saw 1.6.0 is out but the branch alias is still on 1.5.x-dev.

Maybe if you regularly push minor release, a 1.x-dev would be simplier?

This seems to be already done on github-api: https://github.com/KnpLabs/packagist-api/blob/master/composer.json