### PR TITLE
Make sure we always use valid urls

### DIFF
--- a/lib/Github/Api/Authorizations.php
+++ b/lib/Github/Api/Authorizations.php
@@ -17,7 +17,7 @@ class Authorizations extends AbstractApi
      */
     public function all()
     {
-        return $this->get('authorizations');
+        return $this->get('/authorizations');
     }
 
     /**
@@ -29,7 +29,7 @@ class Authorizations extends AbstractApi
      */
     public function show($clientId)
     {
-        return $this->get('authorizations/'.rawurlencode($clientId));
+        return $this->get('/authorizations/'.rawurlencode($clientId));
     }
 
     /**
@@ -44,7 +44,7 @@ class Authorizations extends AbstractApi
     {
         $headers = null === $OTPCode ? array() : array('X-GitHub-OTP' => $OTPCode);
 
-        return $this->post('authorizations', $params, $headers);
+        return $this->post('/authorizations', $params, $headers);
     }
 
     /**
@@ -57,7 +57,7 @@ class Authorizations extends AbstractApi
      */
     public function update($clientId, array $params)
     {
-        return $this->patch('authorizations/'.rawurlencode($clientId), $params);
+        return $this->patch('/authorizations/'.rawurlencode($clientId), $params);
     }
 
     /**
@@ -69,7 +69,7 @@ class Authorizations extends AbstractApi
      */
     public function remove($clientId)
     {
-        return $this->delete('authorizations/'.rawurlencode($clientId));
+        return $this->delete('/authorizations/'.rawurlencode($clientId));
     }
 
     /**
@@ -82,7 +82,7 @@ class Authorizations extends AbstractApi
      */
     public function check($clientId, $token)
     {
-        return $this->get('applications/'.rawurlencode($clientId).'/tokens/'.rawurlencode($token));
+        return $this->get('/applications/'.rawurlencode($clientId).'/tokens/'.rawurlencode($token));
     }
 
     /**
@@ -95,7 +95,7 @@ class Authorizations extends AbstractApi
      */
     public function reset($clientId, $token)
     {
-        return $this->post('applications/'.rawurlencode($clientId).'/tokens/'.rawurlencode($token));
+        return $this->post('/applications/'.rawurlencode($clientId).'/tokens/'.rawurlencode($token));
     }
 
     /**
@@ -106,7 +106,7 @@ class Authorizations extends AbstractApi
      */
     public function revoke($clientId, $token)
     {
-        $this->delete('applications/'.rawurlencode($clientId).'/tokens/'.rawurlencode($token));
+        $this->delete('/applications/'.rawurlencode($clientId).'/tokens/'.rawurlencode($token));
     }
 
     /**
@@ -116,6 +116,6 @@ class Authorizations extends AbstractApi
      */
     public function revokeAll($clientId)
     {
-        $this->delete('applications/'.rawurlencode($clientId).'/tokens');
+        $this->delete('/applications/'.rawurlencode($clientId).'/tokens');
     }
 }

--- a/lib/Github/Api/CurrentUser.php
+++ b/lib/Github/Api/CurrentUser.php
@@ -19,12 +19,12 @@ class CurrentUser extends AbstractApi
 {
     public function show()
     {
-        return $this->get('user');
+        return $this->get('/user');
     }
 
     public function update(array $params)
     {
-        return $this->patch('user', $params);
+        return $this->patch('/user', $params);
     }
 
     /**
@@ -45,7 +45,7 @@ class CurrentUser extends AbstractApi
 
     public function followers($page = 1)
     {
-        return $this->get('user/followers', array(
+        return $this->get('/user/followers', array(
             'page' => $page
         ));
     }
@@ -60,7 +60,7 @@ class CurrentUser extends AbstractApi
      */
     public function issues(array $params = array(), $includeOrgIssues = true)
     {
-        return $this->get($includeOrgIssues ? 'issues' : 'user/issues', array_merge(array('page' => 1), $params));
+        return $this->get($includeOrgIssues ? '/issues' : '/user/issues', array_merge(array('page' => 1), $params));
     }
 
     /**
@@ -94,7 +94,7 @@ class CurrentUser extends AbstractApi
      */
     public function organizations()
     {
-        return $this->get('user/orgs');
+        return $this->get('/user/orgs');
     }
 
     /**
@@ -104,7 +104,7 @@ class CurrentUser extends AbstractApi
      */
     public function teams()
     {
-        return $this->get('user/teams');
+        return $this->get('/user/teams');
     }
 
     /**
@@ -118,7 +118,7 @@ class CurrentUser extends AbstractApi
      */
     public function repositories($type = 'owner', $sort = 'full_name', $direction = 'asc')
     {
-        return $this->get('user/repos', array(
+        return $this->get('/user/repos', array(
             'type' => $type,
             'sort' => $sort,
             'direction' => $direction
@@ -138,7 +138,7 @@ class CurrentUser extends AbstractApi
      */
     public function watched($page = 1)
     {
-        return $this->get('user/watched', array(
+        return $this->get('/user/watched', array(
             'page' => $page
         ));
     }
@@ -156,16 +156,16 @@ class CurrentUser extends AbstractApi
      */
     public function starred($page = 1)
     {
-        return $this->get('user/starred', array(
+        return $this->get('/user/starred', array(
             'page' => $page
         ));
     }
-    
+
     /**
      *  @link https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
      */
     public function subscriptions()
     {
-        return $this->get('user/subscriptions');
+        return $this->get('/user/subscriptions');
     }
 }

--- a/lib/Github/Api/CurrentUser/DeployKeys.php
+++ b/lib/Github/Api/CurrentUser/DeployKeys.php
@@ -20,7 +20,7 @@ class DeployKeys extends AbstractApi
      */
     public function all()
     {
-        return $this->get('user/keys');
+        return $this->get('/user/keys');
     }
 
     /**
@@ -34,7 +34,7 @@ class DeployKeys extends AbstractApi
      */
     public function show($id)
     {
-        return $this->get('user/keys/'.rawurlencode($id));
+        return $this->get('/user/keys/'.rawurlencode($id));
     }
 
     /**
@@ -54,7 +54,7 @@ class DeployKeys extends AbstractApi
             throw new MissingArgumentException(array('title', 'key'));
         }
 
-        return $this->post('user/keys', $params);
+        return $this->post('/user/keys', $params);
     }
 
     /**
@@ -75,7 +75,7 @@ class DeployKeys extends AbstractApi
             throw new MissingArgumentException(array('title', 'key'));
         }
 
-        return $this->patch('user/keys/'.rawurlencode($id), $params);
+        return $this->patch('/user/keys/'.rawurlencode($id), $params);
     }
 
     /**
@@ -89,6 +89,6 @@ class DeployKeys extends AbstractApi
      */
     public function remove($id)
     {
-        return $this->delete('user/keys/'.rawurlencode($id));
+        return $this->delete('/user/keys/'.rawurlencode($id));
     }
 }

--- a/lib/Github/Api/CurrentUser/Emails.php
+++ b/lib/Github/Api/CurrentUser/Emails.php
@@ -20,7 +20,7 @@ class Emails extends AbstractApi
      */
     public function all()
     {
-        return $this->get('user/emails');
+        return $this->get('/user/emails');
     }
 
     /**
@@ -42,7 +42,7 @@ class Emails extends AbstractApi
             throw new InvalidArgumentException();
         }
 
-        return $this->post('user/emails', $emails);
+        return $this->post('/user/emails', $emails);
     }
 
     /**
@@ -64,6 +64,6 @@ class Emails extends AbstractApi
             throw new InvalidArgumentException();
         }
 
-        return $this->delete('user/emails', $emails);
+        return $this->delete('/user/emails', $emails);
     }
 }

--- a/lib/Github/Api/CurrentUser/Followers.php
+++ b/lib/Github/Api/CurrentUser/Followers.php
@@ -21,7 +21,7 @@ class Followers extends AbstractApi
      */
     public function all($page = 1)
     {
-        return $this->get('user/following', array(
+        return $this->get('/user/following', array(
             'page' => $page
         ));
     }
@@ -37,7 +37,7 @@ class Followers extends AbstractApi
      */
     public function check($username)
     {
-        return $this->get('user/following/'.rawurlencode($username));
+        return $this->get('/user/following/'.rawurlencode($username));
     }
 
     /**
@@ -51,7 +51,7 @@ class Followers extends AbstractApi
      */
     public function follow($username)
     {
-        return $this->put('user/following/'.rawurlencode($username));
+        return $this->put('/user/following/'.rawurlencode($username));
     }
 
     /**
@@ -65,6 +65,6 @@ class Followers extends AbstractApi
      */
     public function unfollow($username)
     {
-        return $this->delete('user/following/'.rawurlencode($username));
+        return $this->delete('/user/following/'.rawurlencode($username));
     }
 }

--- a/lib/Github/Api/CurrentUser/Memberships.php
+++ b/lib/Github/Api/CurrentUser/Memberships.php
@@ -15,7 +15,7 @@ class Memberships extends AbstractApi
      */
     public function all()
     {
-        return $this->get('user/memberships/orgs');
+        return $this->get('/user/memberships/orgs');
     }
 
     /**
@@ -29,7 +29,7 @@ class Memberships extends AbstractApi
      */
     public function organization($organization)
     {
-        return $this->get('user/memberships/orgs/'.rawurlencode($organization));
+        return $this->get('/user/memberships/orgs/'.rawurlencode($organization));
     }
 
     /**
@@ -43,6 +43,6 @@ class Memberships extends AbstractApi
      */
     public function edit($organization)
     {
-        return $this->patch('user/memberships/orgs/'.rawurlencode($organization), array('state' => 'active'));
+        return $this->patch('/user/memberships/orgs/'.rawurlencode($organization), array('state' => 'active'));
     }
 }

--- a/lib/Github/Api/CurrentUser/Notifications.php
+++ b/lib/Github/Api/CurrentUser/Notifications.php
@@ -21,7 +21,7 @@ class Notifications extends AbstractApi
      */
     public function all(array $params = array())
     {
-        return $this->get('notifications', $params);
+        return $this->get('/notifications', $params);
     }
 
     /**
@@ -37,7 +37,7 @@ class Notifications extends AbstractApi
      */
     public function allInRepository($username, $repository, array $params = array())
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/notifications', $params);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/notifications', $params);
     }
 
     /**
@@ -51,7 +51,7 @@ class Notifications extends AbstractApi
      */
     public function markAsReadAll(array $params = array())
     {
-        return $this->put('notifications', $params);
+        return $this->put('/notifications', $params);
     }
 
     /**
@@ -67,7 +67,7 @@ class Notifications extends AbstractApi
      */
     public function markAsReadInRepository($username, $repository, array $params = array())
     {
-        return $this->put('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/notifications', $params);
+        return $this->put('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/notifications', $params);
     }
 
     /**
@@ -82,7 +82,7 @@ class Notifications extends AbstractApi
      */
     public function markAsRead($id, array $params)
     {
-        return $this->patch('notifications/threads/'.rawurlencode($id), $params);
+        return $this->patch('/notifications/threads/'.rawurlencode($id), $params);
     }
 
     /**
@@ -96,7 +96,7 @@ class Notifications extends AbstractApi
      */
     public function show($id)
     {
-        return $this->get('notifications/threads/'.rawurlencode($id));
+        return $this->get('/notifications/threads/'.rawurlencode($id));
     }
 
     /**
@@ -110,7 +110,7 @@ class Notifications extends AbstractApi
      */
     public function showSubscription($id)
     {
-        return $this->get('notifications/threads/'.rawurlencode($id).'/subscription');
+        return $this->get('/notifications/threads/'.rawurlencode($id).'/subscription');
     }
 
     /**
@@ -125,7 +125,7 @@ class Notifications extends AbstractApi
      */
     public function createSubscription($id, array $params)
     {
-        return $this->put('notifications/threads/'.rawurlencode($id).'/subscription', $params);
+        return $this->put('/notifications/threads/'.rawurlencode($id).'/subscription', $params);
     }
 
     /**
@@ -139,6 +139,6 @@ class Notifications extends AbstractApi
      */
     public function removeSubscription($id)
     {
-        return $this->delete('notifications/threads/'.rawurlencode($id).'/subscription');
+        return $this->delete('/notifications/threads/'.rawurlencode($id).'/subscription');
     }
 }

--- a/lib/Github/Api/CurrentUser/Starring.php
+++ b/lib/Github/Api/CurrentUser/Starring.php
@@ -21,7 +21,7 @@ class Starring extends AbstractApi
      */
     public function all($page = 1)
     {
-        return $this->get('user/starred', array(
+        return $this->get('/user/starred', array(
             'page' => $page
         ));
     }
@@ -38,7 +38,7 @@ class Starring extends AbstractApi
      */
     public function check($username, $repository)
     {
-        return $this->get('user/starred/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->get('/user/starred/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
     /**
@@ -53,7 +53,7 @@ class Starring extends AbstractApi
      */
     public function star($username, $repository)
     {
-        return $this->put('user/starred/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->put('/user/starred/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
     /**
@@ -68,6 +68,6 @@ class Starring extends AbstractApi
      */
     public function unstar($username, $repository)
     {
-        return $this->delete('user/starred/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->delete('/user/starred/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 }

--- a/lib/Github/Api/CurrentUser/Watchers.php
+++ b/lib/Github/Api/CurrentUser/Watchers.php
@@ -22,7 +22,7 @@ class Watchers extends AbstractApi
      */
     public function all($page = 1)
     {
-        return $this->get('user/subscriptions', array(
+        return $this->get('/user/subscriptions', array(
             'page' => $page
         ));
     }
@@ -39,7 +39,7 @@ class Watchers extends AbstractApi
      */
     public function check($username, $repository)
     {
-        return $this->get('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->get('/user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
     /**
@@ -54,7 +54,7 @@ class Watchers extends AbstractApi
      */
     public function watch($username, $repository)
     {
-        return $this->put('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->put('/user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
     /**
@@ -69,6 +69,6 @@ class Watchers extends AbstractApi
      */
     public function unwatch($username, $repository)
     {
-        return $this->delete('user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->delete('/user/subscriptions/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 }

--- a/lib/Github/Api/Deployment.php
+++ b/lib/Github/Api/Deployment.php
@@ -22,7 +22,7 @@ class Deployment extends AbstractApi
      */
     public function all($username, $repository, array $params = array())
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments', $params);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments', $params);
     }
 
     /**
@@ -45,7 +45,7 @@ class Deployment extends AbstractApi
             throw new MissingArgumentException(array('ref'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments', $params);
     }
 
     /**
@@ -68,7 +68,7 @@ class Deployment extends AbstractApi
             throw new MissingArgumentException(array('state'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments/'.rawurlencode($id).'/statuses', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments/'.rawurlencode($id).'/statuses', $params);
     }
 
     /**
@@ -81,6 +81,6 @@ class Deployment extends AbstractApi
      */
     public function getStatuses($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments/'.rawurlencode($id).'/statuses');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments/'.rawurlencode($id).'/statuses');
     }
 }

--- a/lib/Github/Api/Enterprise/License.php
+++ b/lib/Github/Api/Enterprise/License.php
@@ -15,6 +15,6 @@ class License extends AbstractApi
      */
     public function show()
     {
-        return $this->get('enterprise/settings/license');
+        return $this->get('/enterprise/settings/license');
     }
 }

--- a/lib/Github/Api/Enterprise/Stats.php
+++ b/lib/Github/Api/Enterprise/Stats.php
@@ -123,6 +123,6 @@ class Stats extends AbstractApi
      */
     public function show($type)
     {
-        return $this->get('enterprise/stats/' . rawurlencode($type));
+        return $this->get('/enterprise/stats/' . rawurlencode($type));
     }
 }

--- a/lib/Github/Api/Enterprise/UserAdmin.php
+++ b/lib/Github/Api/Enterprise/UserAdmin.php
@@ -17,7 +17,7 @@ class UserAdmin extends AbstractApi
      */
     public function suspend($username)
     {
-        return $this->put('users/'.rawurldecode($username).'/suspended', array('Content-Length' => 0));
+        return $this->put('/users/'.rawurldecode($username).'/suspended', array('Content-Length' => 0));
     }
 
     /**
@@ -31,6 +31,6 @@ class UserAdmin extends AbstractApi
      */
     public function unsuspend($username)
     {
-        return $this->delete('users/'.rawurldecode($username).'/suspended');
+        return $this->delete('/users/'.rawurldecode($username).'/suspended');
     }
 }

--- a/lib/Github/Api/Gist/Comments.php
+++ b/lib/Github/Api/Gist/Comments.php
@@ -19,7 +19,7 @@ class Comments extends AbstractApi
      */
     public function all($gist)
     {
-        return $this->get('gists/'.rawurlencode($gist).'/comments');
+        return $this->get('/gists/'.rawurlencode($gist).'/comments');
     }
 
     /**
@@ -32,7 +32,7 @@ class Comments extends AbstractApi
      */
     public function show($gist, $comment)
     {
-        return $this->get('gists/'.rawurlencode($gist).'/comments/'.rawurlencode($comment));
+        return $this->get('/gists/'.rawurlencode($gist).'/comments/'.rawurlencode($comment));
     }
 
     /**
@@ -45,7 +45,7 @@ class Comments extends AbstractApi
      */
     public function create($gist, $body)
     {
-        return $this->post('gists/'.rawurlencode($gist).'/comments', array('body' => $body));
+        return $this->post('/gists/'.rawurlencode($gist).'/comments', array('body' => $body));
     }
 
     /**
@@ -59,7 +59,7 @@ class Comments extends AbstractApi
      */
     public function update($gist, $comment_id, $body)
     {
-        return $this->patch('gists/'.rawurlencode($gist).'/comments/'.rawurlencode($comment_id), array('body' => $body));
+        return $this->patch('/gists/'.rawurlencode($gist).'/comments/'.rawurlencode($comment_id), array('body' => $body));
     }
 
     /**
@@ -72,6 +72,6 @@ class Comments extends AbstractApi
      */
     public function remove($gist, $comment)
     {
-        return $this->delete('gists/'.rawurlencode($gist).'/comments/'.rawurlencode($comment));
+        return $this->delete('/gists/'.rawurlencode($gist).'/comments/'.rawurlencode($comment));
     }
 }

--- a/lib/Github/Api/Gists.php
+++ b/lib/Github/Api/Gists.php
@@ -17,15 +17,15 @@ class Gists extends AbstractApi
     public function all($type = null)
     {
         if (!in_array($type, array('public', 'starred'))) {
-            return $this->get('gists');
+            return $this->get('/gists');
         }
 
-        return $this->get('gists/'.rawurlencode($type));
+        return $this->get('/gists/'.rawurlencode($type));
     }
 
     public function show($number)
     {
-        return $this->get('gists/'.rawurlencode($number));
+        return $this->get('/gists/'.rawurlencode($number));
     }
 
     public function create(array $params)
@@ -36,47 +36,47 @@ class Gists extends AbstractApi
 
         $params['public'] = (bool) $params['public'];
 
-        return $this->post('gists', $params);
+        return $this->post('/gists', $params);
     }
 
     public function update($id, array $params)
     {
-        return $this->patch('gists/'.rawurlencode($id), $params);
+        return $this->patch('/gists/'.rawurlencode($id), $params);
     }
 
     public function commits($id)
     {
-        return $this->get('gists/'.rawurlencode($id).'/commits');
+        return $this->get('/gists/'.rawurlencode($id).'/commits');
     }
 
     public function fork($id)
     {
-        return $this->post('gists/'.rawurlencode($id).'/fork');
+        return $this->post('/gists/'.rawurlencode($id).'/fork');
     }
 
     public function forks($id)
     {
-        return $this->get('gists/'.rawurlencode($id).'/forks');
+        return $this->get('/gists/'.rawurlencode($id).'/forks');
     }
 
     public function remove($id)
     {
-        return $this->delete('gists/'.rawurlencode($id));
+        return $this->delete('/gists/'.rawurlencode($id));
     }
 
     public function check($id)
     {
-        return $this->get('gists/'.rawurlencode($id).'/star');
+        return $this->get('/gists/'.rawurlencode($id).'/star');
     }
 
     public function star($id)
     {
-        return $this->put('gists/'.rawurlencode($id).'/star');
+        return $this->put('/gists/'.rawurlencode($id).'/star');
     }
 
     public function unstar($id)
     {
-        return $this->delete('gists/'.rawurlencode($id).'/star');
+        return $this->delete('/gists/'.rawurlencode($id).'/star');
     }
 
     /**

--- a/lib/Github/Api/GitData/Blobs.php
+++ b/lib/Github/Api/GitData/Blobs.php
@@ -38,7 +38,7 @@ class Blobs extends AbstractApi
      */
     public function show($username, $repository, $sha)
     {
-        $response = $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/blobs/'.rawurlencode($sha));
+        $response = $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/blobs/'.rawurlencode($sha));
 
         return $response;
     }
@@ -60,6 +60,6 @@ class Blobs extends AbstractApi
             throw new MissingArgumentException(array('content', 'encoding'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/blobs', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/blobs', $params);
     }
 }

--- a/lib/Github/Api/GitData/Commits.php
+++ b/lib/Github/Api/GitData/Commits.php
@@ -22,7 +22,7 @@ class Commits extends AbstractApi
      */
     public function show($username, $repository, $sha)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/commits/'.rawurlencode($sha));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/commits/'.rawurlencode($sha));
     }
 
     /**
@@ -42,6 +42,6 @@ class Commits extends AbstractApi
             throw new MissingArgumentException(array('message', 'tree', 'parents'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/commits', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/commits', $params);
     }
 }

--- a/lib/Github/Api/GitData/References.php
+++ b/lib/Github/Api/GitData/References.php
@@ -21,7 +21,7 @@ class References extends AbstractApi
      */
     public function all($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs');
     }
 
     /**
@@ -34,7 +34,7 @@ class References extends AbstractApi
      */
     public function branches($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/heads');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/heads');
     }
 
     /**
@@ -47,7 +47,7 @@ class References extends AbstractApi
      */
     public function tags($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/tags');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/tags');
     }
 
     /**
@@ -63,7 +63,7 @@ class References extends AbstractApi
     {
         $reference = $this->encodeReference($reference);
 
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/'.$reference);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/'.$reference);
     }
 
     /**
@@ -83,7 +83,7 @@ class References extends AbstractApi
             throw new MissingArgumentException(array('ref', 'sha'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs', $params);
     }
 
     /**
@@ -106,7 +106,7 @@ class References extends AbstractApi
 
         $reference = $this->encodeReference($reference);
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/'.$reference, $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/'.$reference, $params);
     }
 
     /**
@@ -122,7 +122,7 @@ class References extends AbstractApi
     {
         $reference = $this->encodeReference($reference);
 
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/'.$reference);
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/'.$reference);
     }
 
     /**

--- a/lib/Github/Api/GitData/Tags.php
+++ b/lib/Github/Api/GitData/Tags.php
@@ -21,7 +21,7 @@ class Tags extends AbstractApi
      */
     public function all($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/tags');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/refs/tags');
     }
 
     /**
@@ -35,7 +35,7 @@ class Tags extends AbstractApi
      */
     public function show($username, $repository, $sha)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/tags/'.rawurlencode($sha));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/tags/'.rawurlencode($sha));
     }
 
     /**
@@ -63,6 +63,6 @@ class Tags extends AbstractApi
             throw new MissingArgumentException(array('tagger.name', 'tagger.email', 'tagger.date'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/tags', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/tags', $params);
     }
 }

--- a/lib/Github/Api/GitData/Trees.php
+++ b/lib/Github/Api/GitData/Trees.php
@@ -23,7 +23,7 @@ class Trees extends AbstractApi
      */
     public function show($username, $repository, $sha, $recursive = false)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/trees/'.rawurlencode($sha), $recursive ? array('recursive' => 1) : array());
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/trees/'.rawurlencode($sha), $recursive ? array('recursive' => 1) : array());
     }
 
     /**
@@ -58,6 +58,6 @@ class Trees extends AbstractApi
             }
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/trees', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/trees', $params);
     }
 }

--- a/lib/Github/Api/Issue.php
+++ b/lib/Github/Api/Issue.php
@@ -31,7 +31,7 @@ class Issue extends AbstractApi
      */
     public function all($username, $repository, array $params = array())
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues', array_merge(array('page' => 1), $params));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues', array_merge(array('page' => 1), $params));
     }
 
     /**
@@ -52,7 +52,7 @@ class Issue extends AbstractApi
             $state = 'open';
         }
 
-        return $this->get('legacy/issues/search/'.rawurlencode($username).'/'.rawurlencode($repository).'/'.rawurlencode($state).'/'.rawurlencode($keyword));
+        return $this->get('/legacy/issues/search/'.rawurlencode($username).'/'.rawurlencode($repository).'/'.rawurlencode($state).'/'.rawurlencode($keyword));
     }
 
     /**
@@ -72,7 +72,7 @@ class Issue extends AbstractApi
             $state = 'open';
         }
 
-        return $this->get('orgs/'.rawurlencode($organization).'/issues', array_merge(array('page' => 1, 'state' => $state), $params));
+        return $this->get('/orgs/'.rawurlencode($organization).'/issues', array_merge(array('page' => 1, 'state' => $state), $params));
     }
 
     /**
@@ -88,7 +88,7 @@ class Issue extends AbstractApi
      */
     public function show($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($id));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($id));
     }
 
     /**
@@ -111,7 +111,7 @@ class Issue extends AbstractApi
             throw new MissingArgumentException(array('title', 'body'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues', $params);
     }
 
     /**
@@ -129,7 +129,7 @@ class Issue extends AbstractApi
      */
     public function update($username, $repository, $id, array $params)
     {
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($id), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($id), $params);
     }
 
     /**

--- a/lib/Github/Api/Issue/Comments.php
+++ b/lib/Github/Api/Issue/Comments.php
@@ -43,7 +43,7 @@ class Comments extends AbstractApi
      */
     public function all($username, $repository, $issue, $page = 1)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/comments', array(
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/comments', array(
             'page' => $page
         ));
     }
