### PR TITLE
Add commit_message parameter on Repo::merge only if given

### DIFF
--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -488,11 +488,16 @@ class Repo extends AbstractApi
      */
     public function merge($username, $repository, $base, $head, $message = null)
     {
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/merges', array(
-            'base'           => $base,
-            'head'           => $head,
-            'commit_message' => $message
-        ));
+        $parameters = array(
+            'base' => $base,
+            'head' => $head,
+        );
+
+        if (is_string($message)) {
+            $parameters['commit_message'] = $message;
+        }
+
+        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/merges', $parameters);
     }
 
     /**


### PR DESCRIPTION
If you add the commit_message with null value, you will get this error:

For 'properties/commit_message', nil is not a string.

So the commit_message parameter has to be added only if $message is valid.