### PR TITLE
Fix milestone doc typo

### DIFF
--- a/doc/issue/milestones.md
+++ b/doc/issue/milestones.md
@@ -27,7 +27,7 @@ $milestone = $client->api('issue')->milestones()->create('KnpLabs', 'php-github-
 $milestone = $client->api('issue')->milestones()->update('KnpLabs', 'php-github-api', 123, array('title' => '3.0'));
 ```
 
-### Remove a milestonre
+### Remove a milestone
 
 ```php
 $client->api('issue')->milestones()->remove('KnpLabs', 'php-github-api', 123);

--- a/doc/issue/milestones.md
+++ b/doc/issue/milestones.md
@@ -3,7 +3,7 @@
 
 Wraps [GitHub Issue Milestones API](http://developer.github.com/v3/issues/milestones/).
 
-### List project milestones
+### List milestones for a repository
 
 ```php
 $milestones = $client->api('issue')->milestones()->all('KnpLabs', 'php-github-api');


### PR DESCRIPTION
Fix a typo I found when looking over a PR of that doc page.  Also updating another heading on the page to be more clear.  Now that GH has "projects" it could be confusing to use that term there so I replaced it with the same language that the GH docs uses.