@@ -60,7 +60,7 @@ class Comments extends AbstractApi
      */
     public function show($username, $repository, $comment)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/comments/'.rawurlencode($comment));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/comments/'.rawurlencode($comment));
     }
 
     /**
@@ -81,7 +81,7 @@ class Comments extends AbstractApi
             throw new MissingArgumentException('body');
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/comments', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/comments', $params);
     }
 
     /**
@@ -102,7 +102,7 @@ class Comments extends AbstractApi
             throw new MissingArgumentException('body');
         }
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/comments/'.rawurlencode($comment), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/comments/'.rawurlencode($comment), $params);
     }
 
     /**
@@ -117,6 +117,6 @@ class Comments extends AbstractApi
      */
     public function remove($username, $repository, $comment)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/comments/'.rawurlencode($comment));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/comments/'.rawurlencode($comment));
     }
 }

--- a/lib/Github/Api/Issue/Events.php
+++ b/lib/Github/Api/Issue/Events.php
@@ -23,9 +23,9 @@ class Events extends AbstractApi
     public function all($username, $repository, $issue = null, $page = 1)
     {
         if (null !== $issue) {
-            $path = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/events';
+            $path = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/events';
         } else {
-            $path = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/events';
+            $path = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/events';
         }
 
         return $this->get($path, array(
@@ -44,6 +44,6 @@ class Events extends AbstractApi
      */
     public function show($username, $repository, $event)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/events/'.rawurlencode($event));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/events/'.rawurlencode($event));
     }
 }

--- a/lib/Github/Api/Issue/Labels.php
+++ b/lib/Github/Api/Issue/Labels.php
@@ -25,9 +25,9 @@ class Labels extends AbstractApi
     public function all($username, $repository, $issue = null)
     {
         if ($issue === null) {
-            $path = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels';
+            $path = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels';
         } else {
-            $path = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/labels';
+            $path = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/labels';
         }
 
         return $this->get($path);
@@ -54,7 +54,7 @@ class Labels extends AbstractApi
             $params['color'] = 'FFFFFF';
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels', $params);
     }
 
     /**
@@ -69,7 +69,7 @@ class Labels extends AbstractApi
      */
     public function deleteLabel($username, $repository, $label)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label));
     }
 
     /**
@@ -91,7 +91,7 @@ class Labels extends AbstractApi
             'color' => $color,
         );
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label), $params);
     }
 
     /**
@@ -115,7 +115,7 @@ class Labels extends AbstractApi
             throw new InvalidArgumentException();
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/labels', $labels);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/labels', $labels);
     }
 
     /**
@@ -131,7 +131,7 @@ class Labels extends AbstractApi
      */
     public function replace($username, $repository, $issue, array $params)
     {
-        return $this->put('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/labels', $params);
+        return $this->put('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/labels', $params);
     }
 
     /**
@@ -147,7 +147,7 @@ class Labels extends AbstractApi
      */
     public function remove($username, $repository, $issue, $label)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/labels/'.rawurlencode($label));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/labels/'.rawurlencode($label));
     }
 
     /**
@@ -162,6 +162,6 @@ class Labels extends AbstractApi
      */
     public function clear($username, $repository, $issue)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/labels');
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/labels');
     }
 }

--- a/lib/Github/Api/Issue/Milestones.php
+++ b/lib/Github/Api/Issue/Milestones.php
@@ -33,7 +33,7 @@ class Milestones extends AbstractApi
             $params['direction'] = 'desc';
         }
 
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones', array_merge(array(
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones', array_merge(array(
             'page'      => 1,
             'state'     => 'open',
             'sort'      => 'due_date',
@@ -53,7 +53,7 @@ class Milestones extends AbstractApi
      */
     public function show($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones/'.rawurlencode($id));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones/'.rawurlencode($id));
     }
 
     /**
@@ -77,7 +77,7 @@ class Milestones extends AbstractApi
             $params['state'] = 'open';
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones', $params);
     }
 
     /**
@@ -97,7 +97,7 @@ class Milestones extends AbstractApi
             $params['state'] = 'open';
         }
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones/'.rawurlencode($id), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones/'.rawurlencode($id), $params);
     }
 
     /**
@@ -112,7 +112,7 @@ class Milestones extends AbstractApi
      */
     public function remove($username, $repository, $id)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones/'.rawurlencode($id));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones/'.rawurlencode($id));
     }
 
     /**
@@ -127,6 +127,6 @@ class Milestones extends AbstractApi
      */
     public function labels($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones/'.rawurlencode($id).'/labels');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones/'.rawurlencode($id).'/labels');
     }
 }

--- a/lib/Github/Api/Markdown.php
+++ b/lib/Github/Api/Markdown.php
@@ -31,7 +31,7 @@ class Markdown extends AbstractApi
             $params['context'] = $context;
         }
 
-        return $this->post('markdown', $params);
+        return $this->post('/markdown', $params);
     }
 
     /**
@@ -41,7 +41,7 @@ class Markdown extends AbstractApi
      */
     public function renderRaw($file)
     {
-        return $this->post('markdown/raw', array(
+        return $this->post('/markdown/raw', array(
             'file' => $file
         ));
     }

--- a/lib/Github/Api/Meta.php
+++ b/lib/Github/Api/Meta.php
@@ -17,6 +17,6 @@ class Meta extends AbstractApi
      */
     public function service()
     {
-        return $this->get('meta');
+        return $this->get('/meta');
     }
 }

--- a/lib/Github/Api/Notification.php
+++ b/lib/Github/Api/Notification.php
@@ -36,7 +36,7 @@ class Notification extends AbstractApi
             $parameters['since'] = $since->format(DateTime::ISO8601);
         }
 
