### PR TITLE
Add page variable to organization repo list

### DIFF
--- a/lib/Github/Api/Organization.php
+++ b/lib/Github/Api/Organization.php
@@ -51,13 +51,15 @@ class Organization extends AbstractApi
      *
      * @param string $organization the user name
      * @param string $type         the type of repositories
+     * @param int    $page         the page
      *
      * @return array the repositories
      */
-    public function repositories($organization, $type = 'all')
+    public function repositories($organization, $type = 'all', $page = 1)
     {
         return $this->get('/orgs/'.rawurlencode($organization).'/repos', array(
-            'type' => $type
+            'type' => $type,
+            'page' => $page,
         ));
     }
 

--- a/test/Github/Tests/Api/OrganizationTest.php
+++ b/test/Github/Tests/Api/OrganizationTest.php
@@ -62,7 +62,7 @@ class OrganizationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/orgs/KnpLabs/repos', array('type' => 'all'))
+            ->with('/orgs/KnpLabs/repos', array('type' => 'all', 'page' => 1))
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->repositories('KnpLabs'));


### PR DESCRIPTION
If an organization has more than 30 repositories, this allows to perform subsequent requests to get all of the repositories.