### PR TITLE
added request params and headers to user followers calls

### DIFF
--- a/lib/Github/Api/AbstractApi.php
+++ b/lib/Github/Api/AbstractApi.php
@@ -65,7 +65,7 @@ abstract class AbstractApi implements ApiInterface
      *
      * @return array|string
      */
-    protected function get($path, array $parameters = [], array $requestHeaders = [])
+    protected function get($path, array $parameters = array(), array $requestHeaders = array())
     {
         if (null !== $this->perPage && !isset($parameters['per_page'])) {
             $parameters['per_page'] = $this->perPage;

--- a/lib/Github/Api/AbstractApi.php
+++ b/lib/Github/Api/AbstractApi.php
@@ -65,7 +65,7 @@ abstract class AbstractApi implements ApiInterface
      *
      * @return array|string
      */
-    protected function get($path, array $parameters = array(), array $requestHeaders = array())
+    protected function get($path, array $parameters = [], array $requestHeaders = [])
     {
         if (null !== $this->perPage && !isset($parameters['per_page'])) {
             $parameters['per_page'] = $this->perPage;

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -109,7 +109,7 @@ class User extends AbstractApi
      *
      * @return array list of following users
      */
-    public function followers($username, array $parameters = array(), array $requestHeaders = array())
+    public function followers($username, array $parameters = [], array $requestHeaders = [])
     {
         return $this->get('/users/'.rawurlencode($username).'/followers', $parameters, $requestHeaders);
     }

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -93,7 +93,7 @@ class User extends AbstractApi
      *
      * @return array list of followed users
      */
-    public function following($username, array $parameters = array(), array $requestHeaders = array())
+    public function following($username, array $parameters = [], array $requestHeaders = [])
     {
         return $this->get('/users/'.rawurlencode($username).'/following', $parameters, $requestHeaders);
     }

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -88,12 +88,14 @@ class User extends AbstractApi
      * @link http://developer.github.com/v3/users/followers/
      *
      * @param string $username the username
+     * @param array $parameters parameters for the query string
+     * @param array $requestHeaders additional headers to set in the request
      *
      * @return array list of followed users
      */
-    public function following($username)
+    public function following($username, array $parameters = array(), array $requestHeaders = array())
     {
-        return $this->get('/users/'.rawurlencode($username).'/following');
+        return $this->get('/users/'.rawurlencode($username).'/following', $parameters, $requestHeaders);
     }
 
     /**
@@ -102,12 +104,14 @@ class User extends AbstractApi
      * @link http://developer.github.com/v3/users/followers/
      *
      * @param string $username the username
+     * @param array $parameters parameters for the query string
+     * @param array $requestHeaders additional headers to set in the request
      *
      * @return array list of following users
      */
-    public function followers($username)
+    public function followers($username, array $parameters = array(), array $requestHeaders = array())
     {
-        return $this->get('/users/'.rawurlencode($username).'/followers');
+        return $this->get('/users/'.rawurlencode($username).'/followers', $parameters, $requestHeaders);
     }
 
     /**


### PR DESCRIPTION
This change is a non-breaking way to be able to add parameters and request headers to these two calls. In my honest opinion, this change should be applied to all calls since it allows users an easy way to set custom parameters that GitHub may add even if they don't get implemented in this package immediately. This change also does not affect users who simply use the setPerPage method so it is simply an alternate way to page as well.