-        return $this->get('notifications', $parameters);
+        return $this->get('/notifications', $parameters);
     }
 
     /**
@@ -55,6 +55,6 @@ class Notification extends AbstractApi
             $parameters['last_read_at'] = $since->format(DateTime::ISO8601);
         }
 
-        $this->put('notifications', $parameters);
+        $this->put('/notifications', $parameters);
     }
 }

--- a/lib/Github/Api/Organization.php
+++ b/lib/Github/Api/Organization.php
@@ -22,7 +22,7 @@ class Organization extends AbstractApi
      */
     public function all($since = '')
     {
-        return $this->get('organizations?since='.rawurlencode($since));
+        return $this->get('/organizations?since='.rawurlencode($since));
     }
 
     /**
@@ -36,12 +36,12 @@ class Organization extends AbstractApi
      */
     public function show($organization)
     {
-        return $this->get('orgs/'.rawurlencode($organization));
+        return $this->get('/orgs/'.rawurlencode($organization));
     }
 
     public function update($organization, array $params)
     {
-        return $this->patch('orgs/'.rawurlencode($organization), $params);
+        return $this->patch('/orgs/'.rawurlencode($organization), $params);
     }
 
     /**
@@ -56,7 +56,7 @@ class Organization extends AbstractApi
      */
     public function repositories($organization, $type = 'all')
     {
-        return $this->get('orgs/'.rawurlencode($organization).'/repos', array(
+        return $this->get('/orgs/'.rawurlencode($organization).'/repos', array(
             'type' => $type
         ));
     }
@@ -96,6 +96,6 @@ class Organization extends AbstractApi
      */
     public function issues($organization, array $params = array(), $page = 1)
     {
-        return $this->get('orgs/'.rawurlencode($organization).'/issues', array_merge(array('page' => $page), $params));
+        return $this->get('/orgs/'.rawurlencode($organization).'/issues', array_merge(array('page' => $page), $params));
     }
 }

--- a/lib/Github/Api/Organization/Hooks.php
+++ b/lib/Github/Api/Organization/Hooks.php
@@ -16,7 +16,7 @@ class Hooks extends AbstractApi
      */
     public function all($organization)
     {
-        return $this->get('orgs/'.rawurlencode($organization).'/hooks');
+        return $this->get('/orgs/'.rawurlencode($organization).'/hooks');
     }
 
     /**
@@ -29,7 +29,7 @@ class Hooks extends AbstractApi
      */
     public function show($organization, $id)
     {
-        return $this->get('orgs/'.rawurlencode($organization).'/hooks/'.rawurlencode($id));
+        return $this->get('/orgs/'.rawurlencode($organization).'/hooks/'.rawurlencode($id));
     }
 
     /**
@@ -47,7 +47,7 @@ class Hooks extends AbstractApi
             throw new MissingArgumentException(array('name', 'config'));
         }
 
-        return $this->post('orgs/'.rawurlencode($organization).'/hooks', $params);
+        return $this->post('/orgs/'.rawurlencode($organization).'/hooks', $params);
     }
 
     /**
@@ -66,7 +66,7 @@ class Hooks extends AbstractApi
             throw new MissingArgumentException(array('config'));
         }
 
-        return $this->patch('orgs/'.rawurlencode($organization).'/hooks/'.rawurlencode($id), $params);
+        return $this->patch('/orgs/'.rawurlencode($organization).'/hooks/'.rawurlencode($id), $params);
     }
 
     /**
@@ -79,7 +79,7 @@ class Hooks extends AbstractApi
      */
     public function ping($organization, $id)
     {
-        return $this->post('orgs/'.rawurlencode($organization).'/hooks/'.rawurlencode($id).'/pings');
+        return $this->post('/orgs/'.rawurlencode($organization).'/hooks/'.rawurlencode($id).'/pings');
     }
 
     /**
@@ -92,6 +92,6 @@ class Hooks extends AbstractApi
      */
     public function remove($organization, $id)
     {
-        return $this->delete('orgs/'.rawurlencode($organization).'/hooks/'.rawurlencode($id));
+        return $this->delete('/orgs/'.rawurlencode($organization).'/hooks/'.rawurlencode($id));
     }
 }

--- a/lib/Github/Api/Organization/Members.php
+++ b/lib/Github/Api/Organization/Members.php
@@ -13,7 +13,7 @@ class Members extends AbstractApi
     public function all($organization, $type = null, $filter = 'all', $role = null)
     {
         $parameters = array();
-        $path = 'orgs/'.rawurlencode($organization).'/';
+        $path = '/orgs/'.rawurlencode($organization).'/';
         if (null === $type) {
             $path .= 'members';
             if (null !== $filter) {
@@ -31,32 +31,32 @@ class Members extends AbstractApi
 
     public function show($organization, $username)
     {
-        return $this->get('orgs/'.rawurlencode($organization).'/members/'.rawurlencode($username));
+        return $this->get('/orgs/'.rawurlencode($organization).'/members/'.rawurlencode($username));
     }
 
     public function member($organization, $username)
     {
-        return $this->get('orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
+        return $this->get('/orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
     }
 
     public function check($organization, $username)
     {
-        return $this->get('orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));
+        return $this->get('/orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));
     }
 
     public function addMember($organization, $username)
     {
-        return $this->put('orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
+        return $this->put('/orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
     }
 
     public function publicize($organization, $username)
     {
-        return $this->put('orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));
+        return $this->put('/orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));
     }
 
     public function conceal($organization, $username)
     {
-        return $this->delete('orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));
+        return $this->delete('/orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));
     }
 
     /*
@@ -64,11 +64,11 @@ class Members extends AbstractApi
      */
     public function add($organization, $username)
     {
-        return $this->put('orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
+        return $this->put('/orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
     }
 
     public function remove($organization, $username)
     {
-        return $this->delete('orgs/'.rawurlencode($organization).'/members/'.rawurlencode($username));
+        return $this->delete('/orgs/'.rawurlencode($organization).'/members/'.rawurlencode($username));
     }
 }

--- a/lib/Github/Api/Organization/Teams.php
+++ b/lib/Github/Api/Organization/Teams.php
@@ -13,7 +13,7 @@ class Teams extends AbstractApi
 {
     public function all($organization)
     {
-        return $this->get('orgs/'.rawurlencode($organization).'/teams');
+        return $this->get('/orgs/'.rawurlencode($organization).'/teams');
     }
 
     public function create($organization, array $params)
@@ -28,12 +28,12 @@ class Teams extends AbstractApi
             $params['permission'] = 'pull';
         }
 
-        return $this->post('orgs/'.rawurlencode($organization).'/teams', $params);
+        return $this->post('/orgs/'.rawurlencode($organization).'/teams', $params);
     }
 
     public function show($team)
     {
-        return $this->get('teams/'.rawurlencode($team));
+        return $this->get('/teams/'.rawurlencode($team));
     }
 
     public function update($team, array $params)
@@ -45,42 +45,42 @@ class Teams extends AbstractApi
             $params['permission'] = 'pull';
         }
 
-        return $this->patch('teams/'.rawurlencode($team), $params);
+        return $this->patch('/teams/'.rawurlencode($team), $params);
     }
 
     public function remove($team)
     {
-        return $this->delete('teams/'.rawurlencode($team));
+        return $this->delete('/teams/'.rawurlencode($team));
     }
 
     public function members($team)
     {
-        return $this->get('teams/'.rawurlencode($team).'/members');
+        return $this->get('/teams/'.rawurlencode($team).'/members');
     }
 
     public function check($team, $username)
     {
-        return $this->get('teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        return $this->get('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
     public function addMember($team, $username)
     {
-        return $this->put('teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        return $this->put('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
     public function removeMember($team, $username)
     {
-        return $this->delete('teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        return $this->delete('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
     public function repositories($team)
     {
-        return $this->get('teams/'.rawurlencode($team).'/repos');
+        return $this->get('/teams/'.rawurlencode($team).'/repos');
     }
 
     public function repository($team, $username, $repository)
     {
-        return $this->get('teams/'.rawurlencode($team).'/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->get('/teams/'.rawurlencode($team).'/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
     public function addRepository($team, $username, $repository, $params = array())
@@ -89,11 +89,11 @@ class Teams extends AbstractApi
             $params['permission'] = 'pull';
         }
 
-        return $this->put('teams/'.rawurlencode($team).'/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->put('/teams/'.rawurlencode($team).'/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
     public function removeRepository($team, $username, $repository)
     {
-        return $this->delete('teams/'.rawurlencode($team).'/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->delete('/teams/'.rawurlencode($team).'/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 }

--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -31,7 +31,7 @@ class PullRequest extends AbstractApi
             'per_page' => 30
         ), $params);
 
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls', $parameters);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls', $parameters);
     }
 
     /**
@@ -47,17 +47,17 @@ class PullRequest extends AbstractApi
      */
     public function show($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id));
     }
 
     public function commits($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/commits');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/commits');
     }
 
     public function files($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/files');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/files');
     }
 
     public function comments()
@@ -98,7 +98,7 @@ class PullRequest extends AbstractApi
             throw new MissingArgumentException(array('issue', 'body'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls', $params);
     }
 
     public function update($username, $repository, $id, array $params)
@@ -107,12 +107,12 @@ class PullRequest extends AbstractApi
             $params['state'] = 'open';
         }
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id), $params);
     }
 
     public function merged($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/merge');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/merge');
     }
 
     public function merge($username, $repository, $id, $message, $sha, $squash = false, $title = null)
@@ -127,6 +127,6 @@ class PullRequest extends AbstractApi
             $params['commit_title'] = $title;
         }
 
-        return $this->put('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/merge', $params);
+        return $this->put('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/merge', $params);
     }
 }

--- a/lib/Github/Api/PullRequest/Comments.php
+++ b/lib/Github/Api/PullRequest/Comments.php
@@ -13,12 +13,12 @@ class Comments extends AbstractApi
 {
     public function all($username, $repository, $pullRequest)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($pullRequest).'/comments');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($pullRequest).'/comments');
     }
 
     public function show($username, $repository, $comment)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/comments/'.rawurlencode($comment));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/comments/'.rawurlencode($comment));
     }
 
     public function create($username, $repository, $pullRequest, array $params)
@@ -32,7 +32,7 @@ class Comments extends AbstractApi
             throw new MissingArgumentException(array('commit_id', 'path', 'position'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($pullRequest).'/comments', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($pullRequest).'/comments', $params);
     }
 
     public function update($username, $repository, $comment, array $params)
@@ -41,11 +41,11 @@ class Comments extends AbstractApi
             throw new MissingArgumentException('body');
         }
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/comments/'.rawurlencode($comment), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/comments/'.rawurlencode($comment), $params);
     }
 
     public function remove($username, $repository, $comment)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/comments/'.rawurlencode($comment));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/comments/'.rawurlencode($comment));
     }
 }

--- a/lib/Github/Api/RateLimit.php
+++ b/lib/Github/Api/RateLimit.php
@@ -17,7 +17,7 @@ class RateLimit extends AbstractApi
      */
     public function getRateLimits()
     {
-        return $this->get('rate_limit');
+        return $this->get('/rate_limit');
     }
 
     /**
@@ -28,7 +28,7 @@ class RateLimit extends AbstractApi
     public function getCoreLimit()
     {
         $response = $this->getRateLimits();
-        
+
         return $response['resources']['core']['limit'];
     }
 
@@ -40,7 +40,7 @@ class RateLimit extends AbstractApi
     public function getSearchLimit()
     {
         $response = $this->getRateLimits();
-        
+
         return $response['resources']['search']['limit'];
     }
 }

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -37,7 +37,7 @@ class Repo extends AbstractApi
      */
     public function find($keyword, array $params = array())
     {
-        return $this->get('legacy/repos/search/'.rawurlencode($keyword), array_merge(array('start_page' => 1), $params));
+        return $this->get('/legacy/repos/search/'.rawurlencode($keyword), array_merge(array('start_page' => 1), $params));
     }
 
     /**
@@ -52,10 +52,10 @@ class Repo extends AbstractApi
     public function all($id = null)
     {
         if (!is_int($id)) {
-            return $this->get('repositories');
+            return $this->get('/repositories');
         }
 
-        return $this->get('repositories?since=' . rawurldecode($id));
+        return $this->get('/repositories?since=' . rawurldecode($id));
     }
 
     /**
@@ -70,7 +70,7 @@ class Repo extends AbstractApi
      */
     public function activity($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/stats/commit_activity');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/stats/commit_activity');
     }
 
     /**
@@ -85,7 +85,7 @@ class Repo extends AbstractApi
      */
     public function statistics($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/stats/contributors');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/stats/contributors');
     }
 
     /**
@@ -100,7 +100,7 @@ class Repo extends AbstractApi
      */
     public function org($organization, array $params = array())
     {
-        return $this->get('orgs/'.$organization.'/repos', array_merge(array('start_page' => 1), $params));
+        return $this->get('/orgs/'.$organization.'/repos', array_merge(array('start_page' => 1), $params));
     }
 
     /**
@@ -115,7 +115,7 @@ class Repo extends AbstractApi
      */
     public function show($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
     /**
@@ -148,7 +148,7 @@ class Repo extends AbstractApi
         $teamId = null,
         $autoInit = false
     ) {
-        $path = null !== $organization ? 'orgs/'.$organization.'/repos' : 'user/repos';
+        $path = null !== $organization ? '/orgs/'.$organization.'/repos' : '/user/repos';
 
         $parameters = array(
             'name'          => $name,
@@ -181,7 +181,7 @@ class Repo extends AbstractApi
      */
     public function update($username, $repository, array $values)
     {
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository), $values);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository), $values);
     }
 
     /**
@@ -196,7 +196,7 @@ class Repo extends AbstractApi
      */
     public function remove($username, $repository)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
 
     /**
@@ -211,7 +211,7 @@ class Repo extends AbstractApi
      */
     public function readme($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/readme');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/readme');
     }
 
     /**
@@ -371,7 +371,7 @@ class Repo extends AbstractApi
      */
     public function branches($username, $repository, $branch = null)
     {
-        $url = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/branches';
+        $url = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/branches';
         if (null !== $branch) {
             $url .= '/'.rawurlencode($branch);
         }
@@ -393,7 +393,7 @@ class Repo extends AbstractApi
      */
     public function contributors($username, $repository, $includingAnonymous = false)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contributors', array(
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contributors', array(
             'anon' => $includingAnonymous ?: null
         ));
     }
@@ -410,7 +410,7 @@ class Repo extends AbstractApi
      */
     public function languages($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/languages');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/languages');
     }
 
     /**
@@ -426,7 +426,7 @@ class Repo extends AbstractApi
      */
     public function tags($username, $repository, array $params = [])
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/tags', $params);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/tags', $params);
     }
 
     /**
@@ -441,7 +441,7 @@ class Repo extends AbstractApi
      */
     public function teams($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/teams');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/teams');
     }
 
     /**
@@ -455,7 +455,7 @@ class Repo extends AbstractApi
      */
     public function watchers($username, $repository, $page = 1)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/watchers', array(
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/watchers', array(
             'page' => $page
         ));
     }
@@ -469,7 +469,7 @@ class Repo extends AbstractApi
      */
     public function subscribers($username, $repository, $page = 1)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/subscribers', array(
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/subscribers', array(
             'page' => $page
         ));
     }
@@ -498,7 +498,7 @@ class Repo extends AbstractApi
             $parameters['commit_message'] = $message;
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/merges', $parameters);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/merges', $parameters);
     }
 
     /**
@@ -508,6 +508,6 @@ class Repo extends AbstractApi
      */
     public function milestones($username, $repository)
     {
-        return $this->get('repos/'.rawurldecode($username).'/'.rawurldecode($repository).'/milestones');
+        return $this->get('/repos/'.rawurldecode($username).'/'.rawurldecode($repository).'/milestones');
     }
 }

