### PR TITLE
Documented all $id parameters in API classes as int

### DIFF
--- a/lib/Github/Api/CurrentUser/Notifications.php
+++ b/lib/Github/Api/CurrentUser/Notifications.php
@@ -75,8 +75,8 @@ class Notifications extends AbstractApi
      *
      * @link http://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read
      *
-     * @param string $id     the notification number
-     * @param array  $params
+     * @param int   $id     the notification number
+     * @param array $params
      *
      * @return array
      */
@@ -90,7 +90,7 @@ class Notifications extends AbstractApi
      *
      * @link http://developer.github.com/v3/activity/notifications/#view-a-single-thread
      *
-     * @param string $id the notification number
+     * @param int $id the notification number
      *
      * @return array
      */
@@ -104,7 +104,7 @@ class Notifications extends AbstractApi
      *
      * @link http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription
      *
-     * @param string $id the notification number
+     * @param int $id the notification number
      *
      * @return array
      */
@@ -118,8 +118,8 @@ class Notifications extends AbstractApi
      *
      * @link http://developer.github.com/v3/activity/notifications/#set-a-thread-subscription
      *
-     * @param string $id     the notification number
-     * @param array  $params
+     * @param int   $id     the notification number
+     * @param array $params
      *
      * @return array
      */
@@ -133,7 +133,7 @@ class Notifications extends AbstractApi
      *
      * @link http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription
      *
-     * @param string $id the notification number
+     * @param int $id the notification number
      *
      * @return array
      */

--- a/lib/Github/Api/CurrentUser/PublicKeys.php
+++ b/lib/Github/Api/CurrentUser/PublicKeys.php
@@ -28,7 +28,7 @@ class PublicKeys extends AbstractApi
      *
      * @link https://developer.github.com/v3/users/keys/
      *
-     * @param string $id
+     * @param int $id
      *
      * @return array
      */
@@ -62,7 +62,7 @@ class PublicKeys extends AbstractApi
      *
      * @link https://developer.github.com/v3/users/keys/
      *
-     * @param string $id
+     * @param int $id
      *
      * @return array
      */

--- a/lib/Github/Api/Deployment.php
+++ b/lib/Github/Api/Deployment.php
@@ -68,8 +68,8 @@ class Deployment extends AbstractApi
      *
      * @param string $username the username
      * @param string $repository the repository
-     * @param string $id the deployment number
-     * @param array $params The information about the deployment update.
+     * @param int    $id the deployment number
+     * @param array  $params The information about the deployment update.
      *                       Must include a "state" field of pending, success, error, or failure.
      *                       May also be given a target_url and description, ßee link for more details.
      * @return array information about the deployment

--- a/lib/Github/Api/Issue.php
+++ b/lib/Github/Api/Issue.php
@@ -104,7 +104,7 @@ class Issue extends AbstractApi
      *
      * @param string $username   the username
      * @param string $repository the repository
-     * @param string $id         the issue number
+     * @param int    $id         the issue number
      *
      * @return array information about the issue
      */
@@ -143,7 +143,7 @@ class Issue extends AbstractApi
      *
      * @param string $username   the username
      * @param string $repository the repository
-     * @param string $id         the issue number
+     * @param int    $id         the issue number
      * @param array  $params     key=>value user attributes to update.
      *                           key can be title or body
      *
@@ -161,7 +161,7 @@ class Issue extends AbstractApi
      *
      * @param string $username
      * @param string $repository
-     * @param string $id
+     * @param int    $id
      *
      * @return string
      */
@@ -177,7 +177,7 @@ class Issue extends AbstractApi
      *
      * @param string $username
      * @param string $repository
-     * @param string $id
+     * @param int    $id
      *
      * @return string
      */

--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -75,7 +75,7 @@ class PullRequest extends AbstractApi
      *
      * @param string $username   the username
      * @param string $repository the repository
-     * @param string $id         the ID of the pull request for which details are retrieved
+     * @param int    $id         the ID of the pull request for which details are retrieved
      *
      * @return array|string pull request details
      */
@@ -101,7 +101,7 @@ class PullRequest extends AbstractApi
      *
      * @param string $username   the username
      * @param string $repository the repository
-     * @param string $id         the ID of the pull request for which statuses are retrieved
+     * @param int    $id         the ID of the pull request for which statuses are retrieved
      *
      * @return array array of statuses for the project
      */


### PR DESCRIPTION
When analyzing code which uses GitHub API, static analyzers like PHPStan may produce false positives like:
```
↪ phpstan analyse -l 7 src tests
 3/3 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------------------------------------------------- 
  Line   src/Changeset.php                                                                     
 ------ -------------------------------------------------------------------------------------- 
  120    Parameter #3 $id of method Github\Api\PullRequest::show() expects string, int given.  
 ------ -------------------------------------------------------------------------------------- 
```
According to the documentation, all changed `$id`s are integers.