### PR TITLE
Package guzzle/guzzle is abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php":             ">=5.3.2",
         "ext-curl":        "*",
-        "guzzle/guzzle":   "~3.7"
+        "guzzlehttp/guzzle":   "~3.7"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.