### PR TITLE
Refactoring tests

### DIFF
--- a/test/Github/Tests/Api/Repository/ContentsTest.php
+++ b/test/Github/Tests/Api/Repository/ContentsTest.php
@@ -53,7 +53,7 @@ class ContentsTest extends TestCase
             ->with('/repos/KnpLabs/php-github-api/contents/composer.json', array('ref' => null))
             ->will($this->returnValue($response));
 
-        $this->assertEquals(true, $api->exists('KnpLabs', 'php-github-api', 'composer.json'));
+        $this->assertTrue($api->exists('KnpLabs', 'php-github-api', 'composer.json'));
     }
 
     public function getFailureStubsForExistsTest()

--- a/test/Github/Tests/Integration/RepoTest.php
+++ b/test/Github/Tests/Integration/RepoTest.php
@@ -21,7 +21,7 @@ class RepoTest extends TestCase
 
         $diff = $this->client->api('pull_request')->show('KnpLabs', 'php-github-api', '92');
 
-        $this->assertTrue('string' === gettype($diff));
+        $this->assertInternalType('string', $diff);
     }
 
     /**

--- a/test/Github/Tests/ResultPagerTest.php
+++ b/test/Github/Tests/ResultPagerTest.php
@@ -52,7 +52,7 @@ class ResultPagerTest extends \PHPUnit\Framework\TestCase
         $paginator = new ResultPager($client);
         $result = $paginator->fetchAll($memberApi, $method, $parameters);
 
-        $this->assertEquals($amountLoops * count($content), count($result));
+        $this->assertCount($amountLoops * count($content), $result);
     }
 
     /**
@@ -94,7 +94,7 @@ class ResultPagerTest extends \PHPUnit\Framework\TestCase
         $paginator = new ResultPager($client);
         $result = $paginator->fetchAll($searchApi, $method, array('knplabs'));
 
-        $this->assertEquals($amountLoops * count($content['items']), count($result));
+        $this->assertCount($amountLoops * count($content['items']), $result);
     }
 
     public function testFetch()


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInternalType` instead of `gettype` function;
- `assertTrue` instead of comparison with `true` keyword.