### PR TITLE
Upgrade phpunit dependency to supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
         - $HOME/.composer/cache
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 2.7.0 (Unreleased)
+
+### Removed
+
+- Dropped support for php 5.5
+
+###
+
+- Phpunit 6 compatibility
+
 ## 2.6.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Uses [GitHub API v3](http://developer.github.com/v3/) & supports [GitHub API v4]
 
 ## Requirements
 
-* PHP >= 5.5
+* PHP >= 5.6
 * [Guzzle](https://github.com/guzzle/guzzle) library,
 * (optional) PHPUnit to run tests.
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "psr/http-message": "^1.0",
         "psr/cache": "^1.0",
         "php-http/httplug": "^1.1",
@@ -27,7 +27,7 @@
         "php-http/cache-plugin": "^1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0 || ^5.5",
+        "phpunit/phpunit": "^5.5 || ^6.0",
         "php-http/guzzle6-adapter": "^1.0",
         "php-http/mock-client": "^1.0",
         "guzzlehttp/psr7": "^1.2",

--- a/test/Github/Tests/Api/TestCase.php
+++ b/test/Github/Tests/Api/TestCase.php
@@ -5,7 +5,7 @@ namespace Github\Tests\Api;
 use Github\HttpClient\Builder;
 use ReflectionMethod;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @return string

--- a/test/Github/Tests/ClientTest.php
+++ b/test/Github/Tests/ClientTest.php
@@ -12,7 +12,7 @@ use Http\Client\Common\Plugin;
 use Http\Client\HttpClient;
 use Psr\Http\Message\RequestInterface;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/Github/Tests/Functional/CacheTest.php
+++ b/test/Github/Tests/Functional/CacheTest.php
@@ -11,7 +11,7 @@ use GuzzleHttp\Psr7\Response;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class CacheTest extends \PHPUnit_Framework_TestCase
+class CacheTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/Github/Tests/HttpClient/BuilderTest.php
+++ b/test/Github/Tests/HttpClient/BuilderTest.php
@@ -7,7 +7,7 @@ use Http\Client\Common\Plugin;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class BuilderTest extends \PHPUnit_Framework_TestCase
+class BuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/test/Github/Tests/HttpClient/Message/ResponseMediatorTest.php
+++ b/test/Github/Tests/HttpClient/Message/ResponseMediatorTest.php
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
+class ResponseMediatorTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetContent()
     {

--- a/test/Github/Tests/Integration/TestCase.php
+++ b/test/Github/Tests/Integration/TestCase.php
@@ -9,7 +9,7 @@ use Github\Exception\RuntimeException;
 /**
  * @group integration
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Client

--- a/test/Github/Tests/ResultPagerTest.php
+++ b/test/Github/Tests/ResultPagerTest.php
@@ -18,7 +18,7 @@ use Http\Client\HttpClient;
  * @author Mitchel Verschoof <mitchel@future500.nl>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ResultPagerTest extends \PHPUnit_Framework_TestCase
+class ResultPagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test


### PR DESCRIPTION
Phpunit 4.x is not supported anymore. So I've upgraded our dependency to ^5.5|^6.0 and used the forward compatibility layer (phpunit 5) for the support of namespaces.