### PR TITLE
Allow Adding Repo With Permissions

### DIFF
--- a/lib/Github/Api/Organization/Teams.php
+++ b/lib/Github/Api/Organization/Teams.php
@@ -83,7 +83,7 @@ class Teams extends AbstractApi
         return $this->get('teams/'.rawurlencode($team).'/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
-    public function addRepository($team, $username, $repository, array $params)
+    public function addRepository($team, $username, $repository, $params = array())
     {
         if (isset($params['permission']) && !in_array($params['permission'], array('pull', 'push', 'admin'))) {
             $params['permission'] = 'pull';

--- a/lib/Github/Api/Organization/Teams.php
+++ b/lib/Github/Api/Organization/Teams.php
@@ -83,8 +83,12 @@ class Teams extends AbstractApi
         return $this->get('teams/'.rawurlencode($team).'/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
-    public function addRepository($team, $username, $repository)
+    public function addRepository($team, $username, $repository, array $params)
     {
+        if (isset($params['permission']) && !in_array($params['permission'], array('pull', 'push', 'admin'))) {
+            $params['permission'] = 'pull';
+        }
+
         return $this->put('teams/'.rawurlencode($team).'/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 


### PR DESCRIPTION
The api [allows sending through a permission](https://developer.github.com/v3/orgs/teams/#add-or-update-team-repository) when adding the team/repo relationship that is not exposed in your wrapper. Just added in the way that other endpoints are allowing.