### PR TITLE
Updating a user public key is not allowed

### DIFF
--- a/lib/Github/Api/CurrentUser/DeployKeys.php
+++ b/lib/Github/Api/CurrentUser/DeployKeys.php
@@ -58,27 +58,6 @@ class DeployKeys extends AbstractApi
     }
 
     /**
-     * Updates deploy key for the authenticated user.
-     *
-     * @link http://developer.github.com/v3/repos/keys/
-     *
-     * @param string $id
-     * @param array  $params
-     *
-     * @throws \Github\Exception\MissingArgumentException
-     *
-     * @return array
-     */
-    public function update($id, array $params)
-    {
-        if (!isset($params['title'], $params['key'])) {
-            throw new MissingArgumentException(array('title', 'key'));
-        }
-
-        return $this->patch('/user/keys/'.rawurlencode($id), $params);
-    }
-
-    /**
      * Removes deploy key for the authenticated user.
      *
      * @link http://developer.github.com/v3/repos/keys/

--- a/test/Github/Tests/Api/CurrentUser/DeployKeysTest.php
+++ b/test/Github/Tests/Api/CurrentUser/DeployKeysTest.php
@@ -86,53 +86,6 @@ class DeployKeysTest extends TestCase
     /**
      * @test
      */
-    public function shouldUpdateKey()
-    {
-        $expectedValue = array('id' => '123', 'key' => 'ssh-rsa ...');
-        $data = array('title' => 'my key', 'key' => 'ssh-rsa ...');
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('patch')
-            ->with('/user/keys/123', $data)
-            ->will($this->returnValue($expectedValue));
-
-        $this->assertEquals($expectedValue, $api->update(123, $data));
-    }
-
-    /**
-     * @test
-     * @expectedException \Github\Exception\MissingArgumentException
-     */
-    public function shouldNotUpdateKeyWithoutTitleParam()
-    {
-        $data = array('key' => 'ssh-rsa ...');
-
-        $api = $this->getApiMock();
-        $api->expects($this->never())
-            ->method('patch');
-
-        $api->update(123, $data);
-    }
-
-    /**
-     * @test
-     * @expectedException \Github\Exception\MissingArgumentException
-     */
-    public function shouldNotUpdateKeyWithoutKeyParam()
-    {
-        $data = array('title' => 'my key');
-
-        $api = $this->getApiMock();
-        $api->expects($this->never())
-            ->method('patch');
-
-        $api->update(123, $data);
-    }
-
-    /**
-     * @test
-     */
     public function shouldRemoveKey()
     {
         $expectedValue = array('some value');


### PR DESCRIPTION
By writing docs for the user public keys api I've discovered that updating a key is not allowed. Github recommends deleting the key and creating a new one. 

> Public keys are immutable. If you need to update a public key, remove the key and create a new one instead.
See: https://developer.github.com/v3/users/keys/#update-a-public-key

So I've removed the update method