### PR TITLE
Changes to documentation in the "Repositories/Content"

### DIFF
--- a/doc/repo/contents.md
+++ b/doc/repo/contents.md
@@ -4,53 +4,53 @@
 ### Get a repository's README
 
 ```php
-$readme = $client->api('repo')->contents()->readme('knp-labs', 'php-github-api', $reference);
+$readme = $client->api('repo')->contents()->readme('KnpLabs', 'php-github-api', $reference);
 ```
 
 ### Get information about a repository file or directory
 
 ```php
-$fileInfo = $client->api('repo')->contents()->show('knp-labs', 'php-github-api', $path, $reference);
+$fileInfo = $client->api('repo')->contents()->show('KnpLabs', 'php-github-api', $path, $reference);
 ```
 
 ### Check that a file or directory exists in the repository
 ```php
-$fileExists = $client->api('repo')->contents()->exists('knp-labs', 'php-github-api', $path, $reference);
+$fileExists = $client->api('repo')->contents()->exists('KnpLabs', 'php-github-api', $path, $reference);
 ```
 
 ### Create a file
 ```php
 $committer = array('name' => 'KnpLabs', 'email' => 'info@knplabs.com');
 
-$fileInfo = $client->api('repo')->contents()->create('knp-labs', 'php-github-api', $path, $content, $commitMessage, $branch, $committer);
+$fileInfo = $client->api('repo')->contents()->create('KnpLabs', 'php-github-api', $path, $content, $commitMessage, $branch, $committer);
 ```
 
 ### Update a file
 
 ```php
 $committer = array('name' => 'KnpLabs', 'email' => 'info@knplabs.com');
-$oldFile = $client->api('repo')->contents()->show('knp-labs', 'php-github-api', $path, $branch);
+$oldFile = $client->api('repo')->contents()->show('KnpLabs', 'php-github-api', $path, $branch);
 
-$fileInfo = $client->api('repo')->contents()->update('knp-labs', 'php-github-api', $path, $content, $commitMessage, $oldFile['sha'], $branch, $committer);
+$fileInfo = $client->api('repo')->contents()->update('KnpLabs', 'php-github-api', $path, $content, $commitMessage, $oldFile['sha'], $branch, $committer);
 ```
 
 ### Remove a file
 
 ```php
 $committer = array('name' => 'KnpLabs', 'email' => 'info@knplabs.com');
-$oldFile = $client->api('repo')->contents()->show('knp-labs', 'php-github-api', $path, $branch);
+$oldFile = $client->api('repo')->contents()->show('KnpLabs', 'php-github-api', $path, $branch);
 
-$fileInfo = $client->api('repo')->contents()->rm('knp-labs', 'php-github-api', $path, $commitMessage, $oldFile['sha'], $branch, $committer);
+$fileInfo = $client->api('repo')->contents()->rm('KnpLabs', 'php-github-api', $path, $commitMessage, $oldFile['sha'], $branch, $committer);
 ```
 
 ### Get repository archive
 
 ```php
-$archive = $client->api('repo')->contents()->archive('knp-labs', 'php-github-api', $format, $reference);
+$archive = $client->api('repo')->contents()->archive('KnpLabs', 'php-github-api', $format, $reference);
 ```
 
 ### Download a file
 
 ```php
-$fileContent = $client->api('repo')->contents()->download('knp-labs', 'php-github-api', $path, $reference);
+$fileContent = $client->api('repo')->contents()->download('KnpLabs', 'php-github-api', $path, $reference);
 ```


### PR DESCRIPTION
Change repository name in the examples from "knp-labs" to the correct name "KnpLabs"