### PR TITLE
Added missing docs for currentuser public keys

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -4,6 +4,9 @@ Navigation
 APIs:
 * [Authorizations](authorizations.md)
 * [Commits](commits.md)
+* Current User
+  * [Deploy keys / Public keys](currentuser/deploykeys.md)
+  * [Memberships](currentuser/memberships.md)
 * [Enterprise](enterprise.md)
 * [Gists](gists.md)
   * [Comments](gists/comments.md)

--- a/doc/currentuser/deploykeys.md
+++ b/doc/currentuser/deploykeys.md
@@ -1,0 +1,36 @@
+## Current user / Public Keys API
+[Back to the navigation](../README.md)
+
+Wraps [GitHub User Public Keys API](https://developer.github.com/v3/users/keys/#public-keys).
+
+### List your public keys
+
+```php
+$keys = $client->user()->keys()->all();
+```
+
+Returns a list of public keys for the authenticated user.
+
+### Shows a public key for the authenticated user.
+
+```php
+$key = $client->user()->keys()->show(1234);
+```
+
+### Add a public key to the authenticated user.
+
+> Requires [authentication](security.md).
+
+```php
+$key = $client->user()->keys()->create(array('title' => 'key title', 'key' => 12345));
+```
+
+Adds a key with title 'key title' to the authenticated user and returns a the created key for the user.
+
+### Remove a public key from the authenticated user.
+
+> Requires [authentication](security.md).
+
+```php
+$client->user()->keys()->remove(12345);
+```

--- a/lib/Github/Api/CurrentUser/DeployKeys.php
+++ b/lib/Github/Api/CurrentUser/DeployKeys.php
@@ -14,7 +14,7 @@ class DeployKeys extends AbstractApi
     /**
      * List deploy keys for the authenticated user.
      *
-     * @link http://developer.github.com/v3/repos/keys/
+     * @link https://developer.github.com/v3/users/keys/
      *
      * @return array
      */
@@ -26,7 +26,7 @@ class DeployKeys extends AbstractApi
     /**
      * Shows deploy key for the authenticated user.
      *
-     * @link http://developer.github.com/v3/repos/keys/
+     * @link https://developer.github.com/v3/users/keys/
      *
      * @param string $id
      *
@@ -40,7 +40,7 @@ class DeployKeys extends AbstractApi
     /**
      * Adds deploy key for the authenticated user.
      *
-     * @link http://developer.github.com/v3/repos/keys/
+     * @link https://developer.github.com/v3/users/keys/
      *
      * @param array $params
      *
@@ -60,7 +60,7 @@ class DeployKeys extends AbstractApi
     /**
      * Removes deploy key for the authenticated user.
      *
-     * @link http://developer.github.com/v3/repos/keys/
+     * @link https://developer.github.com/v3/users/keys/
      *
      * @param string $id
      *


### PR DESCRIPTION
The missing docs came to my attention in issue #467 

A questions for another pr, should we rename the current user DeployKeys class (and docs files) to publickeys as this would reflect the names of github?

"Fixes" issues: #464, #467 