### PR TITLE
Travis build config tweaks for hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: php
 
+cache:
+    directories:
+        - vendor
+        - $HOME/.composer/cache
+
 php:
   - 5.5
   - 5.6
@@ -14,7 +19,7 @@ matrix:
 sudo: false
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer install --no-interaction
 
 script:
   - vendor/bin/phpunit --verbose --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+
+matrix:
+  include:
+    - php: hhvm
+      dist: trusty
 
 sudo: false
 

--- a/test/Github/Tests/Api/Repository/AssetsTest.php
+++ b/test/Github/Tests/Api/Repository/AssetsTest.php
@@ -48,7 +48,7 @@ class AssetsTest extends TestCase
     {
         if (!defined('OPENSSL_TLSEXT_SERVER_NAME') || !OPENSSL_TLSEXT_SERVER_NAME) {
             return $this->markTestSkipped(
-                'Asset upload support requires Server Name Indication. This is not supported be your PHP version.'
+                'Asset upload support requires Server Name Indication. This is not supported by your PHP version.'
             );
         }
 


### PR DESCRIPTION
HHVM is not supported anymore in ubuntu precise, so we should use trusty for the hhvm build

Closes #599 