### PR TITLE
Add per_page support to starring()->all()

### DIFF
--- a/lib/Github/Api/CurrentUser/Starring.php
+++ b/lib/Github/Api/CurrentUser/Starring.php
@@ -6,6 +6,7 @@ use Github\Api\AbstractApi;
 
 /**
  * @link   https://developer.github.com/v3/activity/starring/
+ *
  * @author Felipe Valtl de Mello <eu@felipe.im>
  */
 class Starring extends AbstractApi
@@ -16,13 +17,15 @@ class Starring extends AbstractApi
      * @link https://developer.github.com/v3/activity/starring/
      *
      * @param int $page
+     * @param int $perPage
      *
      * @return array
      */
-    public function all($page = 1)
+    public function all($page = 1, $perPage = 30)
     {
         return $this->get('/user/starred', array(
-            'page' => $page
+            'page' => $page,
+            'per_page' => $perPage,
         ));
     }
 


### PR DESCRIPTION
Since `starring()->all()` can have paginated results fetched via the `ResultPager` class, I added an option to specify how many stars per page you want, which gets picked up by `AbstractApi.php`.