### PR TITLE
Renamed "functional" tests to "integration" tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,7 @@
 
     <groups>
         <exclude>
-            <group>functional</group>
+            <group>integration</group>
         </exclude>
     </groups>
 

--- a/test/Github/Tests/Integration/CommitTest.php
+++ b/test/Github/Tests/Integration/CommitTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Github\Tests\Functional;
+namespace Github\Tests\Integration;
 
 /**
- * @group functional
+ * @group integration
  */
 class CommitTest extends TestCase
 {

--- a/test/Github/Tests/Integration/GistTest.php
+++ b/test/Github/Tests/Integration/GistTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Github\Tests\Functional;
+namespace Github\Tests\Integration;
 
 /**
- * @group functional
+ * @group integration
  */
 class GistTest extends TestCase
 {

--- a/test/Github/Tests/Integration/IssueCommentTest.php
+++ b/test/Github/Tests/Integration/IssueCommentTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Github\Tests\Functional;
+namespace Github\Tests\Integration;
 
 /**
- * @group functional
+ * @group integration
  */
 class IssueCommentTest extends TestCase
 {

--- a/test/Github/Tests/Integration/MarkdownTest.php
+++ b/test/Github/Tests/Integration/MarkdownTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Github\Tests\Functional;
+namespace Github\Tests\Integration;
 
 use Github\Api\Markdown;
 
 /**
- * @group functional
+ * @group integration
  */
 class MarkdownTest extends TestCase
 {

--- a/test/Github/Tests/Integration/RateLimitTest.php
+++ b/test/Github/Tests/Integration/RateLimitTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Github\Tests\Functional;
+namespace Github\Tests\Integration;
 
 /**
- * @group functional
+ * @group integration
  */
 class RateLimitTest extends TestCase
 {

--- a/test/Github/Tests/Integration/RepoCommentTest.php
+++ b/test/Github/Tests/Integration/RepoCommentTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Github\Tests\Functional;
+namespace Github\Tests\Integration;
 
 /**
- * @group functional
+ * @group integration
  */
 class RepoCommentTest extends TestCase
 {

--- a/test/Github/Tests/Integration/RepoTest.php
+++ b/test/Github/Tests/Integration/RepoTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Github\Tests\Functional;
+namespace Github\Tests\Integration;
 
 /**
- * @group functional
+ * @group integration
  */
 class RepoTest extends TestCase
 {

--- a/test/Github/Tests/Integration/ResultPagerTest.php
+++ b/test/Github/Tests/Integration/ResultPagerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Github\Tests\Functional;
+namespace Github\Tests\Integration;
 
 use Github\ResultPager;
 
 /**
- * @group functional
+ * @group integration
  */
 class ResultPagerTest extends TestCase
 {

--- a/test/Github/Tests/Integration/TestCase.php
+++ b/test/Github/Tests/Integration/TestCase.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Github\Tests\Functional;
+namespace Github\Tests\Integration;
 
 use Github\Client;
 use Github\Exception\ApiLimitExceedException;
 use Github\Exception\RuntimeException;
 
 /**
- * @group functional
+ * @group integration
  */
 class TestCase extends \PHPUnit_Framework_TestCase
 {

--- a/test/Github/Tests/Integration/UserTest.php
+++ b/test/Github/Tests/Integration/UserTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Github\Tests\Functional;
+namespace Github\Tests\Integration;
 
 /**
- * @group functional
+ * @group integration
  */
 class UserTest extends TestCase
 {


### PR DESCRIPTION
This might seam weird and unnecessary but I want to start write real functional tests. 