### PR TITLE
The Merge methods API is now official

### DIFF
--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -22,11 +22,16 @@ class PullRequest extends AbstractApi
      *
      * @link https://developer.github.com/v3/pulls/#custom-media-types
      * @param string|null $bodyType
+     * @param string|null $apiVersion
      *
      * @return self
      */
-    public function configure($bodyType = null)
+    public function configure($bodyType = null, $apiVersion = null)
     {
+        if (!in_array($apiVersion, array())) {
+            $apiVersion = $this->client->getApiVersion();
+        }
+
         if (!in_array($bodyType, array('text', 'html', 'full', 'diff', 'patch'))) {
             $bodyType = 'raw';
         }
@@ -35,7 +40,7 @@ class PullRequest extends AbstractApi
             $bodyType .= '+json';
         }
 
-        $this->acceptHeaderValue = sprintf('application/vnd.github.%s.%s', $this->client->getApiVersion(), $bodyType);
+        $this->acceptHeaderValue = sprintf('application/vnd.github.%s.%s', $apiVersion, $bodyType);
 
         return $this;
     }

--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -163,6 +163,10 @@ class PullRequest extends AbstractApi
             $mergeMethod = $mergeMethod ? 'squash' : 'merge';
         }
 
+        if (!in_array($mergeMethod, array('merge', 'squash', 'rebase'), true)) {
+            throw new InvalidArgumentException(sprintf('"$mergeMethod" must be one of ["merge", "squash", "rebase"] ("%s" given).', $mergeMethod));
+        }
+
         $params = array(
             'commit_message' => $message,
             'sha' => $sha,

--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -22,16 +22,11 @@ class PullRequest extends AbstractApi
      *
      * @link https://developer.github.com/v3/pulls/#custom-media-types
      * @param string|null $bodyType
-     * @param string|null $apiVersion
      *
      * @return self
      */
-    public function configure($bodyType = null, $apiVersion = null)
+    public function configure($bodyType = null)
     {
-        if (!in_array($apiVersion, array('polaris-preview'))) {
-            $apiVersion = $this->client->getApiVersion();
-        }
-
         if (!in_array($bodyType, array('text', 'html', 'full', 'diff', 'patch'))) {
             $bodyType = 'raw';
         }
@@ -159,8 +154,8 @@ class PullRequest extends AbstractApi
 
     public function merge($username, $repository, $id, $message, $sha, $mergeMethod = 'merge', $title = null)
     {
-        if (is_bool($mergeMethod)) {
-            $mergeMethod = $mergeMethod ? 'squash' : 'merge';
+        if (!in_array($mergeMethod, array('squash', 'rebase'))) {
+            $mergeMethod = 'merge';
         }
 
         $params = array(

--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -5,6 +5,7 @@ namespace Github\Api;
 use Github\Api\PullRequest\Comments;
 use Github\Api\PullRequest\Review;
 use Github\Api\PullRequest\ReviewRequest;
+use Github\Exception\InvalidArgumentException;
 use Github\Exception\MissingArgumentException;
 
 /**

--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -158,10 +158,6 @@ class PullRequest extends AbstractApi
             $mergeMethod = $mergeMethod ? 'squash' : 'merge';
         }
 
-        if (!in_array($mergeMethod, array('squash', 'rebase'))) {
-            $mergeMethod = 'merge';
-        }
-
         $params = array(
             'commit_message' => $message,
             'sha' => $sha,

--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -154,6 +154,10 @@ class PullRequest extends AbstractApi
 
     public function merge($username, $repository, $id, $message, $sha, $mergeMethod = 'merge', $title = null)
     {
+        if (is_bool($mergeMethod)) {
+            $mergeMethod = $mergeMethod ? 'squash' : 'merge';
+        }
+
         if (!in_array($mergeMethod, array('squash', 'rebase'))) {
             $mergeMethod = 'merge';
         }


### PR DESCRIPTION
see: https://developer.github.com/changes/2017-04-07-end-merge-methods-api-preview/
this removes the apiVersion (that wasn't being used anyway..)
also adds support for rebase mergeMethod per https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button