### PR TITLE
Remove need to use configure() on PR review and review request

### DIFF
--- a/doc/pull_request/review_request.md
+++ b/doc/pull_request/review_request.md
@@ -1,13 +1,6 @@
 ## Pull Requests / Review Requests API
 [Back to the "Pull Requests API"](../pull_requests.md) | [Back to the navigation](../README.md)
 
-The Pull Request Review API is currently available for developers to preview.
-To access the API during the preview period, you must provide a custom media type in the Accept header:
-
-```php
-$client->api('pull_request')->reviewRequests()->configure();
-```
-
 ### List all review requests
 
 ```php

--- a/lib/Github/Api/PullRequest/Review.php
+++ b/lib/Github/Api/PullRequest/Review.php
@@ -19,8 +19,6 @@ class Review extends AbstractApi
 
     public function configure()
     {
-        $this->acceptHeaderValue = 'application/vnd.github.black-cat-preview+json';
-
         return $this;
     }
 

--- a/lib/Github/Api/PullRequest/ReviewRequest.php
+++ b/lib/Github/Api/PullRequest/ReviewRequest.php
@@ -14,8 +14,6 @@ class ReviewRequest extends AbstractApi
 
     public function configure()
     {
-        $this->acceptHeaderValue = 'application/vnd.github.black-cat-preview+json';
-
         return $this;
     }
 


### PR DESCRIPTION
https://developer.github.com/changes/2017-05-09-end-black-cat-preview/

I left the configure methods in place to avoid breaking anything and just have them returning $this
Also updated the docs for review requests. Doesn't appear that there are any docs for reviews though.