### PR TITLE
add the ability to fetch repositories for a specific installation and user

### DIFF
--- a/doc/integrations.md
+++ b/doc/integrations.md
@@ -18,7 +18,13 @@ $token = $client->api('integrations')->createInstallationToken(123, 456);
 
 Find all installations for the authenticated integration.
 ```php
-Installations = $client->api('integrations')->findInstallations();
+$installations = $client->api('integrations')->findInstallations();
+```
+
+### Find installations for a user
+
+```php
+$installations = $client->api('current_user')->installations();
 ```
 
 ### List repositories
@@ -26,6 +32,12 @@ Installations = $client->api('integrations')->findInstallations();
 List repositories that are accessible to the authenticated installation.
 ```php
 $repositories = $client->api('integrations')->listRepositories(456);
+```
+
+### List repositories for a given installation and user
+
+```
+$repositories = $client->api('current_user')->repositoriesByInstallation(456);
 ```
 
 ### Add repository to installation

--- a/lib/Github/Api/CurrentUser.php
+++ b/lib/Github/Api/CurrentUser.php
@@ -178,4 +178,15 @@ class CurrentUser extends AbstractApi
     {
         return $this->get('/user/installations', array_merge(array('page' => 1), $params));
     }
+
+    /**
+     * @link https://developer.github.com/v3/integrations/installations/#list-repositories-accessible-to-the-user-for-an-installation
+     *
+     * @param string $installationId  the ID of the Installation
+     * @param array $params
+     */
+    public function repositoriesByInstallation($installationId, array $params = array())
+    {
+        return $this->get(sprintf('/user/installations/%s/repositories', $installationId), array_merge(array('page' => 1), $params));
+    }
 }

--- a/test/Github/Tests/Api/CurrentUserTest.php
+++ b/test/Github/Tests/Api/CurrentUserTest.php
@@ -87,7 +87,7 @@ class CurrentUserTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetInstallationsForUser()
+    public function shouldGetInstallations()
     {
         $result = ['installation1', 'installation2'];
 
@@ -98,6 +98,22 @@ class CurrentUserTest extends TestCase
             ->willReturn($result);
 
         $this->assertEquals($result, $api->installations());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetRepositoriesByInstallation()
+    {
+        $expectedArray = array(array('id' => 1, 'name' => 'l3l0repo'));
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/user/installations/42/repositories', array('page' => 1))
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->repositoriesByInstallation(42));
     }
 
     /**


### PR DESCRIPTION
https://developer.github.com/early-access/integrations/user-identification-authorization/#check-which-installations-resources-a-user-can-access

@Nyholm @acrobat 