--- a/lib/Github/Api/Repository/Assets.php
+++ b/lib/Github/Api/Repository/Assets.php
@@ -24,7 +24,7 @@ class Assets extends AbstractApi
      */
     public function all($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/'.rawurlencode($id).'/assets');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/'.rawurlencode($id).'/assets');
     }
 
     /**
@@ -39,7 +39,7 @@ class Assets extends AbstractApi
      */
     public function show($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/assets/'.rawurlencode($id));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/assets/'.rawurlencode($id));
     }
 
     /**
@@ -97,7 +97,7 @@ class Assets extends AbstractApi
             throw new MissingArgumentException('name');
         }
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/assets/'.rawurlencode($id), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/assets/'.rawurlencode($id), $params);
     }
 
     /**
@@ -112,6 +112,6 @@ class Assets extends AbstractApi
      */
     public function remove($username, $repository, $id)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/assets/'.rawurlencode($id));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/assets/'.rawurlencode($id));
     }
 }

--- a/lib/Github/Api/Repository/Collaborators.php
+++ b/lib/Github/Api/Repository/Collaborators.php
@@ -12,21 +12,21 @@ class Collaborators extends AbstractApi
 {
     public function all($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/collaborators');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/collaborators');
     }
 
     public function check($username, $repository, $collaborator)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/collaborators/'.rawurlencode($collaborator));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/collaborators/'.rawurlencode($collaborator));
     }
 
     public function add($username, $repository, $collaborator)
     {
-        return $this->put('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/collaborators/'.rawurlencode($collaborator));
+        return $this->put('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/collaborators/'.rawurlencode($collaborator));
     }
 
     public function remove($username, $repository, $collaborator)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/collaborators/'.rawurlencode($collaborator));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/collaborators/'.rawurlencode($collaborator));
     }
 }

--- a/lib/Github/Api/Repository/Comments.php
+++ b/lib/Github/Api/Repository/Comments.php
@@ -40,15 +40,15 @@ class Comments extends AbstractApi
     public function all($username, $repository, $sha = null)
     {
         if (null === $sha) {
-            return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/comments');
+            return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/comments');
         }
 
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/comments');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/comments');
     }
 
     public function show($username, $repository, $comment)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/comments/'.rawurlencode($comment));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/comments/'.rawurlencode($comment));
     }
 
     public function create($username, $repository, $sha, array $params)
@@ -57,7 +57,7 @@ class Comments extends AbstractApi
             throw new MissingArgumentException('body');
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/comments', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/comments', $params);
     }
 
     public function update($username, $repository, $comment, array $params)
@@ -66,11 +66,11 @@ class Comments extends AbstractApi
             throw new MissingArgumentException('body');
         }
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/comments/'.rawurlencode($comment), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/comments/'.rawurlencode($comment), $params);
     }
 
     public function remove($username, $repository, $comment)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/comments/'.rawurlencode($comment));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/comments/'.rawurlencode($comment));
     }
 }

--- a/lib/Github/Api/Repository/Commits.php
+++ b/lib/Github/Api/Repository/Commits.php
@@ -12,7 +12,7 @@ class Commits extends AbstractApi
 {
     public function all($username, $repository, array $params)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits', $params);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits', $params);
     }
 
     public function compare($username, $repository, $base, $head, $mediaType = null)
@@ -22,11 +22,11 @@ class Commits extends AbstractApi
             $headers['Accept'] = $mediaType;
         }
 
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/compare/'.rawurlencode($base).'...'.rawurlencode($head), array(), $headers);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/compare/'.rawurlencode($base).'...'.rawurlencode($head), array(), $headers);
     }
 
     public function show($username, $repository, $sha)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha));
     }
 }

--- a/lib/Github/Api/Repository/Contents.php
+++ b/lib/Github/Api/Repository/Contents.php
@@ -27,7 +27,7 @@ class Contents extends AbstractApi
      */
     public function readme($username, $repository, $reference = null)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/readme', array(
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/readme', array(
             'ref' => $reference
         ));
     }
@@ -46,7 +46,7 @@ class Contents extends AbstractApi
      */
     public function show($username, $repository, $path = null, $reference = null)
     {
-        $url = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contents';
+        $url = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contents';
         if (null !== $path) {
             $url .= '/'.rawurlencode($path);
         }
@@ -75,7 +75,7 @@ class Contents extends AbstractApi
      */
     public function create($username, $repository, $path, $content, $message, $branch = null, array $committer = null)
     {
-        $url = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contents/'.rawurlencode($path);
+        $url = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contents/'.rawurlencode($path);
 
         $parameters = array(
           'content' => base64_encode($content),
@@ -108,7 +108,7 @@ class Contents extends AbstractApi
      */
     public function exists($username, $repository, $path, $reference = null)
     {
-        $url = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contents';
+        $url = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contents';
 
         if (null !== $path) {
             $url .= '/'.rawurlencode($path);
@@ -151,7 +151,7 @@ class Contents extends AbstractApi
      */
     public function update($username, $repository, $path, $content, $message, $sha, $branch = null, array $committer = null)
     {
-        $url = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contents/'.rawurlencode($path);
+        $url = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contents/'.rawurlencode($path);
 
         $parameters = array(
           'content' => base64_encode($content),
@@ -192,7 +192,7 @@ class Contents extends AbstractApi
      */
     public function rm($username, $repository, $path, $message, $sha, $branch = null, array $committer = null)
     {
-        $url = 'repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contents/'.rawurlencode($path);
+        $url = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/contents/'.rawurlencode($path);
 
         $parameters = array(
           'message' => $message,
@@ -231,7 +231,7 @@ class Contents extends AbstractApi
             $format = 'tarball';
         }
 
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/'.rawurlencode($format).
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/'.rawurlencode($format).
             ((null !== $reference) ? ('/'.rawurlencode($reference)) : ''));
     }
 

--- a/lib/Github/Api/Repository/DeployKeys.php
+++ b/lib/Github/Api/Repository/DeployKeys.php
@@ -13,12 +13,12 @@ class DeployKeys extends AbstractApi
 {
     public function all($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys');
     }
 
     public function show($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys/'.rawurlencode($id));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys/'.rawurlencode($id));
     }
 
     public function create($username, $repository, array $params)
@@ -27,7 +27,7 @@ class DeployKeys extends AbstractApi
             throw new MissingArgumentException(array('title', 'key'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys', $params);
     }
 
     public function update($username, $repository, $id, array $params)
@@ -36,11 +36,11 @@ class DeployKeys extends AbstractApi
             throw new MissingArgumentException(array('title', 'key'));
         }
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys/'.rawurlencode($id), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys/'.rawurlencode($id), $params);
     }
 
     public function remove($username, $repository, $id)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys/'.rawurlencode($id));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys/'.rawurlencode($id));
     }
 }

--- a/lib/Github/Api/Repository/Downloads.php
+++ b/lib/Github/Api/Repository/Downloads.php
@@ -22,7 +22,7 @@ class Downloads extends AbstractApi
      */
     public function all($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/downloads');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/downloads');
     }
 
     /**
@@ -38,7 +38,7 @@ class Downloads extends AbstractApi
      */
     public function show($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/downloads/'.rawurlencode($id));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/downloads/'.rawurlencode($id));
     }
 
     /**
@@ -54,6 +54,6 @@ class Downloads extends AbstractApi
      */
     public function remove($username, $repository, $id)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/downloads/'.rawurlencode($id));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/downloads/'.rawurlencode($id));
     }
 }

--- a/lib/Github/Api/Repository/Forks.php
+++ b/lib/Github/Api/Repository/Forks.php
@@ -16,11 +16,11 @@ class Forks extends AbstractApi
             $params['sort'] = 'newest';
         }
 
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/forks', array_merge(array('page' => 1), $params));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/forks', array_merge(array('page' => 1), $params));
     }
 
     public function create($username, $repository, array $params = array())
     {
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/forks', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/forks', $params);
     }
 }

--- a/lib/Github/Api/Repository/Hooks.php
+++ b/lib/Github/Api/Repository/Hooks.php
@@ -13,12 +13,12 @@ class Hooks extends AbstractApi
 {
     public function all($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks');
     }
 
     public function show($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id));
     }
 
     public function create($username, $repository, array $params)
@@ -27,7 +27,7 @@ class Hooks extends AbstractApi
             throw new MissingArgumentException(array('name', 'config'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks', $params);
     }
 
     public function update($username, $repository, $id, array $params)
@@ -36,21 +36,21 @@ class Hooks extends AbstractApi
             throw new MissingArgumentException(array('name', 'config'));
         }
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id), $params);
     }
 
     public function ping($username, $repository, $id)
     {
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id).'/pings');
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id).'/pings');
     }
 
     public function test($username, $repository, $id)
     {
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id).'/test');
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id).'/test');
     }
 
     public function remove($username, $repository, $id)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id));
     }
 }

--- a/lib/Github/Api/Repository/Labels.php
+++ b/lib/Github/Api/Repository/Labels.php
@@ -13,12 +13,12 @@ class Labels extends AbstractApi
 {
     public function all($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels');
     }
 
     public function show($username, $repository, $label)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label));
     }
 
     public function create($username, $repository, array $params)
@@ -27,7 +27,7 @@ class Labels extends AbstractApi
             throw new MissingArgumentException(array('name', 'color'));
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels', $params);
     }
 
     public function update($username, $repository, $label, array $params)
@@ -36,11 +36,11 @@ class Labels extends AbstractApi
             throw new MissingArgumentException(array('name', 'color'));
         }
 
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label), $params);
     }
 
     public function remove($username, $repository, $label)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label));
     }
 }

--- a/lib/Github/Api/Repository/Releases.php
+++ b/lib/Github/Api/Repository/Releases.php
@@ -22,7 +22,7 @@ class Releases extends AbstractApi
      */
     public function latest($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/latest');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/latest');
     }
 
     /**
@@ -36,7 +36,7 @@ class Releases extends AbstractApi
      */
     public function tag($username, $repository, $tag)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/tags/'.rawurlencode($tag));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/tags/'.rawurlencode($tag));
     }
 
     /**
@@ -50,7 +50,7 @@ class Releases extends AbstractApi
      */
     public function all($username, $repository, array $params = [])
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases', $params);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases', $params);
     }
 
     /**
@@ -64,7 +64,7 @@ class Releases extends AbstractApi
      */
     public function show($username, $repository, $id)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/'.rawurlencode($id));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/'.rawurlencode($id));
     }
 
     /**
@@ -84,7 +84,7 @@ class Releases extends AbstractApi
             throw new MissingArgumentException('tag_name');
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases', $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases', $params);
     }
 
     /**
@@ -99,7 +99,7 @@ class Releases extends AbstractApi
      */
     public function edit($username, $repository, $id, array $params)
     {
-        return $this->patch('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/'.rawurlencode($id), $params);
+        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/'.rawurlencode($id), $params);
     }
 
     /**
@@ -113,7 +113,7 @@ class Releases extends AbstractApi
      */
     public function remove($username, $repository, $id)
     {
-        return $this->delete('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/'.rawurlencode($id));
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/'.rawurlencode($id));
     }
 
     /**

--- a/lib/Github/Api/Repository/Stargazers.php
+++ b/lib/Github/Api/Repository/Stargazers.php
@@ -30,6 +30,6 @@ class Stargazers extends AbstractApi
 
     public function all($username, $repository)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/stargazers');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/stargazers');
     }
 }

--- a/lib/Github/Api/Repository/Statuses.php
+++ b/lib/Github/Api/Repository/Statuses.php
@@ -22,7 +22,7 @@ class Statuses extends AbstractApi
      */
     public function show($username, $repository, $sha)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/statuses');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/statuses');
     }
 
     /**
@@ -36,7 +36,7 @@ class Statuses extends AbstractApi
      */
     public function combined($username, $repository, $sha)
     {
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/status');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/status');
     }
 
     /**
@@ -57,6 +57,6 @@ class Statuses extends AbstractApi
             throw new MissingArgumentException('state');
         }
 
-        return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/statuses/'.rawurlencode($sha), $params);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/statuses/'.rawurlencode($sha), $params);
     }
 }

--- a/lib/Github/Api/Search.php
+++ b/lib/Github/Api/Search.php
@@ -23,7 +23,7 @@ class Search extends AbstractApi
      */
     public function repositories($q, $sort = 'updated', $order = 'desc')
     {
-        return $this->get('search/repositories', array('q' => $q, 'sort' => $sort, 'order' => $order));
+        return $this->get('/search/repositories', array('q' => $q, 'sort' => $sort, 'order' => $order));
     }
 
     /**
@@ -39,7 +39,7 @@ class Search extends AbstractApi
      */
     public function issues($q, $sort = 'updated', $order = 'desc')
     {
-        return $this->get('search/issues', array('q' => $q, 'sort' => $sort, 'order' => $order));
+        return $this->get('/search/issues', array('q' => $q, 'sort' => $sort, 'order' => $order));
     }
 
     /**
@@ -55,7 +55,7 @@ class Search extends AbstractApi
      */
     public function code($q, $sort = 'updated', $order = 'desc')
     {
-        return $this->get('search/code', array('q' => $q, 'sort' => $sort, 'order' => $order));
+        return $this->get('/search/code', array('q' => $q, 'sort' => $sort, 'order' => $order));
     }
 
     /**
@@ -71,6 +71,6 @@ class Search extends AbstractApi
      */
     public function users($q, $sort = 'updated', $order = 'desc')
     {
-        return $this->get('search/users', array('q' => $q, 'sort' => $sort, 'order' => $order));
+        return $this->get('/search/users', array('q' => $q, 'sort' => $sort, 'order' => $order));
     }
 }

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -22,7 +22,7 @@ class User extends AbstractApi
      */
     public function find($keyword)
     {
-        return $this->get('legacy/user/search/'.rawurlencode($keyword));
+        return $this->get('/legacy/user/search/'.rawurlencode($keyword));
     }
 
     /**
@@ -37,10 +37,10 @@ class User extends AbstractApi
     public function all($id = null)
     {
         if (!is_int($id)) {
-            return $this->get('users');
+            return $this->get('/users');
         }
 
-        return $this->get('users?since=' . rawurldecode($id));
+        return $this->get('/users?since=' . rawurldecode($id));
     }
 
     /**
@@ -54,7 +54,7 @@ class User extends AbstractApi
      */
     public function show($username)
     {
-        return $this->get('users/'.rawurlencode($username));
+        return $this->get('/users/'.rawurlencode($username));
     }
 
     /**
@@ -68,7 +68,7 @@ class User extends AbstractApi
      */
     public function organizations($username)
     {
-        return $this->get('users/'.rawurlencode($username).'/orgs');
+        return $this->get('/users/'.rawurlencode($username).'/orgs');
     }
 
     /**
@@ -82,7 +82,7 @@ class User extends AbstractApi
      */
     public function following($username)
     {
-        return $this->get('users/'.rawurlencode($username).'/following');
+        return $this->get('/users/'.rawurlencode($username).'/following');
     }
 
     /**
@@ -96,7 +96,7 @@ class User extends AbstractApi
      */
     public function followers($username)
     {
-        return $this->get('users/'.rawurlencode($username).'/followers');
+        return $this->get('/users/'.rawurlencode($username).'/followers');
     }
 
     /**
@@ -110,7 +110,7 @@ class User extends AbstractApi
      */
     public function watched($username)
     {
-        return $this->get('users/'.rawurlencode($username).'/watched');
+        return $this->get('/users/'.rawurlencode($username).'/watched');
     }
 
     /**
@@ -125,7 +125,7 @@ class User extends AbstractApi
      */
     public function starred($username, $page = 1)
     {
-        return $this->get('users/'.rawurlencode($username).'/starred', array(
+        return $this->get('/users/'.rawurlencode($username).'/starred', array(
             'page' => $page
         ));
     }
@@ -141,7 +141,7 @@ class User extends AbstractApi
      */
     public function subscriptions($username)
     {
-        return $this->get('users/'.rawurlencode($username).'/subscriptions');
+        return $this->get('/users/'.rawurlencode($username).'/subscriptions');
     }
 
     /**
@@ -158,7 +158,7 @@ class User extends AbstractApi
      */
     public function repositories($username, $type = 'owner', $sort = 'full_name', $direction = 'asc')
     {
-        return $this->get('users/'.rawurlencode($username).'/repos', array(
+        return $this->get('/users/'.rawurlencode($username).'/repos', array(
             'type' => $type,
             'sort' => $sort,
             'direction' => $direction
@@ -176,7 +176,7 @@ class User extends AbstractApi
      */
     public function gists($username)
     {
-        return $this->get('users/'.rawurlencode($username).'/gists');
+        return $this->get('/users/'.rawurlencode($username).'/gists');
     }
 
     /**
@@ -190,7 +190,7 @@ class User extends AbstractApi
      */
     public function keys($username)
     {
-        return $this->get('users/'.rawurlencode($username).'/keys');
+        return $this->get('/users/'.rawurlencode($username).'/keys');
     }
 
     /**
@@ -204,6 +204,6 @@ class User extends AbstractApi
      */
     public function publicEvents($username)
     {
-        return $this->get('users/'.rawurlencode($username) . '/events/public');
+        return $this->get('/users/'.rawurlencode($username) . '/events/public');
     }
 }

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -154,7 +154,7 @@ class Client
         $this->addPlugin(new GithubExceptionThrower());
         $this->addPlugin(new Plugin\HistoryPlugin($this->responseHistory));
         $this->addPlugin(new Plugin\RedirectPlugin());
-        $this->addPlugin(new Plugin\AddHostPlugin(UriFactoryDiscovery::find()->createUri('https://api.github.com/')));
+        $this->addPlugin(new Plugin\AddHostPlugin(UriFactoryDiscovery::find()->createUri('https://api.github.com')));
         $this->addPlugin(new Plugin\HeaderDefaultsPlugin(array(
             'User-Agent'  => 'php-github-api (http://github.com/KnpLabs/php-github-api)',
         )));

--- a/test/Github/Tests/Api/AuthorizationsTest.php
+++ b/test/Github/Tests/Api/AuthorizationsTest.php
@@ -14,7 +14,7 @@ class AuthorizationsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('authorizations')
+            ->with('/authorizations')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all());
@@ -31,7 +31,7 @@ class AuthorizationsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('authorizations/'.$id)
+            ->with('/authorizations/'.$id)
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->show($id));
@@ -49,7 +49,7 @@ class AuthorizationsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('authorizations', $input);
+            ->with('/authorizations', $input);
 
         $api->create($input);
     }
@@ -67,7 +67,7 @@ class AuthorizationsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('authorizations/'.$id, $input);
+            ->with('/authorizations/'.$id, $input);
 
         $api->update($id, $input);
     }
@@ -81,7 +81,7 @@ class AuthorizationsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('authorizations/'.$id);
+            ->with('/authorizations/'.$id);
 
         $api->remove($id);
     }
@@ -98,7 +98,7 @@ class AuthorizationsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('applications/'.$id.'/tokens/'.$token)
+            ->with('/applications/'.$id.'/tokens/'.$token)
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->check($id, $token));
@@ -115,7 +115,7 @@ class AuthorizationsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('applications/'.$id.'/tokens/'.$token);
+            ->with('/applications/'.$id.'/tokens/'.$token);
 
         $api->reset($id, $token);
     }
