### PR TITLE
Accessing the API as an integration

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -7,6 +7,7 @@ APIs:
 * [Enterprise](enterprise.md)
 * [Gists](gists.md)
   * [Comments](gists/comments.md)
+* [Integrations](integrations.md)
 * [Issues](issues.md)
   * [Comments](issue/comments.md)
   * [Labels](issue/labels.md)

--- a/doc/integrations.md
+++ b/doc/integrations.md
@@ -1,0 +1,15 @@
+## Instegrations API
+[Back to the navigation](README.md)
+
+Wraps [GitHub Integrations API](http://developer.github.com/v3/integrations/).
+
+### Create a new installation token
+For the installation id 123 use the following:
+```php
+$token = $client->api('integrations')->createInstallationToken(123);
+```
+
+To create an access token on behalf of a user with id 456 use:
+```php
+$token = $client->api('integrations')->createInstallationToken(123, 456);
+```

--- a/doc/security.md
+++ b/doc/security.md
@@ -13,15 +13,17 @@ $client->authenticate($usernameOrToken, $password, $method);
 ```
 
 `$usernameOrToken` is, of course, the username (or in some cases token/client ID, more details you can find below),
-and guess what should contain `$password`. The `$method` can contain one of the three allowed values:
+and guess what should contain `$password`. The `$method` can contain one of the five allowed values:
 
 * `Github\Client::AUTH_URL_TOKEN`
 * `Github\Client::AUTH_URL_CLIENT_ID`
 * `Github\Client::AUTH_HTTP_TOKEN`
 * `Github\Client::AUTH_HTTP_PASSWORD`
+* `Github\Client::AUTH_JWT`
 
-The required value of `$password` depends on the chosen `$method`. For the `Github\Client::AUTH_*_TOKEN` methods,
-you should provide the API token in `$username` variable (`$password` is omitted in this particular case). For the
+The required value of `$password` depends on the chosen `$method`. For `Github\Client::AUTH_URL_TOKEN`,
+`Github\Client::AUTH_HTTP_TOKEN` and `Github\Client::JWT` methods you should provide the API token in
+`$username` variable (`$password` is omitted in this particular case). For the
 `Github\Client::AUTH_HTTP_PASSWORD`, you should provide the password of the account. When using `Github\Client::AUTH_URL_CLIENT_ID`
 `$usernameOrToken` should contain your client ID, and `$password` should contain client secret.
 
@@ -32,10 +34,37 @@ all further requests are done as the given user.
 
 The `Github\Client::AUTH_URL_TOKEN` authentication method sends the API token in URL parameters.
 The `Github\Client::AUTH_URL_CLIENT_ID` authentication method sends the client ID and secret in URL parameters.
-The `Github_Client::AUTH_HTTP_*` authentication methods send their values to GitHub using HTTP Basic Authentication.
+The `Github\Client::AUTH_HTTP_*` authentication methods send their values to GitHub using HTTP Basic Authentication.
+The `Github\Client::AUTH_JWT` authentication method sends the specified JSON Web Token in an Authorization header.
 
 `Github\Client::AUTH_URL_TOKEN` used to be the only available authentication method. To prevent existing applications
 from changing their behavior in case of an API upgrade, this method is chosen as the default for this API implementation.
 
 Note however that GitHub describes this method as deprecated. In most case you should use the
 `Github\Client::AUTH_HTTP_TOKEN` instead.
+
+### Authenticating as an Integration
+
+To authenticate as an integration you need to supply a JSON Web Token with `Github\Client::AUTH_JWT` to request
+and installation access token which is then usable with `Github\Client::AUTH_HTTP_TOKEN`. [Github´s integration
+authentication docs](https://developer.github.com/early-access/integrations/authentication/) describe the flow in detail.
+It´s important for integration requests to use the custom Accept header `application/vnd.github.machine-man-preview`.
+
+The following sample code authenticates as an installation using [lcobucci/jwt](https://github.com/lcobucci/jwt/tree/3.2.0)
+to generate a JSON Web Token (JWT).
+
+```php
+$github = new Github\Client(new GuzzleClient(), 'machine-man-preview');
+
+$jwt = (new Builder)
+    ->setIssuer($integrationId)
+    ->setIssuedAt(time())
+    ->setExpiration(time() + 60)
+    ->sign(new Sha256(),  (new Keychain)->getPrivateKey($pemPrivateKeyPath))
+    ->getToken();
+
+$github->authenticate($jwt, null, Github\Client::AUTH_JWT);
+
+$token = $github->api('installations')->createAccessToken($installationId);
+$github->authenticate($token['token'], null, Github\Client::AUTH_HTTP_TOKEN);
+```

--- a/doc/security.md
+++ b/doc/security.md
@@ -65,6 +65,6 @@ $jwt = (new Builder)
 
 $github->authenticate($jwt, null, Github\Client::AUTH_JWT);
 
-$token = $github->api('installations')->createAccessToken($installationId);
+$token = $github->api('integrations')->createInstallationToken($installationId);
 $github->authenticate($token['token'], null, Github\Client::AUTH_HTTP_TOKEN);
 ```

--- a/lib/Github/Api/Installations.php
+++ b/lib/Github/Api/Installations.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Github\Api;
+
+/**
+ * @link   https://developer.github.com/early-access/integrations/authentication/
+ * @author Nils Adermann <naderman@naderman.de>
+ */
+class Installations extends AbstractApi
+{
+    /**
+     * Create an access token for an installation
+     *
+     * @param int $installationId An integration installation id
+     * @param int $userId         An optional user id on behalf of whom the
+     *                            token will be requested
+     *
+     * @return array token and token metadata
+     */
+    public function createAccessToken($installationId, $userId = null)
+    {
+        $parameters = array();
+        if ($userId) {
+            $paramters['user_id'] = $userId;
+        }
+        return $this->post('/installations/'.rawurlencode($installationId).'/access_tokens', $parameters);
+    }
+}

--- a/lib/Github/Api/Installations.php
+++ b/lib/Github/Api/Installations.php
@@ -23,6 +23,7 @@ class Installations extends AbstractApi
         if ($userId) {
             $paramters['user_id'] = $userId;
         }
+
         return $this->post('/installations/'.rawurlencode($installationId).'/access_tokens', $parameters);
     }
 }

