### PR TITLE
Add ability to define parameters for /users/{user}/starred

### DIFF
--- a/lib/Github/Api/CurrentUser.php
+++ b/lib/Github/Api/CurrentUser.php
@@ -112,7 +112,7 @@ class CurrentUser extends AbstractApi
      *
      * @param string $type      role in the repository
      * @param string $sort      sort by
-     * @param string $direction direction of sort, ask or desc
+     * @param string $direction direction of sort, asc or desc
      *
      * @return array
      */

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -131,13 +131,19 @@ class User extends AbstractApi
      *
      * @param string $username the username
      * @param int    $page     the page number of the paginated result set
+     * @param int    $perPage  the number of results per page
+     * @param string $sort     sort by (possible values: created, updated)
+     * @param int    $perPage  direction of sort (possible values: asc, desc)
      *
      * @return array list of starred repositories
      */
-    public function starred($username, $page = 1)
+    public function starred($username, $page = 1, $perPage = 30, $sort = 'created', $direction = 'desc')
     {
         return $this->get('/users/'.rawurlencode($username).'/starred', array(
-            'page' => $page
+            'page' => $page,
+            'per_page' => $perPage,
+            'sort' => $sort,
+            'direction' => $direction,
         ));
     }
 

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -129,11 +129,11 @@ class User extends AbstractApi
      *
      * @link http://developer.github.com/v3/activity/starring/
      *
-     * @param string $username the username
-     * @param int    $page     the page number of the paginated result set
-     * @param int    $perPage  the number of results per page
-     * @param string $sort     sort by (possible values: created, updated)
-     * @param int    $perPage  direction of sort (possible values: asc, desc)
+     * @param string $username  the username
+     * @param int    $page      the page number of the paginated result set
+     * @param int    $perPage   the number of results per page
+     * @param string $sort      sort by (possible values: created, updated)
+     * @param string $direction direction of sort (possible values: asc, desc)
      *
      * @return array list of starred repositories
      */

--- a/test/Github/Tests/Api/UserTest.php
+++ b/test/Github/Tests/Api/UserTest.php
@@ -42,6 +42,7 @@ class UserTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->organizations('l3l0'));
     }
+
     public function shouldGetUserOrgs()
     {
         $expectedArray = array(array(
@@ -61,6 +62,7 @@ class UserTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->orgs());
     }
+
     /**
      * @test
      */
@@ -129,6 +131,22 @@ class UserTest extends TestCase
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->followers('l3l0'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetStarredToRepositories()
+    {
+        $expectedArray = array(array('id' => 1, 'name' => 'l3l0repo'));
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/users/l3l0/starred', ['page' => 2, 'per_page' => 30, 'sort' => 'created', 'direction' => 'desc'])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->starred('l3l0', 2));
     }
 
     /**


### PR DESCRIPTION
Following the [documentation](https://developer.github.com/v3/activity/starring/#list-repositories-being-starred) we can define few parameters to the request:
- page (was already available in the lib)
- per_page
- sort
- direction

I also fixed a small typo.