### PR TITLE
Added 'user/repos' missing endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 - API for Repo\Cards
 - API for Repo\Columns
 - API for Repo\Projects
+- API for User\MyRepositories
 - Methods in Repo API for frequency and participation
 
 ### Changed

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -145,11 +145,9 @@ class User extends AbstractApi
     }
 
     /**
-     * @deprecated use repos($username, $options) instead
+     * List public repositories for the specified user.
      *
-     * Get the repositories of a user.
-     *
-     * @link http://developer.github.com/v3/repos/
+     * @link https://developer.github.com/v3/repos/#list-user-repositories
      *
      * @param string $username  the username
      * @param string $type      role in the repository
@@ -160,24 +158,25 @@ class User extends AbstractApi
      */
     public function repositories($username, $type = 'owner', $sort = 'full_name', $direction = 'asc')
     {
-        return $this->repos($username, array(
+        return $this->get('/users/'.rawurlencode($username).'/repos', [
             'type' => $type,
             'sort' => $sort,
-            'direction' => $direction
-        ));
+            'direction' => $direction,
+        ]);
     }
 
     /**
-     * @param null $username
-     * @param array $options
+     * List repositories that are accessible to the authenticated user.
+     *
+     * @link https://developer.github.com/v3/repos/#list-your-repositories
+     *
+     * @param array $params visibility, affiliation, type, sort, direction
      *
      * @return array list of the user repositories
      */
-    public function repos($username = null, array $options = array())
+    public function myRepositories(array $params = [])
     {
-        $url = $username ? '/users/'.rawurldecode($username).'/repos' : '/user/repos';
-
-        return $this->get($url, $options);
+        return $this->get('/user/repos', $params);
     }
 
     /**

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -175,7 +175,7 @@ class User extends AbstractApi
      */
     public function repos($username = null, array $options = array())
     {
-        $url = $username ? 'users/'.rawurldecode($username).'/repos' : 'user/repos';
+        $url = $username ? '/users/'.rawurldecode($username).'/repos' : '/user/repos';
 
         return $this->get($url, $options);
     }

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -145,6 +145,8 @@ class User extends AbstractApi
     }
 
     /**
+     * @deprecated use repos($username, $options) instead
+     *
      * Get the repositories of a user.
      *
      * @link http://developer.github.com/v3/repos/
@@ -158,11 +160,24 @@ class User extends AbstractApi
      */
     public function repositories($username, $type = 'owner', $sort = 'full_name', $direction = 'asc')
     {
-        return $this->get('/users/'.rawurlencode($username).'/repos', array(
+        return $this->repos($username, array(
             'type' => $type,
             'sort' => $sort,
             'direction' => $direction
         ));
+    }
+
+    /**
+     * @param null $username
+     * @param array $options
+     *
+     * @return array list of the user repositories
+     */
+    public function repos($username = null, array $options = array())
+    {
+        $url = $username ? 'users/'.rawurldecode($username).'/repos' : 'user/repos';
+
+        return $this->get($url, $options);
     }
 
     /**

--- a/test/Github/Tests/Api/UserTest.php
+++ b/test/Github/Tests/Api/UserTest.php
@@ -148,6 +148,21 @@ class UserTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetMyRepositories()
+    {
+        $expectedArray = [['id' => 1, 'name' => 'l3l0repo']];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')->with('/user/repos', [])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->myRepositories());
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetUserGists()
     {
         $expectedArray = array(array('id' => 1, 'name' => 'l3l0repo'));


### PR DESCRIPTION
List repositories that are accessible to the authenticated user.

 https://developer.github.com/v3/repos/#list-your-repositories

On the other hand, I think, `repositories($username, $type = 'owner', $sort = 'full_name', $direction = 'asc')` method is outdated since `affiliation` and `visibility` options are not covered