@@ -131,7 +131,7 @@ class AuthorizationsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('applications/'.$id.'/tokens/'.$token);
+            ->with('/applications/'.$id.'/tokens/'.$token);
 
         $api->revoke($id, $token);
     }
@@ -146,7 +146,7 @@ class AuthorizationsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('applications/'.$id.'/tokens');
+            ->with('/applications/'.$id.'/tokens');
 
         $api->revokeAll($id);
     }

--- a/test/Github/Tests/Api/CurrentUser/DeployKeysTest.php
+++ b/test/Github/Tests/Api/CurrentUser/DeployKeysTest.php
@@ -14,7 +14,7 @@ class DeployKeysTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/keys/12')
+            ->with('/user/keys/12')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show(12));
@@ -30,7 +30,7 @@ class DeployKeysTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/keys')
+            ->with('/user/keys')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all());
@@ -47,7 +47,7 @@ class DeployKeysTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('user/keys', $data)
+            ->with('/user/keys', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create($data));
@@ -94,7 +94,7 @@ class DeployKeysTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('user/keys/123', $data)
+            ->with('/user/keys/123', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update(123, $data));
@@ -140,7 +140,7 @@ class DeployKeysTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('user/keys/123')
+            ->with('/user/keys/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove(123));

--- a/test/Github/Tests/Api/CurrentUser/EmailsTest.php
+++ b/test/Github/Tests/Api/CurrentUser/EmailsTest.php
@@ -14,7 +14,7 @@ class EmailsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/emails')
+            ->with('/user/emails')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all());
@@ -30,7 +30,7 @@ class EmailsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('user/emails', array('email@example.com'))
+            ->with('/user/emails', array('email@example.com'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('email@example.com'));
@@ -46,7 +46,7 @@ class EmailsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('user/emails', array('email@example.com', 'email2@example.com'))
+            ->with('/user/emails', array('email@example.com', 'email2@example.com'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove(array('email@example.com', 'email2@example.com')));
@@ -75,7 +75,7 @@ class EmailsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('user/emails', array('email@example.com'))
+            ->with('/user/emails', array('email@example.com'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->add('email@example.com'));
@@ -91,7 +91,7 @@ class EmailsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('user/emails', array('email@example.com', 'email2@example.com'))
+            ->with('/user/emails', array('email@example.com', 'email2@example.com'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->add(array('email@example.com', 'email2@example.com')));

--- a/test/Github/Tests/Api/CurrentUser/FollowersTest.php
+++ b/test/Github/Tests/Api/CurrentUser/FollowersTest.php
@@ -17,7 +17,7 @@ class FollowersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/following')
+            ->with('/user/following')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all());
@@ -31,7 +31,7 @@ class FollowersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/following/l3l0')
+            ->with('/user/following/l3l0')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->check('l3l0'));
@@ -45,7 +45,7 @@ class FollowersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('user/following/l3l0')
+            ->with('/user/following/l3l0')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->follow('l3l0'));
@@ -59,7 +59,7 @@ class FollowersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('user/following/l3l0')
+            ->with('/user/following/l3l0')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->unfollow('l3l0'));

--- a/test/Github/Tests/Api/CurrentUser/MembershipsTest.php
+++ b/test/Github/Tests/Api/CurrentUser/MembershipsTest.php
@@ -35,7 +35,7 @@ class MembershipsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/memberships/orgs')
+            ->with('/user/memberships/orgs')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all());
@@ -60,7 +60,7 @@ class MembershipsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/memberships/orgs/invitocat')
+            ->with('/user/memberships/orgs/invitocat')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->organization('invitocat'));
@@ -78,7 +78,7 @@ class MembershipsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('user/memberships/orgs/invitocat')
+            ->with('/user/memberships/orgs/invitocat')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->edit('invitocat'));

--- a/test/Github/Tests/Api/CurrentUser/StarringTest.php
+++ b/test/Github/Tests/Api/CurrentUser/StarringTest.php
@@ -17,7 +17,7 @@ class StarringTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/starred')
+            ->with('/user/starred')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all());
@@ -31,7 +31,7 @@ class StarringTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/starred/l3l0/test')
+            ->with('/user/starred/l3l0/test')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->check('l3l0', 'test'));
@@ -45,7 +45,7 @@ class StarringTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('user/starred/l3l0/test')
+            ->with('/user/starred/l3l0/test')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->star('l3l0', 'test'));
@@ -59,7 +59,7 @@ class StarringTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('user/starred/l3l0/test')
+            ->with('/user/starred/l3l0/test')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->unstar('l3l0', 'test'));

--- a/test/Github/Tests/Api/CurrentUser/WatchersTest.php
+++ b/test/Github/Tests/Api/CurrentUser/WatchersTest.php
@@ -17,7 +17,7 @@ class WatchersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/subscriptions')
+            ->with('/user/subscriptions')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all());
@@ -31,7 +31,7 @@ class WatchersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/subscriptions/l3l0/test')
+            ->with('/user/subscriptions/l3l0/test')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->check('l3l0', 'test'));
@@ -45,7 +45,7 @@ class WatchersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('user/subscriptions/l3l0/test')
+            ->with('/user/subscriptions/l3l0/test')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->watch('l3l0', 'test'));
@@ -59,7 +59,7 @@ class WatchersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('user/subscriptions/l3l0/test')
+            ->with('/user/subscriptions/l3l0/test')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->unwatch('l3l0', 'test'));

--- a/test/Github/Tests/Api/CurrentUserTest.php
+++ b/test/Github/Tests/Api/CurrentUserTest.php
@@ -14,7 +14,7 @@ class CurrentUserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user')
+            ->with('/user')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->show());
@@ -30,7 +30,7 @@ class CurrentUserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('user', array('value' => 'toChange'))
+            ->with('/user', array('value' => 'toChange'))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->update(array('value' => 'toChange')));
@@ -46,7 +46,7 @@ class CurrentUserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/followers', array('page' => 1))
+            ->with('/user/followers', array('page' => 1))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->followers(1));
@@ -62,7 +62,7 @@ class CurrentUserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('issues', array('page' => 1, 'some' => 'param'))
+            ->with('/issues', array('page' => 1, 'some' => 'param'))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->issues(array('some' => 'param')));
@@ -78,7 +78,7 @@ class CurrentUserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('user/watched', array('page' => 1))
+            ->with('/user/watched', array('page' => 1))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->watched(1));

--- a/test/Github/Tests/Api/DeploymentTest.php
+++ b/test/Github/Tests/Api/DeploymentTest.php
@@ -13,7 +13,7 @@ class DeploymentTest extends TestCase
         $deploymentData = array('ref' => 'fd6a5f9e5a430dddae8d6a8ea378f913d3a766f9');
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/deployments', $deploymentData);
+            ->with('/repos/KnpLabs/php-github-api/deployments', $deploymentData);
 
         $api->create('KnpLabs', 'php-github-api', $deploymentData);
     }
@@ -26,7 +26,7 @@ class DeploymentTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/deployments');
+            ->with('/repos/KnpLabs/php-github-api/deployments');
 
         $api->all('KnpLabs', 'php-github-api');
     }
@@ -41,7 +41,7 @@ class DeploymentTest extends TestCase
 
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/deployments', $filterData);
+            ->with('/repos/KnpLabs/php-github-api/deployments', $filterData);
 
         $api->all('KnpLabs', 'php-github-api', $filterData);
     }
@@ -56,7 +56,7 @@ class DeploymentTest extends TestCase
 
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/deployments/1/statuses', $statusData);
+            ->with('/repos/KnpLabs/php-github-api/deployments/1/statuses', $statusData);
 
         $api->updateStatus('KnpLabs', 'php-github-api', 1, $statusData);
     }
@@ -81,7 +81,7 @@ class DeploymentTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/deployments/1/statuses');
+            ->with('/repos/KnpLabs/php-github-api/deployments/1/statuses');
 
         $api->getStatuses('KnpLabs', 'php-github-api', 1);
     }

--- a/test/Github/Tests/Api/Enterprise/LicenseTest.php
+++ b/test/Github/Tests/Api/Enterprise/LicenseTest.php
@@ -23,7 +23,7 @@ class LicenseTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('enterprise/settings/license')
+            ->with('/enterprise/settings/license')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->show());

--- a/test/Github/Tests/Api/Enterprise/StatsTest.php
+++ b/test/Github/Tests/Api/Enterprise/StatsTest.php
@@ -16,7 +16,7 @@ class StatsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('enterprise/stats/all')
+            ->with('/enterprise/stats/all')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->show('all'));
@@ -33,7 +33,7 @@ class StatsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with(sprintf('enterprise/stats/%s', $type))
+            ->with(sprintf('/enterprise/stats/%s', $type))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, call_user_func(array($api, $type)));

--- a/test/Github/Tests/Api/Enterprise/UserAdminTest.php
+++ b/test/Github/Tests/Api/Enterprise/UserAdminTest.php
@@ -15,7 +15,7 @@ class UserAdminTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('users/l3l0/suspended')
+            ->with('/users/l3l0/suspended')
             ->will($this->returnValue($expectedArray));
         $this->assertEquals($expectedArray, $api->suspend('l3l0'));
     }
@@ -30,7 +30,7 @@ class UserAdminTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('users/l3l0/suspended')
+            ->with('/users/l3l0/suspended')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->unsuspend('l3l0'));

--- a/test/Github/Tests/Api/Gist/CommentsTest.php
+++ b/test/Github/Tests/Api/Gist/CommentsTest.php
@@ -16,7 +16,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('gists/123/comments')
+            ->with('/gists/123/comments')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('123'));
@@ -32,7 +32,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('gists/123/comments/123')
+            ->with('/gists/123/comments/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show(123, 123));
@@ -48,7 +48,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('gists/123/comments', array('body' => 'Test body'))
+            ->with('/gists/123/comments', array('body' => 'Test body'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('123', 'Test body'));
@@ -65,7 +65,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('gists/123/comments/233', $data)
+            ->with('/gists/123/comments/233', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update(123, 233, 'body test'));
@@ -81,7 +81,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('gists/123/comments/233')
+            ->with('/gists/123/comments/233')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove(123, 233));

--- a/test/Github/Tests/Api/GistsTest.php
+++ b/test/Github/Tests/Api/GistsTest.php
@@ -14,7 +14,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('gists/starred')
+            ->with('/gists/starred')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all('starred'));
@@ -30,7 +30,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('gists')
+            ->with('/gists')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all());
@@ -46,7 +46,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('gists/123')
+            ->with('/gists/123')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->show(123));
@@ -62,7 +62,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('gists/123/commits')
+            ->with('/gists/123/commits')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->commits(123));
@@ -88,7 +88,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('gists/123/fork')
+            ->with('/gists/123/fork')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->fork(123));
@@ -104,7 +104,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('gists/123/forks')
+            ->with('/gists/123/forks')
             ->will($this->returnValue($expectedArray));
 
         $api->forks(123);
@@ -138,7 +138,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('gists/123/star')
+            ->with('/gists/123/star')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->check(123));
@@ -154,7 +154,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('gists/123/star')
+            ->with('/gists/123/star')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->star(123));
@@ -170,7 +170,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('gists/123/star')
+            ->with('/gists/123/star')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->unstar(123));
@@ -194,7 +194,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('gists', $input);
+            ->with('/gists', $input);
 
         $api->create($input);
     }
@@ -220,7 +220,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('gists/5', $input);
+            ->with('/gists/5', $input);
 
         $api->update(5, $input);
     }
@@ -233,7 +233,7 @@ class GistsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('gists/5');
+            ->with('/gists/5');
 
         $api->remove(5);
     }

--- a/test/Github/Tests/Api/GitData/BlobsTest.php
+++ b/test/Github/Tests/Api/GitData/BlobsTest.php
@@ -14,7 +14,7 @@ class BlobsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/l3l0/l3l0repo/git/blobs/123456sha')
+            ->with('/repos/l3l0/l3l0repo/git/blobs/123456sha')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('l3l0', 'l3l0repo', '123456sha'));
@@ -40,7 +40,7 @@ class BlobsTest extends TestCase
             ->with('raw');
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/l3l0/l3l0repo/git/blobs/123456sha')
+            ->with('/repos/l3l0/l3l0repo/git/blobs/123456sha')
             ->will($this->returnValue($expectedValue));
 
         $api->configure('raw');
@@ -59,7 +59,7 @@ class BlobsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/l3l0/l3l0repo/git/blobs', $data)
+            ->with('/repos/l3l0/l3l0repo/git/blobs', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('l3l0', 'l3l0repo', $data));

