### PR TITLE
Missing miscellaneous api endpoints

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -14,6 +14,10 @@ APIs:
 * [Issues](issues.md)
   * [Comments](issue/comments.md)
   * [Labels](issue/labels.md)
+* Miscellaneous
+  * [Emojis](miscellaneous/emojis.md)
+  * [Gitignore](miscellaneous/gitignore.md)
+  * [Markdown](miscellaneous/markdown.md)
 * [Organization](organization.md)
   * [Members](organization/members.md)
   * [Teams](organization/teams.md)

--- a/doc/miscellaneous/emojis.md
+++ b/doc/miscellaneous/emojis.md
@@ -1,0 +1,8 @@
+## Emojis API
+[Back to the navigation](../README.md)
+
+### Lists all available emojis on GitHub.
+
+```php
+$emojis = $client->api('emojis')->all();
+```

--- a/doc/miscellaneous/gitignore.md
+++ b/doc/miscellaneous/gitignore.md
@@ -1,0 +1,14 @@
+## Gitignore API
+[Back to the navigation](../README.md)
+
+### Lists all available gitignore templates
+
+```php
+$gitignoreTemplates = $client->api('gitignore')->all();
+```
+
+### Get a single template
+
+```php
+$gitignore = $client->api('gitignore')->show('C');
+```

--- a/doc/miscellaneous/markdown.md
+++ b/doc/miscellaneous/markdown.md
@@ -1,0 +1,14 @@
+## Markdown API
+[Back to the navigation](../README.md)
+
+### Render an arbitrary Markdown document
+
+```php
+$gitignoreTemplates = $client->api('markdown')->render('Hello world github/linguist#1 **cool**, and #1!', 'markdown');
+```
+
+### Render a Markdown document in raw mode
+
+```php
+$gitignore = $client->api('markdown')->renderRaw('path/to/file');
+```

--- a/lib/Github/Api/Miscellaneous/Emojis.php
+++ b/lib/Github/Api/Miscellaneous/Emojis.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Github\Api\Miscellaneous;
+
+use Github\Api\AbstractApi;
+
+class Emojis extends AbstractApi
+{
+    /**
+     * Lists all the emojis available to use on GitHub.
+     *
+     * @link https://developer.github.com/v3/emojis/
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->get('/emojis');
+    }
+}

--- a/lib/Github/Api/Miscellaneous/Gitignore.php
+++ b/lib/Github/Api/Miscellaneous/Gitignore.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Github\Api\Miscellaneous;
+
+use Github\Api\AbstractApi;
+
+class Gitignore extends AbstractApi
+{
+    /**
+     * List all templates available to pass as an option when creating a repository.
+     *
+     * @link https://developer.github.com/v3/gitignore/#listing-available-templates
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->get('/gitignore/templates');
+    }
+
+    /**
+     * Get a single template.
+     *
+     * @link https://developer.github.com/v3/gitignore/#get-a-single-template
+     *
+     * @param string $template
+     *
+     * @return array
+     */
+    public function show($template)
+    {
+        return $this->get('/gitignore/templates/' . rawurlencode($template));
+    }
+}

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -23,10 +23,12 @@ use Psr\Cache\CacheItemPoolInterface;
  * @method Api\CurrentUser me()
  * @method Api\Enterprise ent()
  * @method Api\Enterprise enterprise()
+ * @method Api\Miscellaneous\Emojis emojis()
  * @method Api\GitData git()
  * @method Api\GitData gitData()
  * @method Api\Gists gist()
  * @method Api\Gists gists()
+ * @method Api\Miscellaneous\Gitignore gitignore()
  * @method Api\Integrations integration()
  * @method Api\Integrations integrations()
  * @method Api\Issue issue()
@@ -177,6 +179,10 @@ class Client
                 $api = new Api\Enterprise($this);
                 break;
 
+            case 'emojis':
+                $api = new Api\Miscellaneous\Emojis($this);
+                break;
+
             case 'git':
             case 'git_data':
             case 'gitData':
@@ -186,6 +192,10 @@ class Client
             case 'gist':
             case 'gists':
                 $api = new Api\Gists($this);
+                break;
+
+            case 'gitignore':
+                $api = new Api\Miscellaneous\Gitignore($this);
                 break;
 
             case 'integration':

--- a/test/Github/Tests/Api/Miscellaneous/EmojisTest.php
+++ b/test/Github/Tests/Api/Miscellaneous/EmojisTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Github\Tests\Api\Miscellaneous;
+
+use Github\Api\Miscellaneous\Emojis;
+use Github\Tests\Api\TestCase;
+
+class EmojisTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllEmojis()
+    {
+        $expectedArray = array(
+            '+1' => 'https://github.global.ssl.fastly.net/images/icons/emoji/+1.png?v5',
+            '-1' => 'https://github.global.ssl.fastly.net/images/icons/emoji/-1.png?v5',
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/emojis')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->all());
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass()
+    {
+        return Emojis::class;
+    }
+}

--- a/test/Github/Tests/Api/Miscellaneous/GitignoreTest.php
+++ b/test/Github/Tests/Api/Miscellaneous/GitignoreTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Github\Tests\Api\Miscellaneous;
+
+use Github\Api\Miscellaneous\Emojis;
+use Github\Api\Miscellaneous\Gitignore;
+use Github\Tests\Api\TestCase;
+
+class GitignoreTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllTemplates()
+    {
+        $expectedArray = array(
+            'Actionscript',
+            'Android',
+            'AppceleratorTitanium',
+            'Autotools',
+            'Bancha',
+            'C',
+            'C++'
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/gitignore/templates')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->all());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetTemplate()
+    {
+        $expectedArray = array(
+            'name' => 'C',
+            'source' => "# Object files\n*.o\n\n# Libraries\n*.lib\n*.a"
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/gitignore/templates/C')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->show('C'));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass()
+    {
+        return Gitignore::class;
+    }
+}

--- a/test/Github/Tests/Api/Miscellaneous/MarkdownTest.php
+++ b/test/Github/Tests/Api/Miscellaneous/MarkdownTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Github\Tests\Api;
+namespace Github\Tests\Api\Miscellaneous;
+
+use Github\Tests\Api\TestCase;
 
 class MarkdownTest extends TestCase
 {


### PR DESCRIPTION
I'm checking the lib to see if we missed any api endpoints available. This PR fixes the missing miscellaneous api endpoints.

@Nyholm what do you think? Can we move the markdown, ratelimit, etc api classes to the miscellaneous subfolder/namespace to mimic the structure github has for these api's? See: https://developer.github.com/v3/misc/

It would not change how the user would use these api's as $client->api('ratelimit') and $client->ratelimit() would point to the correct class.