### PR TITLE
Add support of GraphQL variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## 2.6.0 (unreleased)
 
+### Added
+
+- Support for graphql api [variables](https://developer.github.com/v4/guides/forming-calls/#working-with-variables) (#612)
+
 ## 2.5.0
 
 ### Added

--- a/doc/graphql.md
+++ b/doc/graphql.md
@@ -8,3 +8,25 @@ Wraps [GitHub v4 API (GraphQL API)](http://developer.github.com/v4/).
 ```php
 $rateLimits = $client->api('graphql')->execute($query);
 ```
+
+#### Use variables
+
+[Variables](https://developer.github.com/v4/guides/forming-calls/#working-with-variables) allow specifying of requested data without dynamical change of a query on a client side.
+
+```php
+$query = <<<'QUERY'
+query showOrganizationInfo (
+  $organizationLogin: String!
+) {
+  organization(login: $organizationLogin) {
+    name
+    url
+  }
+}
+QUERY;
+$variables = [
+    'organizationLogin' => 'KnpLabs'
+];
+
+$orgInfo = $client->api('graphql')->execute($query, $variables);
+```

--- a/lib/Github/Api/GraphQL.php
+++ b/lib/Github/Api/GraphQL.php
@@ -16,15 +16,19 @@ class GraphQL extends AbstractApi
     
     /**
      * @param string $query
+     * @param array $variables
      *
      * @return array
      */
-    public function execute($query)
+    public function execute($query, array $variables = null)
     {
         $this->acceptHeaderValue = 'application/vnd.github.v4+json';
         $params = array(
             'query' => $query
         );
+        if (!empty($variables)) {
+            $params['variables'] = json_encode($variables);
+        }
 
         return $this->post('/graphql', $params);
     }

--- a/lib/Github/Api/GraphQL.php
+++ b/lib/Github/Api/GraphQL.php
@@ -20,7 +20,7 @@ class GraphQL extends AbstractApi
      *
      * @return array
      */
-    public function execute($query, array $variables = null)
+    public function execute($query, array $variables = array())
     {
         $this->acceptHeaderValue = 'application/vnd.github.v4+json';
         $params = array(

--- a/test/Github/Tests/Api/GraphQLTest.php
+++ b/test/Github/Tests/Api/GraphQLTest.php
@@ -21,6 +21,35 @@ class GraphQLTest extends TestCase
         $this->assertEquals('foo', $result);
     }
 
+    /**
+     * @test
+     */
+    public function shouldSupportGraphQLVariables()
+    {
+        $api = $this->getApiMock();
+
+        $api->method('post')
+            ->with('/graphql', $this->arrayHasKey('variables'));
+
+        $api->execute('bar', ['variable' => 'foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldJSONEncodeGraphQLVariables()
+    {
+        $api = $this->getApiMock();
+
+        $api->method('post')
+            ->with('/graphql', $this->equalTo([
+                'query'=>'bar',
+                'variables' => '{"variable":"foo"}'
+            ]));
+
+        $api->execute('bar', ['variable' => 'foo']);
+    }
+
     protected function getApiClass()
     {
         return \Github\Api\GraphQL::class;


### PR DESCRIPTION
GitHub GraphQL API [supports](https://developer.github.com/v4/guides/forming-calls/#working-with-variables) [variables](http://graphql.org/learn/queries/#variables) that allow specifying of requested data without dynamical change of a query on a client side.

This PR adds the possibility to send variables with a query to GitHub GraphQL API v4.

Usage:
```
$query = <<<'QUERY'
query showOrganizationInfo (
  $organizationLogin: String!
) {
  organization(login: $organizationLogin) {
    name
    url
  }
}
QUERY;
$variables = [
    'organizationLogin' => 'KnpLabs'
];

$orgInfo = $client->api('graphql')->execute($query, $variables);
```

 