### PR TITLE
Fix recursive trees

### DIFF
--- a/lib/Github/Api/GitData/Trees.php
+++ b/lib/Github/Api/GitData/Trees.php
@@ -23,7 +23,7 @@ class Trees extends AbstractApi
      */
     public function show($username, $repository, $sha, $recursive = false)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/trees/'.rawurlencode($sha), array('recursive' => $recursive ? 1 : null));
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/trees/'.rawurlencode($sha), $recursive ? array('recursive' => 1) : array());
     }
 
     /**


### PR DESCRIPTION
GitHub returns the trees recursively even when the `recursive` parameter is empty. This change makes sure the parameter isn't set at all.