### PR TITLE
Allow getting repo info by id, not just user and repo name

### DIFF
--- a/doc/repos.md
+++ b/doc/repos.md
@@ -44,11 +44,13 @@ $repos = $client->api('repo')->find('chess', array('language' => 'php', 'start_p
 
 ### Get extended information about a repository
 
+Using the username of the repository owner and the repository name:
+
 ```php
 $repo = $client->api('repo')->show('KnpLabs', 'php-github-api')
 ```
 
-or
+Or by using the repository id (note that this is at time of writing an undocumented feature, see [here](https://github.com/piotrmurach/github/issues/283) and [here](https://github.com/piotrmurach/github/issues/282)):
 
 ```php
 $repo = $client->api('repo')->showById(123456)

--- a/doc/repos.md
+++ b/doc/repos.md
@@ -48,6 +48,12 @@ $repos = $client->api('repo')->find('chess', array('language' => 'php', 'start_p
 $repo = $client->api('repo')->show('KnpLabs', 'php-github-api')
 ```
 
+or
+
+```php
+$repo = $client->api('repo')->showById(123456)
+```
+
 Returns an array of information about the specified repository.
 
 ### Get the repositories of a specific user

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -150,6 +150,20 @@ class Repo extends AbstractApi
     {
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository));
     }
+    
+    /**
+     * Get extended information about a repository by its id.
+     *
+     * @link http://developer.github.com/v3/repos/
+     *
+     * @param int $id   the id of the repository
+     *
+     * @return array information about the repository
+     */
+    public function showById($id)
+    {
+        return $this->get('/repositories/'.rawurlencode($id));
+    }
 
     /**
      * Create repository.

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -153,8 +153,11 @@ class Repo extends AbstractApi
     
     /**
      * Get extended information about a repository by its id.
+     * Note: at time of writing this is an undocumented feature but GitHub support have advised that it can be relied on.
      *
      * @link http://developer.github.com/v3/repos/
+     * @link https://github.com/piotrmurach/github/issues/283
+     * @link https://github.com/piotrmurach/github/issues/282
      *
      * @param int $id   the id of the repository
      *

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -19,6 +19,22 @@ class RepoTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->show('KnpLabs', 'php-github-api'));
     }
+    
+    /**
+     * @test
+     */
+    public function shouldShowRepositoryById()
+    {
+        $expectedArray = array('id' => 123456, 'name' => 'repoName');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repositories/123456')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->showById(123456));
+    }
 
     /**
      * @test


### PR DESCRIPTION
This is an undocumented feature, but GitHub support have said it can be relied on. It's also really handy!

GitHub support said:
> Thanks for reaching out. Indeed that is undocumented, but that's intentional for now. We'll be documenting that endpoint in the future (actually, it's not just that endpoint, you can replace a name with the ID for most other endpoints), but I can't promise when it will happen. Still, you can rely on this behavior in your scripts and applications -- we don't have any plans on changing it.

See https://github.com/piotrmurach/github/issues/283 and https://github.com/piotrmurach/github/issues/282