### PR TITLE
add new alias for pull request to make it same with REST API

### DIFF
--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -235,6 +235,7 @@ class Client
                 break;
 
             case 'pr':
+            case 'pulls':
             case 'pullRequest':
             case 'pull_request':
             case 'pullRequests':


### PR DESCRIPTION
To make it same with REST API, I think, `pulls` should be added as well