### PR TITLE
PathPrepend plugin: Only overwrite the request uri if it actually changed

### DIFF
--- a/lib/Github/HttpClient/Plugin/PathPrepend.php
+++ b/lib/Github/HttpClient/Plugin/PathPrepend.php
@@ -30,9 +30,8 @@ class PathPrepend implements Plugin
         $currentPath = $request->getUri()->getPath();
         if (strpos($currentPath, $this->path) !== 0) {
             $uri = $request->getUri()->withPath($this->path.$currentPath);
+            $request = $request->withUri($uri);
         }
-
-        $request = $request->withUri($uri);
 
         return $next($request);
     }


### PR DESCRIPTION
Fix bug introduced in https://github.com/KnpLabs/php-github-api/pull/661