--- a/lib/Github/Api/Integrations.php
+++ b/lib/Github/Api/Integrations.php
@@ -3,10 +3,10 @@
 namespace Github\Api;
 
 /**
- * @link   https://developer.github.com/early-access/integrations/authentication/
+ * @link   https://developer.github.com/v3/integrations/
  * @author Nils Adermann <naderman@naderman.de>
  */
-class Installations extends AbstractApi
+class Integrations extends AbstractApi
 {
     /**
      * Create an access token for an installation
@@ -17,11 +17,11 @@ class Installations extends AbstractApi
      *
      * @return array token and token metadata
      */
-    public function createAccessToken($installationId, $userId = null)
+    public function createInstallationToken($installationId, $userId = null)
     {
         $parameters = array();
         if ($userId) {
-            $paramters['user_id'] = $userId;
+            $parameters['user_id'] = $userId;
         }
 
         return $this->post('/installations/'.rawurlencode($installationId).'/access_tokens', $parameters);

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -210,6 +210,11 @@ class Client
                 $api = new Api\Gists($this);
                 break;
 
+            case 'installation':
+            case 'installations':
+                $api = new Api\Installations($this);
+                break;
+
             case 'issue':
             case 'issues':
                 $api = new Api\Issue($this);

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -87,6 +87,12 @@ class Client
     const AUTH_HTTP_TOKEN = 'http_token';
 
     /**
+     * Constant for authentication method. Indicates JSON Web Token
+     * authentication required for integration access to the API.
+     */
+    const AUTH_JWT = 'jwt';
+
+    /**
      * @var string
      */
     private $apiVersion;

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -210,9 +210,9 @@ class Client
                 $api = new Api\Gists($this);
                 break;
 
-            case 'installation':
-            case 'installations':
-                $api = new Api\Installations($this);
+            case 'integration':
+            case 'integrations':
+                $api = new Api\Integrations($this);
                 break;
 
             case 'issue':

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -294,7 +294,7 @@ class Client
             throw new InvalidArgumentException('You need to specify authentication method!');
         }
 
-        if (null === $authMethod && in_array($password, array(self::AUTH_URL_TOKEN, self::AUTH_URL_CLIENT_ID, self::AUTH_HTTP_PASSWORD, self::AUTH_HTTP_TOKEN))) {
+        if (null === $authMethod && in_array($password, array(self::AUTH_URL_TOKEN, self::AUTH_URL_CLIENT_ID, self::AUTH_HTTP_PASSWORD, self::AUTH_HTTP_TOKEN, self::AUTH_JWT))) {
             $authMethod = $password;
             $password   = null;
         }

--- a/lib/Github/HttpClient/Plugin/Authentication.php
+++ b/lib/Github/HttpClient/Plugin/Authentication.php
@@ -71,6 +71,10 @@ class Authentication implements Plugin
                 $request = $request->withUri($uri);
                 break;
 
+            case Client::AUTH_JWT:
+                $request = $request->withHeader('Authorization', sprintf('Bearer %s', $this->tokenOrLogin));
+                break;
+
             default:
                 throw new RuntimeException(sprintf('%s not yet implemented', $this->method));
                 break;


### PR DESCRIPTION
- Add JWT authentication introduced with GitHub integrations
- Add endpoint for Installation access tokens required for API use from GitHub integrations