### PR TITLE
Mark legacy search methods as deprecated

### DIFF
--- a/lib/Github/Api/Issue.php
+++ b/lib/Github/Api/Issue.php
@@ -60,6 +60,8 @@ class Issue extends AbstractApi
     /**
      * Search issues by username, repo, state and keyword.
      *
+     * @deprecated This method is deprecated use the Search api instead. See https://developer.github.com/v3/search/legacy/#legacy-search-api-is-deprecated
+     *
      * @link http://developer.github.com/v3/search/#search-issues
      *
      * @param string $username   the username

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -31,6 +31,8 @@ class Repo extends AbstractApi
     /**
      * Search repositories by keyword.
      *
+     * @deprecated This method is deprecated use the Search api instead. See https://developer.github.com/v3/search/legacy/#legacy-search-api-is-deprecated
+     *
      * @link http://developer.github.com/v3/search/#search-repositories
      *
      * @param string $keyword the search query

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -14,6 +14,8 @@ class User extends AbstractApi
     /**
      * Search users by username.
      *
+     * @deprecated This method is deprecated use the Search api instead. See https://developer.github.com/v3/search/legacy/#legacy-search-api-is-deprecated
+     *
      * @link http://developer.github.com/v3/search/#search-users
      *
      * @param string $keyword the keyword to search


### PR DESCRIPTION
The legacy search endpoints are deprecated by github, we should also mark these methods as deprecated. See: https://developer.github.com/v3/search/legacy/#legacy-search-api-is-deprecated