### PR TITLE
Added missing api methods for the integrations installation api

### DIFF
--- a/doc/integrations.md
+++ b/doc/integrations.md
@@ -13,3 +13,29 @@ To create an access token on behalf of a user with id 456 use:
 ```php
 $token = $client->api('integrations')->createInstallationToken(123, 456);
 ```
+
+### Find all installations
+
+Find all installations for the authenticated integration.
+```php
+Installations = $client->api('integrations')->findInstallations();
+```
+
+### List repositories
+
+List repositories that are accessible to the authenticated installation.
+```php
+$repositories = $client->api('integrations')->listRepositories(456);
+```
+
+### Add repository to installation
+Add a single repository to an installation.
+```php
+$client->api('integrations')->addRepository(123);
+```
+
+### Remove repository from installation
+Remove a single repository from an installation.
+```php
+$client->api('integrations')->removeRepository(123);
+```

--- a/lib/Github/Api/Integrations.php
+++ b/lib/Github/Api/Integrations.php
@@ -26,4 +26,60 @@ class Integrations extends AbstractApi
 
         return $this->post('/installations/'.rawurlencode($installationId).'/access_tokens', $parameters);
     }
+
+    /**
+     * Find all installations for the authenticated integration.
+     *
+     * @link https://developer.github.com/v3/integrations/#find-installations
+     *
+     * @return array
+     */
+    public function findInstallations()
+    {
+        return $this->get('/integration/installations');
+    }
+
+    /**
+     * List repositories that are accessible to the authenticated installation.
+     *
+     * @link https://developer.github.com/v3/integrations/installations/#list-repositories
+     *
+     * @param int $userId
+     *
+     * @return array
+     */
+    public function listRepositories($userId)
+    {
+        return $this->get('/installation/repositories', ['user_id' => $userId]);
+    }
+
+    /**
+     * Add a single repository to an installation.
+     *
+     * @link https://developer.github.com/v3/integrations/installations/#add-repository-to-installation
+     *
+     * @param int $installationId
+     * @param int $repositoryId
+     *
+     * @return array
+     */
+    public function addRepository($installationId, $repositoryId)
+    {
+        return $this->put('/installations/'.rawurlencode($installationId).'/repositories/'.rawurlencode($repositoryId));
+    }
+
+    /**
+     * Remove a single repository from an installation.
+     *
+     * @link https://developer.github.com/v3/integrations/installations/#remove-repository-from-installation
+     *
+     * @param int $installationId
+     * @param int $repositoryId
+     *
+     * @return array
+     */
+    public function removeRepository($installationId, $repositoryId)
+    {
+        return $this->delete('/installations/'.rawurlencode($installationId).'/repositories/'.rawurlencode($repositoryId));
+    }
 }

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -27,6 +27,8 @@ use Psr\Cache\CacheItemPoolInterface;
  * @method Api\GitData gitData()
  * @method Api\Gists gist()
  * @method Api\Gists gists()
+ * @method Api\Integrations integration()
+ * @method Api\Integrations integrations()
  * @method Api\Issue issue()
  * @method Api\Issue issues()
  * @method Api\Markdown markdown()

--- a/test/Github/Tests/Api/IntegrationTest.php
+++ b/test/Github/Tests/Api/IntegrationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Github\Tests\Api;
+
+class IntegrationTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldFindRepositoriesForIntegration()
+    {
+        $result = ['installation1', 'installation2'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/integration/installations')
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->findInstallations());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetRepositoriesFromInstallation()
+    {
+        $result = ['repo1', 'repo2'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/installation/repositories', ['user_id' => '1234'])
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->listRepositories('1234'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddRepositoryToInstallation()
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('/installations/1234/repositories/5678');
+
+        $api->addRepository('1234', '5678');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRemoveRepositoryToInstallation()
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('/installations/1234/repositories/5678');
+
+        $api->removeRepository('1234', '5678');
+    }
+
+
+    /**
+     * @return string
+     */
+    protected function getApiClass()
+    {
+        return \Github\Api\Integrations::class;
+    }
+}


### PR DESCRIPTION
Missing methds for the integrations installation api. See https://developer.github.com/v3/integrations/installations/#installations

And added the [`findInstallations` api method](https://developer.github.com/v3/integrations/#find-installations). Closes #516 