### PR TITLE
Add Deployment show method

### DIFF
--- a/doc/repo/deployments.md
+++ b/doc/repo/deployments.md
@@ -15,6 +15,12 @@ You can also filter the returned results (see [the documentation](https://develo
 $deployments = $client->api('deployment')->all('KnpLabs', 'php-github-api', array('environment' => 'production'));
 ```
 
+### List one deployment.
+
+```php
+$deployment = $client->api('deployment')->show('KnpLabs', 'php-github-api', $id);
+```
+
 #### Create a new deployments.
 
 The `ref` parameter is required.

--- a/lib/Github/Api/Deployment.php
+++ b/lib/Github/Api/Deployment.php
@@ -26,6 +26,20 @@ class Deployment extends AbstractApi
     }
 
     /**
+     * Get a deployment in selected repository.
+     *
+     * @param string $username   the user who owns the repo
+     * @param string $repository the name of the repo
+     * @param int    $id         the id of the deployment
+     *
+     * @return array
+     */
+    public function show($username, $repository, $id)
+    {
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments/'.rawurlencode($id));
+    }
+
+    /**
      * Create a new deployment for the given username and repo.
      * @link https://developer.github.com/v3/repos/deployments/#create-a-deployment
      *

--- a/test/Github/Tests/Api/DeploymentTest.php
+++ b/test/Github/Tests/Api/DeploymentTest.php
@@ -51,7 +51,7 @@ class DeploymentTest extends TestCase
      */
     public function shouldShowProject()
     {
-      $expectedValue = array('id' => 123, 'ref' => 'master');
+        $expectedValue = array('id' => 123, 'ref' => 'master');
 
         $api = $this->getApiMock();
         $api->expects($this->once())

--- a/test/Github/Tests/Api/DeploymentTest.php
+++ b/test/Github/Tests/Api/DeploymentTest.php
@@ -49,6 +49,22 @@ class DeploymentTest extends TestCase
     /**
      * @test
      */
+    public function shouldShowProject()
+    {
+      $expectedValue = array('id' => 123, 'ref' => 'master');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/deployments/123')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
+    }
+
+    /**
+     * @test
+     */
     public function shouldCreateStatusUpdate()
     {
         $api = $this->getApiMock();


### PR DESCRIPTION
## What?

Get a single deployment by it's unique ID.
## Why?

The current implementation only supports getting all deployments for a repository and filtering by; sha, ref, task or environment. But just get te details of one specific deployment is not possible.
## Changes
- Added a `show` method to the Deployment class.
- Updated the docs describing the show method
- Added a unittest for the new show method.
