### PR TITLE
Allow userId to be an optional argument in Integrations->listRepositories()

### DIFF
--- a/lib/Github/Api/Integrations.php
+++ b/lib/Github/Api/Integrations.php
@@ -23,7 +23,6 @@ class Integrations extends AbstractApi
         if ($userId) {
             $parameters['user_id'] = $userId;
         }
-
         return $this->post('/installations/'.rawurlencode($installationId).'/access_tokens', $parameters);
     }
 
@@ -48,9 +47,13 @@ class Integrations extends AbstractApi
      *
      * @return array
      */
-    public function listRepositories($userId)
+    public function listRepositories($userId = null)
     {
-        return $this->get('/installation/repositories', ['user_id' => $userId]);
+        $parameters = array();
+        if ($userId) {
+            $parameters['user_id'] = $userId;
+        }
+        return $this->get('/installation/repositories', $parameters);
     }
 
     /**


### PR DESCRIPTION
The API supports for the user_id argument to be omitted from this API call but this PHP library does not. This PR follows the pattern established in the createInstallationToken method to allow user_id to be optional also.