### PR TITLE
Add a helper fromFile function to get GraphQL queries from a file

### DIFF
--- a/lib/Github/Api/GraphQL.php
+++ b/lib/Github/Api/GraphQL.php
@@ -32,4 +32,15 @@ class GraphQL extends AbstractApi
 
         return $this->post('/graphql', $params);
     }
+    
+    /**
+     * @param string $file
+     * @param array $variables
+     *
+     * @return array
+     */
+    public function fromFile($file, array $variables = array())
+    {
+        return $this->execute(file_get_contents($file), $variables);
+    }
 }


### PR DESCRIPTION
GraphQL queries can be long, so I normally store them in a external file. This PR adds a helper function that loads the query from an external file.

:octocat: