### PR TITLE
Bugfix: headers not being passed to request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ phpunit.xml
 composer.lock
 composer.phar
 vendor/*
+
+# IDEs
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@ phpunit.xml
 composer.lock
 composer.phar
 vendor/*
-
-# IDEs
-/.idea/

--- a/lib/Github/HttpClient/Builder.php
+++ b/lib/Github/HttpClient/Builder.php
@@ -168,6 +168,9 @@ class Builder
         } else {
             $this->headers[$header] = array_merge((array)$this->headers[$header], array($headerValue));
         }
+
+        $this->removePlugin(Plugin\HeaderAppendPlugin::class);
+        $this->addPlugin(new Plugin\HeaderAppendPlugin($this->headers));
     }
 
     /**

--- a/test/Github/Tests/HttpClient/BuilderTest.php
+++ b/test/Github/Tests/HttpClient/BuilderTest.php
@@ -49,4 +49,28 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
         $client->addHeaders($headers);
     }
+
+    /**
+     * @test
+     */
+    public function appendingHeaderShouldAddAndRemovePlugin()
+    {
+        $expectedHeaders = [
+            'Accept' => 'application/vnd.github.v3',
+        ];
+
+        $client = $this->getMockBuilder(\Github\HttpClient\Builder::class)
+            ->setMethods(array('removePlugin', 'addPlugin'))
+            ->getMock();
+
+        $client->expects($this->once())
+            ->method('removePlugin')
+            ->with(Plugin\HeaderAppendPlugin::class);
+
+        $client->expects($this->once())
+            ->method('addPlugin')
+            ->with(new Plugin\HeaderAppendPlugin($expectedHeaders));
+
+        $client->addHeaderValue('Accept', 'application/vnd.github.v3');
+    }
 }


### PR DESCRIPTION
The bug was that the version header (and any other headers which were set using `addHeaderValue()`) were not passed to the `HeaderAppendPlugin`, so when the request was made those headers didn't get sent.