--- a/test/Github/Tests/Api/GitData/CommitsTest.php
+++ b/test/Github/Tests/Api/GitData/CommitsTest.php
@@ -14,7 +14,7 @@ class CommitsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/git/commits/123')
+            ->with('/repos/KnpLabs/php-github-api/git/commits/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
@@ -31,7 +31,7 @@ class CommitsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/git/commits', $data)
+            ->with('/repos/KnpLabs/php-github-api/git/commits', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));

--- a/test/Github/Tests/Api/GitData/ReferencesTest.php
+++ b/test/Github/Tests/Api/GitData/ReferencesTest.php
@@ -14,7 +14,7 @@ class ReferencesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/l3l0/l3l0repo/git/refs/master/some%2A%26%40%23branch/dasd1212')
+            ->with('/repos/l3l0/l3l0repo/git/refs/master/some%2A%26%40%23branch/dasd1212')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('l3l0', 'l3l0repo', 'master/some*&@#branch/dasd1212'));
@@ -30,7 +30,7 @@ class ReferencesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/l3l0/l3l0repo/git/refs/123456sha')
+            ->with('/repos/l3l0/l3l0repo/git/refs/123456sha')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('l3l0', 'l3l0repo', '123456sha'));
@@ -46,7 +46,7 @@ class ReferencesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/l3l0/l3l0repo/git/refs/123456sha')
+            ->with('/repos/l3l0/l3l0repo/git/refs/123456sha')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('l3l0', 'l3l0repo', '123456sha'));
@@ -62,7 +62,7 @@ class ReferencesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/l3l0/l3l0repo/git/refs')
+            ->with('/repos/l3l0/l3l0repo/git/refs')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('l3l0', 'l3l0repo'));
@@ -78,7 +78,7 @@ class ReferencesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/l3l0/l3l0repo/git/refs/heads')
+            ->with('/repos/l3l0/l3l0repo/git/refs/heads')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->branches('l3l0', 'l3l0repo'));
@@ -94,7 +94,7 @@ class ReferencesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/l3l0/l3l0repo/git/refs/tags')
+            ->with('/repos/l3l0/l3l0repo/git/refs/tags')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->tags('l3l0', 'l3l0repo'));
@@ -111,7 +111,7 @@ class ReferencesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/l3l0/l3l0repo/git/refs', $data)
+            ->with('/repos/l3l0/l3l0repo/git/refs', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('l3l0', 'l3l0repo', $data));
@@ -158,7 +158,7 @@ class ReferencesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/l3l0/l3l0repo/git/refs/someRefs', $data)
+            ->with('/repos/l3l0/l3l0repo/git/refs/someRefs', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('l3l0', 'l3l0repo', 'someRefs', $data));

--- a/test/Github/Tests/Api/GitData/TagsTest.php
+++ b/test/Github/Tests/Api/GitData/TagsTest.php
@@ -14,7 +14,7 @@ class TagsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/git/tags/123')
+            ->with('/repos/KnpLabs/php-github-api/git/tags/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
@@ -30,7 +30,7 @@ class TagsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/git/refs/tags')
+            ->with('/repos/KnpLabs/php-github-api/git/refs/tags')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -57,7 +57,7 @@ class TagsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/git/tags', $data)
+            ->with('/repos/KnpLabs/php-github-api/git/tags', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));

--- a/test/Github/Tests/Api/GitData/TreesTest.php
+++ b/test/Github/Tests/Api/GitData/TreesTest.php
@@ -14,7 +14,7 @@ class TreesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/git/trees/123', array())
+            ->with('/repos/KnpLabs/php-github-api/git/trees/123', array())
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
@@ -46,7 +46,7 @@ class TreesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/git/trees', $data)
+            ->with('/repos/KnpLabs/php-github-api/git/trees', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
@@ -78,7 +78,7 @@ class TreesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/git/trees', $data)
+            ->with('/repos/KnpLabs/php-github-api/git/trees', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));

--- a/test/Github/Tests/Api/Issue/CommentsTest.php
+++ b/test/Github/Tests/Api/Issue/CommentsTest.php
@@ -16,7 +16,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/issues/123/comments', array('page' => 1))
+            ->with('/repos/KnpLabs/php-github-api/issues/123/comments', array('page' => 1))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', 123));
@@ -32,7 +32,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/issues/comments/123')
+            ->with('/repos/KnpLabs/php-github-api/issues/comments/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
@@ -64,7 +64,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/issues/123/comments', $data)
+            ->with('/repos/KnpLabs/php-github-api/issues/123/comments', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', '123', $data));
@@ -96,7 +96,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/issues/comments/233', $data)
+            ->with('/repos/KnpLabs/php-github-api/issues/comments/233', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', '233', $data));
@@ -112,7 +112,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/issues/comments/123')
+            ->with('/repos/KnpLabs/php-github-api/issues/comments/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123));

--- a/test/Github/Tests/Api/Issue/EventsTest.php
+++ b/test/Github/Tests/Api/Issue/EventsTest.php
@@ -16,7 +16,7 @@ class EventsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/issues/events', array('page' => 1))
+            ->with('/repos/KnpLabs/php-github-api/issues/events', array('page' => 1))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -32,7 +32,7 @@ class EventsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/issues/123/events', array('page' => 1))
+            ->with('/repos/KnpLabs/php-github-api/issues/123/events', array('page' => 1))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', 123));
@@ -48,7 +48,7 @@ class EventsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/issues/events/123')
+            ->with('/repos/KnpLabs/php-github-api/issues/events/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));

--- a/test/Github/Tests/Api/Issue/LabelsTest.php
+++ b/test/Github/Tests/Api/Issue/LabelsTest.php
@@ -19,7 +19,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/labels', array())
+            ->with('/repos/KnpLabs/php-github-api/labels', array())
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -35,7 +35,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/issues/123/labels')
+            ->with('/repos/KnpLabs/php-github-api/issues/123/labels')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', '123'));
@@ -52,7 +52,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/labels', $data + array('color' => 'FFFFFF'))
+            ->with('/repos/KnpLabs/php-github-api/labels', $data + array('color' => 'FFFFFF'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
@@ -69,7 +69,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/labels', $data)
+            ->with('/repos/KnpLabs/php-github-api/labels', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
@@ -85,7 +85,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/labels/foo')
+            ->with('/repos/KnpLabs/php-github-api/labels/foo')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->deleteLabel('KnpLabs', 'php-github-api', 'foo'));
@@ -102,7 +102,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/labels/foo', $data)
+            ->with('/repos/KnpLabs/php-github-api/labels/foo', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 'foo', 'bar', 'FFF'));
@@ -118,7 +118,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/issues/123/labels/somename')
+            ->with('/repos/KnpLabs/php-github-api/issues/123/labels/somename')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123, 'somename'));
@@ -134,7 +134,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/issues/123/labels', array('labelname'))
+            ->with('/repos/KnpLabs/php-github-api/issues/123/labels', array('labelname'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->add('KnpLabs', 'php-github-api', 123, 'labelname'));
@@ -150,7 +150,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/issues/123/labels', array('labelname', 'labelname2'))
+            ->with('/repos/KnpLabs/php-github-api/issues/123/labels', array('labelname', 'labelname2'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->add('KnpLabs', 'php-github-api', 123, array('labelname', 'labelname2')));
@@ -167,7 +167,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('repos/KnpLabs/php-github-api/issues/123/labels', $data)
+            ->with('/repos/KnpLabs/php-github-api/issues/123/labels', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->replace('KnpLabs', 'php-github-api', 123, $data));
@@ -196,7 +196,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/issues/123/labels')
+            ->with('/repos/KnpLabs/php-github-api/issues/123/labels')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->clear('KnpLabs', 'php-github-api', 123));

--- a/test/Github/Tests/Api/Issue/MilestonesTest.php
+++ b/test/Github/Tests/Api/Issue/MilestonesTest.php
@@ -16,7 +16,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
+            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -33,7 +33,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/milestones', $data)
+            ->with('/repos/KnpLabs/php-github-api/milestones', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
@@ -65,7 +65,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/milestones', array('state' => 'open', 'title' => 'milestone'))
+            ->with('/repos/KnpLabs/php-github-api/milestones', array('state' => 'open', 'title' => 'milestone'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', array('state' => 'clos', 'title' => 'milestone')));
@@ -82,7 +82,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/milestones/123', array('title' => 'milestone'))
+            ->with('/repos/KnpLabs/php-github-api/milestones/123', array('title' => 'milestone'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 123, $data));
@@ -99,7 +99,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/milestones/123', $data)
+            ->with('/repos/KnpLabs/php-github-api/milestones/123', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 123, $data));
@@ -116,7 +116,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/milestones/123', array('state' => 'open', 'title' => 'milestone'))
+            ->with('/repos/KnpLabs/php-github-api/milestones/123', array('state' => 'open', 'title' => 'milestone'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 123, $data));
@@ -132,7 +132,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
+            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', array('sort' => 'completenes')));
@@ -148,7 +148,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
+            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', array('state' => 'clos')));
@@ -164,7 +164,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
+            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', array('direction' => 'des')));
@@ -180,7 +180,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/milestones/123')
+            ->with('/repos/KnpLabs/php-github-api/milestones/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123));
@@ -196,7 +196,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/milestones/123')
+            ->with('/repos/KnpLabs/php-github-api/milestones/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
@@ -212,7 +212,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/milestones/123/labels')
+            ->with('/repos/KnpLabs/php-github-api/milestones/123/labels')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->labels('KnpLabs', 'php-github-api', 123));

--- a/test/Github/Tests/Api/IssueTest.php
+++ b/test/Github/Tests/Api/IssueTest.php
@@ -19,7 +19,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/ornicar/php-github-api/issues', $sentData);
+            ->with('/repos/ornicar/php-github-api/issues', $sentData);
 
         $api->all('ornicar', 'php-github-api', $data);
     }
@@ -46,7 +46,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/ornicar/php-github-api/issues', $sentData)
+            ->with('/repos/ornicar/php-github-api/issues', $sentData)
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all('ornicar', 'php-github-api', $data));
@@ -62,7 +62,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/ornicar/php-github-api/issues/14')
+            ->with('/repos/ornicar/php-github-api/issues/14')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->show('ornicar', 'php-github-api', 14));
@@ -81,7 +81,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/ornicar/php-github-api/issues', $data);
+            ->with('/repos/ornicar/php-github-api/issues', $data);
 
         $api->create('ornicar', 'php-github-api', $data);
     }
@@ -132,7 +132,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/ornicar/php-github-api/issues/14', $data);
+            ->with('/repos/ornicar/php-github-api/issues/14', $data);
 
         $api->update('ornicar', 'php-github-api', 14, $data);
     }
@@ -149,7 +149,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/ornicar/php-github-api/issues/14', $data);
+            ->with('/repos/ornicar/php-github-api/issues/14', $data);
 
         $api->update('ornicar', 'php-github-api', 14, $data);
     }
@@ -164,7 +164,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/issues/search/KnpLabs/php-github-api/open/Invalid%20Commits')
+            ->with('/legacy/issues/search/KnpLabs/php-github-api/open/Invalid%20Commits')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->find('KnpLabs', 'php-github-api', 'open', 'Invalid Commits'));
@@ -180,7 +180,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/issues/search/KnpLabs/php-github-api/closed/Invalid%20Commits')
+            ->with('/legacy/issues/search/KnpLabs/php-github-api/closed/Invalid%20Commits')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->find('KnpLabs', 'php-github-api', 'closed', 'Invalid Commits'));
@@ -196,7 +196,7 @@ class IssueTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/issues/search/KnpLabs/php-github-api/open/Invalid%20Commits')
+            ->with('/legacy/issues/search/KnpLabs/php-github-api/open/Invalid%20Commits')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->find('KnpLabs', 'php-github-api', 'abc', 'Invalid Commits'));

--- a/test/Github/Tests/Api/MarkdownTest.php
+++ b/test/Github/Tests/Api/MarkdownTest.php
@@ -14,7 +14,7 @@ class MarkdownTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('markdown', array('text' => $input, 'mode' => 'markdown'));
+            ->with('/markdown', array('text' => $input, 'mode' => 'markdown'));
 
         $api->render($input);
     }
@@ -29,7 +29,7 @@ class MarkdownTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('markdown', array('text' => $input, 'mode' => 'gfm'));
+            ->with('/markdown', array('text' => $input, 'mode' => 'gfm'));
 
         $api->render($input, 'gfm');
     }
@@ -44,7 +44,7 @@ class MarkdownTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('markdown', array('text' => $input, 'mode' => 'markdown'));
+            ->with('/markdown', array('text' => $input, 'mode' => 'markdown'));
 
         $api->render($input, 'abc');
     }
@@ -59,12 +59,12 @@ class MarkdownTest extends TestCase
         $apiWithMarkdown = $this->getApiMock();
         $apiWithMarkdown->expects($this->once())
             ->method('post')
-            ->with('markdown', array('text' => $input, 'mode' => 'markdown'));
+            ->with('/markdown', array('text' => $input, 'mode' => 'markdown'));
 
         $apiWithGfm = $this->getApiMock();
         $apiWithGfm->expects($this->once())
             ->method('post')
-            ->with('markdown', array('text' => $input, 'mode' => 'gfm', 'context' => 'someContext'));
+            ->with('/markdown', array('text' => $input, 'mode' => 'gfm', 'context' => 'someContext'));
 
         $apiWithMarkdown->render($input, 'markdown', 'someContext');
         $apiWithGfm->render($input, 'gfm', 'someContext');
@@ -80,7 +80,7 @@ class MarkdownTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('markdown/raw', array('file' => $file));
+            ->with('/markdown/raw', array('file' => $file));
 
         $api->renderRaw($file);
     }

--- a/test/Github/Tests/Api/NotificationTest.php
+++ b/test/Github/Tests/Api/NotificationTest.php
@@ -19,7 +19,7 @@ class NotificationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('notifications', $parameters);
+            ->with('/notifications', $parameters);
 
         $api->all();
     }
@@ -40,7 +40,7 @@ class NotificationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('notifications', $parameters);
+            ->with('/notifications', $parameters);
 
         $api->all(false, false, $since);
     }
@@ -58,7 +58,7 @@ class NotificationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('notifications', $parameters);
+            ->with('/notifications', $parameters);
 
         $api->all(true, true);
     }
@@ -73,7 +73,7 @@ class NotificationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('notifications', $parameters);
+            ->with('/notifications', $parameters);
 
         $api->markRead();
     }
@@ -92,7 +92,7 @@ class NotificationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('notifications', $parameters);
+            ->with('/notifications', $parameters);
 
         $api->markRead($since);
     }

