### PR TITLE
Typos and bugfix

### DIFF
--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -312,15 +312,16 @@ class Client
     }
 
     /**
-     * Remove a plugin by its fqn.
+     * Remove a plugin by its fully qualified class name (FQCN).
      *
-     * @param string $fqn
+     * @param string $fqcn
      */
-    protected function removePlugin($fqn)
+    protected function removePlugin($fqcn)
     {
         foreach ($this->plugins as $idx => $plugin) {
-            if ($plugin instanceof $fqn) {
+            if ($plugin instanceof $fqcn) {
                 unset($this->plugins[$idx]);
+                $this->httpClientModified = true;
             }
         }
     }


### PR DESCRIPTION
This will correct typo s/fqn/fqcn/

Also, When we remove a plugin we should rebuild the HttpClient (set `$this->httpClientModified = true`). Nobody is effected by this bug since we always call addPlugin after we remove a plugin. But this is for the sake of correctness. 