### PR TITLE
Fixed integration authentication example

### DIFF
--- a/doc/security.md
+++ b/doc/security.md
@@ -54,6 +54,10 @@ The following sample code authenticates as an installation using [lcobucci/jwt](
 to generate a JSON Web Token (JWT).
 
 ```php
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+
 $builder = new Github\HttpClient\Builder(new GuzzleClient());
 $github = new Github\Client($builder, 'machine-man-preview');
 
@@ -61,7 +65,7 @@ $jwt = (new Builder)
     ->setIssuer($integrationId)
     ->setIssuedAt(time())
     ->setExpiration(time() + 60)
-    ->sign(new Sha256(),  (new Keychain)->getPrivateKey($pemPrivateKeyPath))
+    ->sign(new Sha256(),  new Key('file:///path/to/integration.private-key.pem'))
     ->getToken();
 
 $github->authenticate($jwt, null, Github\Client::AUTH_JWT);


### PR DESCRIPTION
The ```Keychain``` class used in the example is deprecated. Using ```Key``` is recommended. And I've added the use lines for the used classes to make the example more clear. 