--- a/test/Github/Tests/Api/Organization/HooksTest.php
+++ b/test/Github/Tests/Api/Organization/HooksTest.php
@@ -16,7 +16,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('orgs/KnpLabs/hooks')
+            ->with('/orgs/KnpLabs/hooks')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs'));
@@ -32,7 +32,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('orgs/KnpLabs/hooks/123')
+            ->with('/orgs/KnpLabs/hooks/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 123));
@@ -48,7 +48,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('orgs/KnpLabs/hooks/123')
+            ->with('/orgs/KnpLabs/hooks/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 123));
@@ -95,7 +95,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('orgs/KnpLabs/hooks', $data)
+            ->with('/orgs/KnpLabs/hooks', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', $data));
@@ -127,7 +127,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('orgs/KnpLabs/hooks/123', $data)
+            ->with('/orgs/KnpLabs/hooks/123', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 123, $data));
@@ -143,7 +143,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('orgs/KnpLabs/hooks/123/pings')
+            ->with('/orgs/KnpLabs/hooks/123/pings')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->ping('KnpLabs', 123));

--- a/test/Github/Tests/Api/Organization/MembersTest.php
+++ b/test/Github/Tests/Api/Organization/MembersTest.php
@@ -16,7 +16,7 @@ class MembersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('orgs/KnpLabs/members')
+            ->with('/orgs/KnpLabs/members')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs'));
@@ -32,7 +32,7 @@ class MembersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('orgs/KnpLabs/public_members')
+            ->with('/orgs/KnpLabs/public_members')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', true));
@@ -48,7 +48,7 @@ class MembersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('orgs/KnpLabs/public_members/l3l0')
+            ->with('/orgs/KnpLabs/public_members/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->check('KnpLabs', 'l3l0'));
@@ -64,7 +64,7 @@ class MembersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('orgs/KnpLabs/memberships/l3l0')
+            ->with('/orgs/KnpLabs/memberships/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->add('KnpLabs', 'l3l0'));
@@ -80,7 +80,7 @@ class MembersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('orgs/KnpLabs/members/l3l0')
+            ->with('/orgs/KnpLabs/members/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'l3l0'));
@@ -96,7 +96,7 @@ class MembersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('orgs/KnpLabs/public_members/l3l0')
+            ->with('/orgs/KnpLabs/public_members/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->publicize('KnpLabs', 'l3l0'));
@@ -112,7 +112,7 @@ class MembersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('orgs/KnpLabs/public_members/l3l0')
+            ->with('/orgs/KnpLabs/public_members/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->conceal('KnpLabs', 'l3l0'));
@@ -128,7 +128,7 @@ class MembersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('orgs/KnpLabs/members/l3l0')
+            ->with('/orgs/KnpLabs/members/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'l3l0'));

--- a/test/Github/Tests/Api/Organization/TeamsTest.php
+++ b/test/Github/Tests/Api/Organization/TeamsTest.php
@@ -16,7 +16,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('orgs/KnpLabs/teams')
+            ->with('/orgs/KnpLabs/teams')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs'));
@@ -32,7 +32,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('teams/KnpWorld/memberships/l3l0')
+            ->with('/teams/KnpWorld/memberships/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->check('KnpWorld', 'l3l0'));
@@ -48,7 +48,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('teams/KnpWorld')
+            ->with('/teams/KnpWorld')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpWorld'));
@@ -64,7 +64,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('teams/KnpWorld')
+            ->with('/teams/KnpWorld')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpWorld'));
@@ -80,7 +80,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('teams/KnpWorld/members')
+            ->with('/teams/KnpWorld/members')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->members('KnpWorld'));
@@ -96,7 +96,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('teams/KnpWorld/memberships/l3l0')
+            ->with('/teams/KnpWorld/memberships/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->addMember('KnpWorld', 'l3l0'));
@@ -112,7 +112,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('teams/KnpWorld/memberships/l3l0')
+            ->with('/teams/KnpWorld/memberships/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->removeMember('KnpWorld', 'l3l0'));
@@ -128,7 +128,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('teams/KnpWorld/repos')
+            ->with('/teams/KnpWorld/repos')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->repositories('KnpWorld'));
@@ -144,7 +144,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('teams/KnpWorld/repos/l3l0/l3l0Repo')
+            ->with('/teams/KnpWorld/repos/l3l0/l3l0Repo')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->repository('KnpWorld', 'l3l0', 'l3l0Repo'));
@@ -160,7 +160,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('teams/KnpWorld/repos/l3l0/l3l0Repo')
+            ->with('/teams/KnpWorld/repos/l3l0/l3l0Repo')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->addRepository('KnpWorld', 'l3l0', 'l3l0Repo'));
@@ -176,7 +176,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('teams/KnpWorld/repos/l3l0/l3l0Repo')
+            ->with('/teams/KnpWorld/repos/l3l0/l3l0Repo')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->removeRepository('KnpWorld', 'l3l0', 'l3l0Repo'));
@@ -208,7 +208,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('orgs/KnpLabs/teams', $data)
+            ->with('/orgs/KnpLabs/teams', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', $data));
@@ -225,7 +225,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('orgs/KnpLabs/teams', array('name' => 'KnpWorld', 'repo_names' => array('somerepo')))
+            ->with('/orgs/KnpLabs/teams', array('name' => 'KnpWorld', 'repo_names' => array('somerepo')))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', $data));
@@ -242,7 +242,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('orgs/KnpLabs/teams', array('name' => 'KnpWorld', 'permission' => 'pull'))
+            ->with('/orgs/KnpLabs/teams', array('name' => 'KnpWorld', 'permission' => 'pull'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', $data));
@@ -274,7 +274,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('teams/KnpWorld', $data)
+            ->with('/teams/KnpWorld', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpWorld', $data));
@@ -291,7 +291,7 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('teams/KnpWorld', array('name' => 'KnpWorld', 'permission' => 'pull'))
+            ->with('/teams/KnpWorld', array('name' => 'KnpWorld', 'permission' => 'pull'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpWorld', $data));

--- a/test/Github/Tests/Api/OrganizationTest.php
+++ b/test/Github/Tests/Api/OrganizationTest.php
@@ -14,7 +14,7 @@ class OrganizationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('organizations?since=1')
+            ->with('/organizations?since=1')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all(1));
@@ -30,7 +30,7 @@ class OrganizationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('orgs/KnpLabs')
+            ->with('/orgs/KnpLabs')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->show('KnpLabs'));
@@ -46,7 +46,7 @@ class OrganizationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('orgs/KnpLabs', array('value' => 'toUpdate'))
+            ->with('/orgs/KnpLabs', array('value' => 'toUpdate'))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->update('KnpLabs', array('value' => 'toUpdate')));
@@ -62,7 +62,7 @@ class OrganizationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('orgs/KnpLabs/repos', array('type' => 'all'))
+            ->with('/orgs/KnpLabs/repos', array('type' => 'all'))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->repositories('KnpLabs'));

--- a/test/Github/Tests/Api/PullRequestTest.php
+++ b/test/Github/Tests/Api/PullRequestTest.php
@@ -14,7 +14,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/ezsystems/ezpublish/pulls')
+            ->with('/repos/ezsystems/ezpublish/pulls')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all('ezsystems', 'ezpublish'));
@@ -30,7 +30,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/ezsystems/ezpublish/pulls', array('state' => 'open', 'per_page' => 30, 'page' => 1))
+            ->with('/repos/ezsystems/ezpublish/pulls', array('state' => 'open', 'per_page' => 30, 'page' => 1))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all('ezsystems', 'ezpublish', array('state' => 'open')));
@@ -46,7 +46,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/ezsystems/ezpublish/pulls', array('state' => 'closed', 'per_page' => 30, 'page' => 1))
+            ->with('/repos/ezsystems/ezpublish/pulls', array('state' => 'closed', 'per_page' => 30, 'page' => 1))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all('ezsystems', 'ezpublish', array('state' => 'closed')));
@@ -63,7 +63,7 @@ class PullRequestTest extends TestCase
 
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/ezsystems/ezpublish/pulls/15')
+            ->with('/repos/ezsystems/ezpublish/pulls/15')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->show('ezsystems', 'ezpublish', '15'));
@@ -79,7 +79,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/ezsystems/ezpublish/pulls/15/commits')
+            ->with('/repos/ezsystems/ezpublish/pulls/15/commits')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->commits('ezsystems', 'ezpublish', '15'));
@@ -95,7 +95,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/ezsystems/ezpublish/pulls/15/files')
+            ->with('/repos/ezsystems/ezpublish/pulls/15/files')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->files('ezsystems', 'ezpublish', '15'));
@@ -111,7 +111,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/ezsystems/ezpublish/pulls/15', array('state' => 'open', 'some' => 'param'))
+            ->with('/repos/ezsystems/ezpublish/pulls/15', array('state' => 'open', 'some' => 'param'))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->update('ezsystems', 'ezpublish', 15, array('state' => 'aa', 'some' => 'param')));
@@ -127,7 +127,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/ezsystems/ezpublish/pulls/15/merge')
+            ->with('/repos/ezsystems/ezpublish/pulls/15/merge')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->merged('ezsystems', 'ezpublish', 15));
@@ -143,7 +143,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('repos/ezsystems/ezpublish/pulls/15/merge', array('commit_message' => 'Merged something', 'sha' => str_repeat('A', 40), 'squash' => false))
+            ->with('/repos/ezsystems/ezpublish/pulls/15/merge', array('commit_message' => 'Merged something', 'sha' => str_repeat('A', 40), 'squash' => false))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->merge('ezsystems', 'ezpublish', 15, 'Merged something', str_repeat('A', 40)));
@@ -164,7 +164,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/ezsystems/ezpublish/pulls', $data);
+            ->with('/repos/ezsystems/ezpublish/pulls', $data);
 
         $api->create('ezsystems', 'ezpublish', $data);
     }
@@ -183,7 +183,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/ezsystems/ezpublish/pulls', $data);
+            ->with('/repos/ezsystems/ezpublish/pulls', $data);
 
         $api->create('ezsystems', 'ezpublish', $data);
     }

--- a/test/Github/Tests/Api/RateLimitTest.php
+++ b/test/Github/Tests/Api/RateLimitTest.php
@@ -27,7 +27,7 @@ class RateLimitTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('rate_limit')
+            ->with('/rate_limit')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->getRateLimits());

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -14,7 +14,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api')
+            ->with('/repos/KnpLabs/php-github-api')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->show('KnpLabs', 'php-github-api'));
@@ -33,7 +33,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/repos/search/php', array('myparam' => 2, 'start_page' => 1))
+            ->with('/legacy/repos/search/php', array('myparam' => 2, 'start_page' => 1))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->find('php', array('myparam' => 2)));
@@ -52,7 +52,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/repos/search/php', array('start_page' => 2))
+            ->with('/legacy/repos/search/php', array('start_page' => 2))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->find('php', array('start_page' => 2)));
@@ -73,7 +73,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repositories')
+            ->with('/repositories')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all());
@@ -94,7 +94,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repositories?since=2')
+            ->with('/repositories?since=2')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all(2));
@@ -110,7 +110,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('user/repos', array(
+            ->with('/user/repos', array(
                 'name'          => 'l3l0Repo',
                 'description'   => '',
                 'homepage'      => '',
@@ -135,7 +135,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('orgs/KnpLabs/repos', array(
+            ->with('/orgs/KnpLabs/repos', array(
                 'name'          => 'KnpLabsRepo',
                 'description'   => '',
                 'homepage'      => '',
@@ -160,7 +160,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/subscribers', array('page' => 2))
+            ->with('/repos/KnpLabs/php-github-api/subscribers', array('page' => 2))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->subscribers('KnpLabs', 'php-github-api', 2));
@@ -176,7 +176,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/tags')
+            ->with('/repos/KnpLabs/php-github-api/tags')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->tags('KnpLabs', 'php-github-api'));
@@ -192,7 +192,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/branches')
+            ->with('/repos/KnpLabs/php-github-api/branches')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->branches('KnpLabs', 'php-github-api'));
@@ -208,7 +208,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/branches/master')
+            ->with('/repos/KnpLabs/php-github-api/branches/master')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->branches('KnpLabs', 'php-github-api', 'master'));
@@ -224,7 +224,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/languages')
+            ->with('/repos/KnpLabs/php-github-api/languages')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->languages('KnpLabs', 'php-github-api'));
@@ -240,7 +240,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/milestones')
+            ->with('/repos/KnpLabs/php-github-api/milestones')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->milestones('KnpLabs', 'php-github-api'));
@@ -256,7 +256,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/contributors', array('anon' => null))
+            ->with('/repos/KnpLabs/php-github-api/contributors', array('anon' => null))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->contributors('KnpLabs', 'php-github-api', false));
@@ -272,7 +272,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/contributors', array('anon' => true))
+            ->with('/repos/KnpLabs/php-github-api/contributors', array('anon' => true))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->contributors('KnpLabs', 'php-github-api', true));
@@ -288,7 +288,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/teams')
+            ->with('/repos/KnpLabs/php-github-api/teams')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->teams('KnpLabs', 'php-github-api'));
@@ -304,7 +304,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('user/repos', array(
+            ->with('/user/repos', array(
                 'name'          => 'l3l0Repo',
                 'description'   => 'test',
                 'homepage'      => 'http://l3l0.eu',
@@ -329,7 +329,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/l3l0Repo/test', array('description' => 'test', 'homepage' => 'http://l3l0.eu'))
+            ->with('/repos/l3l0Repo/test', array('description' => 'test', 'homepage' => 'http://l3l0.eu'))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->update('l3l0Repo', 'test', array('description' => 'test', 'homepage' => 'http://l3l0.eu')));
@@ -343,7 +343,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/l3l0Repo/test')
+            ->with('/repos/l3l0Repo/test')
             ->will($this->returnValue(null));
 
         $this->assertNull($api->remove('l3l0Repo', 'test'));
@@ -359,7 +359,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/l3l0Repo/uknown-repo')
+            ->with('/repos/l3l0Repo/uknown-repo')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->remove('l3l0Repo', 'uknown-repo'));
@@ -495,7 +495,7 @@ class RepoTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/stats/commit_activity')
+            ->with('/repos/KnpLabs/php-github-api/stats/commit_activity')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->activity('KnpLabs', 'php-github-api'));

--- a/test/Github/Tests/Api/Repository/AssetsTest.php
+++ b/test/Github/Tests/Api/Repository/AssetsTest.php
@@ -17,7 +17,7 @@ class AssetsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/releases/'.$id.'/assets')
+            ->with('/repos/KnpLabs/php-github-api/releases/'.$id.'/assets')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', $id));
@@ -34,7 +34,7 @@ class AssetsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/releases/assets/'.$assetId)
+            ->with('/repos/KnpLabs/php-github-api/releases/assets/'.$assetId)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', $assetId));
@@ -78,7 +78,7 @@ class AssetsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/releases/assets/'.$assetId)
+            ->with('/repos/KnpLabs/php-github-api/releases/assets/'.$assetId)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->edit('KnpLabs', 'php-github-api', $assetId, $data));
@@ -111,7 +111,7 @@ class AssetsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/releases/assets/'.$assetId)
+            ->with('/repos/KnpLabs/php-github-api/releases/assets/'.$assetId)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', $assetId));

