### PR TITLE
Make chaining available in Stargazers

### DIFF
--- a/lib/Github/Api/Repository/Stargazers.php
+++ b/lib/Github/Api/Repository/Stargazers.php
@@ -26,6 +26,7 @@ class Stargazers extends AbstractApi
         if ('star' === $bodyType) {
             $this->acceptHeaderValue = sprintf('application/vnd.github.%s.star+json', $this->client->getApiVersion());
         }
+        return $this;
     }
 
     public function all($username, $repository)


### PR DESCRIPTION
Allows for:

```php
$stargazers = $client->repo()->stargazers()->configure('star')->all('vuejs', 'vue');
```

instead of

```php
$stargazers = $client->repo()->stargazers();
$stargazers->configure('star');
$stargazers = $stargazers->all('vuejs', 'vue');
```