### PR TITLE
Fix GitHub Enterprise API Pagination: do not prepend api/vX/ to the path if it already starts that way

### DIFF
--- a/lib/Github/HttpClient/Plugin/PathPrepend.php
+++ b/lib/Github/HttpClient/Plugin/PathPrepend.php
@@ -28,7 +28,9 @@ class PathPrepend implements Plugin
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
         $currentPath = $request->getUri()->getPath();
-        $uri = $request->getUri()->withPath($this->path.$currentPath);
+        if (strpos($currentPath, $this->path) !== 0) {
+            $uri = $request->getUri()->withPath($this->path.$currentPath);
+        }
 
         $request = $request->withUri($uri);
 


### PR DESCRIPTION
Currently pagination does not work on GHE because the next URLs returned for pagination on GHE are absolutely paths which the guzzle plugin will prefix with /api/v3/ leading to URLs starting with /api/v3/api/v3/... resulting in 404 errors.