### PR TITLE
Fix recursive trees + tests

### DIFF
--- a/lib/Github/Api/GitData/Trees.php
+++ b/lib/Github/Api/GitData/Trees.php
@@ -23,7 +23,7 @@ class Trees extends AbstractApi
      */
     public function show($username, $repository, $sha, $recursive = false)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/trees/'.rawurlencode($sha), array('recursive' => $recursive ? 1 : null));
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/trees/'.rawurlencode($sha), $recursive ? array('recursive' => 1) : array());
     }
 
     /**

--- a/test/Github/Tests/Api/GitData/TreesTest.php
+++ b/test/Github/Tests/Api/GitData/TreesTest.php
@@ -14,7 +14,7 @@ class TreesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/git/trees/123', array('recursive' => null))
+            ->with('repos/KnpLabs/php-github-api/git/trees/123', array())
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));


### PR DESCRIPTION
GitHub returns the trees recursively even when the recursive parameter is empty. This change makes sure the parameter isn't set at all.

Created a new PR with fixed test.