### PR TITLE
Updated functional tests with getApiVersion

### DIFF
--- a/test/Github/Tests/Functional/RepoTest.php
+++ b/test/Github/Tests/Functional/RepoTest.php
@@ -15,7 +15,7 @@ class RepoTest extends TestCase
         $this->client->addHeaders(
             array('Accept' => sprintf(
                 'application/vnd.github.%s.diff',
-                $this->client->getOption('api_version')
+                $this->client->getApiVersion()
             ))
         );
 


### PR DESCRIPTION
This is a small bugfix related to #415 

Also: Why isn't the functional tests running on Travis?