--- a/test/Github/Tests/Api/Repository/CollaboratorsTest.php
+++ b/test/Github/Tests/Api/Repository/CollaboratorsTest.php
@@ -16,7 +16,7 @@ class CollaboratorsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/collaborators')
+            ->with('/repos/KnpLabs/php-github-api/collaborators')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -32,7 +32,7 @@ class CollaboratorsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/collaborators/l3l0')
+            ->with('/repos/KnpLabs/php-github-api/collaborators/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->check('KnpLabs', 'php-github-api', 'l3l0'));
@@ -48,7 +48,7 @@ class CollaboratorsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('repos/KnpLabs/php-github-api/collaborators/l3l0')
+            ->with('/repos/KnpLabs/php-github-api/collaborators/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->add('KnpLabs', 'php-github-api', 'l3l0'));
@@ -64,7 +64,7 @@ class CollaboratorsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/collaborators/l3l0')
+            ->with('/repos/KnpLabs/php-github-api/collaborators/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 'l3l0'));

--- a/test/Github/Tests/Api/Repository/CommentsTest.php
+++ b/test/Github/Tests/Api/Repository/CommentsTest.php
@@ -16,7 +16,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/comments')
+            ->with('/repos/KnpLabs/php-github-api/comments')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -32,7 +32,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/commits/commitSHA123456/comments')
+            ->with('/repos/KnpLabs/php-github-api/commits/commitSHA123456/comments')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', 'commitSHA123456'));
@@ -48,7 +48,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/comments/123')
+            ->with('/repos/KnpLabs/php-github-api/comments/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
@@ -80,7 +80,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/commits/commitSHA123456/comments', $data)
+            ->with('/repos/KnpLabs/php-github-api/commits/commitSHA123456/comments', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', 'commitSHA123456', $data));
@@ -97,7 +97,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/commits/commitSHA123456/comments', $data)
+            ->with('/repos/KnpLabs/php-github-api/commits/commitSHA123456/comments', $data)
             ->will($this->returnValue($expectedValue));
 
         $api->create('KnpLabs', 'php-github-api', 'commitSHA123456', $data);
@@ -127,7 +127,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/comments/123', $data)
+            ->with('/repos/KnpLabs/php-github-api/comments/123', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 123, $data));
@@ -143,7 +143,7 @@ class CommentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/comments/123')
+            ->with('/repos/KnpLabs/php-github-api/comments/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123));

--- a/test/Github/Tests/Api/Repository/CommitsTest.php
+++ b/test/Github/Tests/Api/Repository/CommitsTest.php
@@ -17,7 +17,7 @@ class CommitsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/commits', $data)
+            ->with('/repos/KnpLabs/php-github-api/commits', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', $data));
@@ -33,7 +33,7 @@ class CommitsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/compare/v3...HEAD')
+            ->with('/repos/KnpLabs/php-github-api/compare/v3...HEAD')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->compare('KnpLabs', 'php-github-api', 'v3', 'HEAD'));
@@ -49,7 +49,7 @@ class CommitsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/commits/123')
+            ->with('/repos/KnpLabs/php-github-api/commits/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));

--- a/test/Github/Tests/Api/Repository/ContentsTest.php
+++ b/test/Github/Tests/Api/Repository/ContentsTest.php
@@ -18,7 +18,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', array('ref' => null))
+            ->with('/repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', array('ref' => null))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 'test/Github/Tests/Api/Repository/ContentsTest.php'));
@@ -34,7 +34,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/readme', array('ref' => null))
+            ->with('/repos/KnpLabs/php-github-api/readme', array('ref' => null))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->readme('KnpLabs', 'php-github-api'));
@@ -50,7 +50,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('head')
-            ->with('repos/KnpLabs/php-github-api/contents/composer.json', array('ref' => null))
+            ->with('/repos/KnpLabs/php-github-api/contents/composer.json', array('ref' => null))
             ->will($this->returnValue($response));
 
         $this->assertEquals(true, $api->exists('KnpLabs', 'php-github-api', 'composer.json'));
@@ -77,7 +77,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('head')
-            ->with('repos/KnpLabs/php-github-api/contents/composer.json', array('ref' => null))
+            ->with('/repos/KnpLabs/php-github-api/contents/composer.json', array('ref' => null))
             ->will($failureStub);
 
         $this->assertFalse($api->exists('KnpLabs', 'php-github-api', 'composer.json'));
@@ -92,7 +92,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('head')
-            ->with('repos/KnpLabs/php-github-api/contents/composer.json', array('ref' => null))
+            ->with('/repos/KnpLabs/php-github-api/contents/composer.json', array('ref' => null))
             ->will($this->throwException(new TwoFactorAuthenticationRequiredException(0)));
 
         $api->exists('KnpLabs', 'php-github-api', 'composer.json');
@@ -118,7 +118,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', $parameters)
+            ->with('/repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', $parameters)
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->create('KnpLabs', 'php-github-api', 'test/Github/Tests/Api/Repository/ContentsTest.php', $content, $message, $branch, $committer));
@@ -158,7 +158,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', $parameters)
+            ->with('/repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', $parameters)
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->update('KnpLabs', 'php-github-api', 'test/Github/Tests/Api/Repository/ContentsTest.php', $content, $message, $sha, $branch, $committer));
@@ -196,7 +196,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', $parameters)
+            ->with('/repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', $parameters)
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->rm('KnpLabs', 'php-github-api', 'test/Github/Tests/Api/Repository/ContentsTest.php', $message, $sha, $branch, $committer));
@@ -224,7 +224,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/tarball')
+            ->with('/repos/KnpLabs/php-github-api/tarball')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->archive('KnpLabs', 'php-github-api', 'someFormat'));
@@ -240,7 +240,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/tarball')
+            ->with('/repos/KnpLabs/php-github-api/tarball')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->archive('KnpLabs', 'php-github-api', 'tarball'));
@@ -256,7 +256,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/zipball')
+            ->with('/repos/KnpLabs/php-github-api/zipball')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->archive('KnpLabs', 'php-github-api', 'zipball'));
@@ -272,7 +272,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/zipball/master')
+            ->with('/repos/KnpLabs/php-github-api/zipball/master')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->archive('KnpLabs', 'php-github-api', 'zipball', 'master'));
@@ -292,7 +292,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', array('ref' => null))
+            ->with('/repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', array('ref' => null))
             ->will($this->returnValue($getValue));
 
         $this->assertEquals($expectedValue, $api->download('KnpLabs', 'php-github-api', 'test/Github/Tests/Api/Repository/ContentsTest.php'));
@@ -312,7 +312,7 @@ class ContentsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/mads379/scala.tmbundle/contents/Syntaxes%2FSimple%20Build%20Tool.tmLanguage', array('ref' => null))
+            ->with('/repos/mads379/scala.tmbundle/contents/Syntaxes%2FSimple%20Build%20Tool.tmLanguage', array('ref' => null))
             ->will($this->returnValue($getValue));
 
         $this->assertEquals($expectedValue, $api->download('mads379', 'scala.tmbundle', 'Syntaxes/Simple Build Tool.tmLanguage'));

--- a/test/Github/Tests/Api/Repository/DeployKeysTest.php
+++ b/test/Github/Tests/Api/Repository/DeployKeysTest.php
@@ -16,7 +16,7 @@ class DeployKeysTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/keys')
+            ->with('/repos/KnpLabs/php-github-api/keys')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -32,7 +32,7 @@ class DeployKeysTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/keys/123')
+            ->with('/repos/KnpLabs/php-github-api/keys/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
@@ -48,7 +48,7 @@ class DeployKeysTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/keys/123')
+            ->with('/repos/KnpLabs/php-github-api/keys/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123));
@@ -95,7 +95,7 @@ class DeployKeysTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/keys', $data)
+            ->with('/repos/KnpLabs/php-github-api/keys', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
@@ -142,7 +142,7 @@ class DeployKeysTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/keys/123', $data)
+            ->with('/repos/KnpLabs/php-github-api/keys/123', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 123, $data));

--- a/test/Github/Tests/Api/Repository/DownloadsTest.php
+++ b/test/Github/Tests/Api/Repository/DownloadsTest.php
@@ -16,7 +16,7 @@ class DownloadsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/downloads')
+            ->with('/repos/KnpLabs/php-github-api/downloads')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -32,7 +32,7 @@ class DownloadsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/downloads/l3l0')
+            ->with('/repos/KnpLabs/php-github-api/downloads/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 'l3l0'));
@@ -48,7 +48,7 @@ class DownloadsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/downloads/l3l0')
+            ->with('/repos/KnpLabs/php-github-api/downloads/l3l0')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 'l3l0'));

--- a/test/Github/Tests/Api/Repository/ForksTest.php
+++ b/test/Github/Tests/Api/Repository/ForksTest.php
@@ -16,7 +16,7 @@ class ForksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/forks', array('page' => 1))
+            ->with('/repos/KnpLabs/php-github-api/forks', array('page' => 1))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -33,7 +33,7 @@ class ForksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/forks', $data)
+            ->with('/repos/KnpLabs/php-github-api/forks', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
@@ -49,7 +49,7 @@ class ForksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/forks', array('page' => 1, 'sort' => 'newest'))
+            ->with('/repos/KnpLabs/php-github-api/forks', array('page' => 1, 'sort' => 'newest'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', array('sort' => 'oldes')));

--- a/test/Github/Tests/Api/Repository/HooksTest.php
+++ b/test/Github/Tests/Api/Repository/HooksTest.php
@@ -16,7 +16,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/hooks')
+            ->with('/repos/KnpLabs/php-github-api/hooks')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -32,7 +32,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/hooks/123')
+            ->with('/repos/KnpLabs/php-github-api/hooks/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
@@ -48,7 +48,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/hooks/123')
+            ->with('/repos/KnpLabs/php-github-api/hooks/123')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123));
@@ -95,7 +95,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/hooks', $data)
+            ->with('/repos/KnpLabs/php-github-api/hooks', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
@@ -142,7 +142,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/hooks/123', $data)
+            ->with('/repos/KnpLabs/php-github-api/hooks/123', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 123, $data));
@@ -158,7 +158,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/hooks/123/test')
+            ->with('/repos/KnpLabs/php-github-api/hooks/123/test')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->test('KnpLabs', 'php-github-api', 123));

--- a/test/Github/Tests/Api/Repository/LabelsTest.php
+++ b/test/Github/Tests/Api/Repository/LabelsTest.php
@@ -16,7 +16,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/labels')
+            ->with('/repos/KnpLabs/php-github-api/labels')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -32,7 +32,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/labels/somename')
+            ->with('/repos/KnpLabs/php-github-api/labels/somename')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 'somename'));
@@ -48,7 +48,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/labels/somename')
+            ->with('/repos/KnpLabs/php-github-api/labels/somename')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 'somename'));
@@ -95,7 +95,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/labels', $data)
+            ->with('/repos/KnpLabs/php-github-api/labels', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
@@ -142,7 +142,7 @@ class LabelsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/labels/labelName', $data)
+            ->with('/repos/KnpLabs/php-github-api/labels/labelName', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 'labelName', $data));

--- a/test/Github/Tests/Api/Repository/ReleasesTest.php
+++ b/test/Github/Tests/Api/Repository/ReleasesTest.php
@@ -16,7 +16,7 @@ class ReleasesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/releases/latest')
+            ->with('/repos/KnpLabs/php-github-api/releases/latest')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->latest('KnpLabs', 'php-github-api'));
@@ -32,7 +32,7 @@ class ReleasesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/releases/tags/5f078080e01e0365690920d618f12342d2c941c8')
+            ->with('/repos/KnpLabs/php-github-api/releases/tags/5f078080e01e0365690920d618f12342d2c941c8')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->tag(
@@ -52,7 +52,7 @@ class ReleasesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/releases')
+            ->with('/repos/KnpLabs/php-github-api/releases')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -69,7 +69,7 @@ class ReleasesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/releases/'.$id)
+            ->with('/repos/KnpLabs/php-github-api/releases/'.$id)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', $id));
@@ -86,7 +86,7 @@ class ReleasesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/releases')
+            ->with('/repos/KnpLabs/php-github-api/releases')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
@@ -119,7 +119,7 @@ class ReleasesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('repos/KnpLabs/php-github-api/releases/'.$id)
+            ->with('/repos/KnpLabs/php-github-api/releases/'.$id)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->edit('KnpLabs', 'php-github-api', $id, $data));
@@ -136,7 +136,7 @@ class ReleasesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('repos/KnpLabs/php-github-api/releases/'.$id)
+            ->with('/repos/KnpLabs/php-github-api/releases/'.$id)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', $id));

--- a/test/Github/Tests/Api/Repository/StargazersTest.php
+++ b/test/Github/Tests/Api/Repository/StargazersTest.php
@@ -16,7 +16,7 @@ class StargazersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/stargazers')
+            ->with('/repos/KnpLabs/php-github-api/stargazers')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -32,7 +32,7 @@ class StargazersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/stargazers')
+            ->with('/repos/KnpLabs/php-github-api/stargazers')
             ->will($this->returnValue($expectedValue));
         $api->configure('star');
 

--- a/test/Github/Tests/Api/Repository/StatusesTest.php
+++ b/test/Github/Tests/Api/Repository/StatusesTest.php
@@ -19,7 +19,7 @@ class StatusesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/commits/commitSHA123456/statuses')
+            ->with('/repos/KnpLabs/php-github-api/commits/commitSHA123456/statuses')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 'commitSHA123456'));
@@ -49,7 +49,7 @@ class StatusesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('repos/KnpLabs/php-github-api/commits/commitSHA123456/status')
+            ->with('/repos/KnpLabs/php-github-api/commits/commitSHA123456/status')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->combined('KnpLabs', 'php-github-api', 'commitSHA123456'));
@@ -81,7 +81,7 @@ class StatusesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('repos/KnpLabs/php-github-api/statuses/commitSHA123456', $data)
+            ->with('/repos/KnpLabs/php-github-api/statuses/commitSHA123456', $data)
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', 'commitSHA123456', $data));

--- a/test/Github/Tests/Api/SearchTest.php
+++ b/test/Github/Tests/Api/SearchTest.php
@@ -16,7 +16,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                'search/repositories',
+                '/search/repositories',
                 array('q' => 'query text', 'sort' => 'updated', 'order' => 'desc')
             )
             ->will($this->returnValue($expectedArray));
@@ -36,7 +36,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                'search/repositories',
+                '/search/repositories',
                 array('q' => 'query text', 'sort' => 'created', 'order' => 'asc')
             )
             ->will($this->returnValue($expectedArray));
@@ -59,7 +59,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                'search/issues',
+                '/search/issues',
                 array('q' => 'query text', 'sort' => 'updated', 'order' => 'desc')
             )
             ->will($this->returnValue($expectedArray));
@@ -79,7 +79,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                'search/issues',
+                '/search/issues',
                 array('q' => 'query text', 'sort' => 'created', 'order' => 'asc')
             )
             ->will($this->returnValue($expectedArray));
@@ -102,7 +102,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                'search/code',
+                '/search/code',
                 array('q' => 'query text', 'sort' => 'updated', 'order' => 'desc')
             )
             ->will($this->returnValue($expectedArray));
@@ -122,7 +122,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                'search/code',
+                '/search/code',
                 array('q' => 'query text', 'sort' => 'created', 'order' => 'asc')
             )
             ->will($this->returnValue($expectedArray));
@@ -145,7 +145,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                'search/users',
+                '/search/users',
                 array('q' => 'query text', 'sort' => 'updated', 'order' => 'desc')
             )
             ->will($this->returnValue($expectedArray));
@@ -165,7 +165,7 @@ class SearchTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with(
-                'search/users',
+                '/search/users',
                 array('q' => 'query text', 'sort' => 'created', 'order' => 'asc')
             )
             ->will($this->returnValue($expectedArray));

--- a/test/Github/Tests/Api/UserTest.php
+++ b/test/Github/Tests/Api/UserTest.php
@@ -14,7 +14,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users/l3l0')
+            ->with('/users/l3l0')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->show('l3l0'));
@@ -37,7 +37,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users/l3l0/orgs')
+            ->with('/users/l3l0/orgs')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->organizations('l3l0'));
@@ -56,7 +56,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users')
+            ->with('/users')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all());
@@ -75,7 +75,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('legacy/user/search/l3l0')
+            ->with('/legacy/user/search/l3l0')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->find('l3l0'));
@@ -91,7 +91,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users/l3l0/following')
+            ->with('/users/l3l0/following')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->following('l3l0'));
@@ -107,7 +107,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users/l3l0/followers')
+            ->with('/users/l3l0/followers')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->followers('l3l0'));
@@ -123,7 +123,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users/l3l0/subscriptions')
+            ->with('/users/l3l0/subscriptions')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->subscriptions('l3l0'));
@@ -139,7 +139,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users/l3l0/repos', array('type' => 'owner', 'sort' => 'full_name', 'direction' => 'asc'))
+            ->with('/users/l3l0/repos', array('type' => 'owner', 'sort' => 'full_name', 'direction' => 'asc'))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->repositories('l3l0'));
@@ -155,7 +155,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users/l3l0/gists')
+            ->with('/users/l3l0/gists')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->gists('l3l0'));


### PR DESCRIPTION
This is a massive PR but it does nothing but add a slash ("/") infront of all URL. 
The reason for this is because Guzzle decided to validate the url as soon as it changes. (https://github.com/guzzle/psr7/pull/94)

We added a url like "user/Nyholm/repos" then we use AddHostPlugin which executes like this: 

```php
$uri = $request->getUri()
                ->withHost($this->host->getHost())
                ->withScheme($this->host->getScheme())
                ->withPort($this->host->getPort())
            ;
```

If we add a host like "api.github.com" it will not be valid at that state. It was before because https://github.com/guzzle/psr7/pull/94/files#diff-db412dbd2c689be753da90d14beffc1bL461

With this PR we make sure to always have a valid URL. Because "/foo" is a valid URL. 