### PR TITLE
Improve rate limit exceeded exception

### DIFF
--- a/lib/Github/Exception/ApiLimitExceedException.php
+++ b/lib/Github/Exception/ApiLimitExceedException.php
@@ -9,8 +9,24 @@ namespace Github\Exception;
  */
 class ApiLimitExceedException extends RuntimeException
 {
-    public function __construct($limit = 5000, $code = 0, $previous = null)
+    private $limit;
+    private $reset;
+
+    public function __construct($limit = 5000, $reset = 1800, $code = 0, $previous = null)
     {
-        parent::__construct('You have reached GitHub hour limit! Actual limit is: '. $limit, $code, $previous);
+        $this->limit = (int) $limit;
+        $this->reset = (int) $reset;
+
+        parent::__construct(sprintf('You have reached GitHub hourly limit! Actual limit is: %d', $limit), $code, $previous);
+    }
+
+    public function getLimit()
+    {
+        return $this->limit;
+    }
+
+    public function getResetTime()
+    {
+        return $this->reset;
     }
 }

--- a/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
+++ b/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
@@ -30,10 +30,11 @@ class GithubExceptionThrower implements Plugin
 
             // If error:
             $remaining = ResponseMediator::getHeader($response, 'X-RateLimit-Remaining');
-            $limit = ResponseMediator::getHeader($response, 'X-RateLimit-Limit');
-
             if (null != $remaining && 1 > $remaining && 'rate_limit' !== substr($request->getRequestTarget(), 1, 10)) {
-                throw new ApiLimitExceedException($limit);
+                $limit = ResponseMediator::getHeader($response, 'X-RateLimit-Limit');
+                $reset = ResponseMediator::getHeader($response, 'X-RateLimit-Reset');
+                
+                throw new ApiLimitExceedException($limit, $reset);
             }
 
             if (401 === $response->getStatusCode()) {


### PR DESCRIPTION
Adds two helpful methods to ``ApiLimitExceedException`` to allow getting the actual limit and reset time. I am working on a console application that needs to get the reset time in order to sleep until Github resets the token. Hope that makes sense, Thanks!