### PR TITLE
refactor:Make addMember an alias of add

### DIFF
--- a/lib/Github/Api/Organization/Members.php
+++ b/lib/Github/Api/Organization/Members.php
@@ -44,11 +44,6 @@ class Members extends AbstractApi
         return $this->get('/orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));
     }
 
-    public function addMember($organization, $username)
-    {
-        return $this->put('/orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
-    }
-
     public function publicize($organization, $username)
     {
         return $this->put('/orgs/'.rawurlencode($organization).'/public_members/'.rawurlencode($username));
@@ -66,6 +61,11 @@ class Members extends AbstractApi
     {
         return $this->put('/orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
     }
+
+	public function addMember($organization, $username)
+	{
+		return $this->add($organization, $username);
+	}
 
     public function remove($organization, $username)
     {

--- a/lib/Github/Api/Organization/Members.php
+++ b/lib/Github/Api/Organization/Members.php
@@ -62,10 +62,10 @@ class Members extends AbstractApi
         return $this->put('/orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
     }
 
-	public function addMember($organization, $username)
-	{
-		return $this->add($organization, $username);
-	}
+    public function addMember($organization, $username)
+    {
+        return $this->add($organization, $username);
+    }
 
     public function remove($organization, $username)
     {


### PR DESCRIPTION
Duplicate code existed for adding member to an organisation

Under lib/Github/Api/Organisation/Members.php the addMember and add
methods returned the exact same code and used the exact same arguments.

With that in mind I made addMember an "alias" returning $this->add
passing the same arguments through.