### PR TITLE
Use same default sort as github api does

### DIFF
--- a/lib/Github/Api/Issue/Milestones.php
+++ b/lib/Github/Api/Issue/Milestones.php
@@ -30,14 +30,14 @@ class Milestones extends AbstractApi
             $params['sort'] = 'due_date';
         }
         if (isset($params['direction']) && !in_array($params['direction'], array('asc', 'desc'))) {
-            $params['direction'] = 'desc';
+            $params['direction'] = 'asc';
         }
 
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/milestones', array_merge(array(
             'page'      => 1,
             'state'     => 'open',
             'sort'      => 'due_date',
-            'direction' => 'desc'
+            'direction' => 'asc'
         ), $params));
     }
 

--- a/test/Github/Tests/Api/Issue/MilestonesTest.php
+++ b/test/Github/Tests/Api/Issue/MilestonesTest.php
@@ -16,7 +16,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
+            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'asc'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
@@ -132,7 +132,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
+            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'asc'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', array('sort' => 'completenes')));
@@ -148,7 +148,7 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
+            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'asc'))
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', array('state' => 'clos')));
@@ -164,10 +164,10 @@ class MilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'desc'))
+            ->with('/repos/KnpLabs/php-github-api/milestones', array('page' => 1, 'state' => 'open', 'sort' => 'due_date', 'direction' => 'asc'))
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', array('direction' => 'des')));
+        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', array('direction' => 'asc')));
     }
 
     /**


### PR DESCRIPTION
Updated the default value to keep in sync with the github api

> The direction of the sort. Either asc or desc. Default: asc
See: https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository

Closes: #306