### PR TITLE
Bumped version of cache plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php-http/discovery": "^1.0",
         "php-http/client-implementation": "^1.0",
         "php-http/client-common": "^1.1",
-        "php-http/cache-plugin": "^1.0"
+        "php-http/cache-plugin": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Version 1.1 has support for 304 responses which is needed to not effect our API limit.