### PR TITLE
update php-http/client-common version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php-http/httplug": "^1.1",
         "php-http/discovery": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "php-http/client-common": "^1.3",
+        "php-http/client-common": "^1.2",
         "php-http/cache-plugin": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
The dependencies before could not have been resolved. Thus, it was not
possible to run the test suite at all.