### PR TITLE
Support paginator attributes

### DIFF
--- a/lib/Github/Api/Search.php
+++ b/lib/Github/Api/Search.php
@@ -37,6 +37,8 @@ class Search extends AbstractApi
      * @param string $q     the filter
      * @param string $sort  the sort field
      * @param string $order asc/desc
+     * @param int $page paginator page
+     * @param int $per_page Number of items per page, defaults to 100 Github API limit
      *
      * @return array list of issues found
      */
@@ -56,9 +58,9 @@ class Search extends AbstractApi
      *
      * @return array list of code found
      */
-    public function code($q, $sort = 'updated', $order = 'desc')
+    public function code($q, $sort = 'updated', $order = 'desc', $page = 1, $per_page = 100)
     {
-        return $this->get('/search/code', ['q' => $q, 'sort' => $sort, 'order' => $order]);
+        return $this->get('/search/code', array('q' => $q, 'sort' => $sort, 'order' => $order, 'page' => $page, 'per_page' => $per_page));
     }
 
     /**

--- a/test/Github/Tests/Api/SearchTest.php
+++ b/test/Github/Tests/Api/SearchTest.php
@@ -103,7 +103,7 @@ class SearchTest extends TestCase
             ->method('get')
             ->with(
                 '/search/code',
-                ['q' => 'query text', 'sort' => 'updated', 'order' => 'desc']
+                array('q' => 'query text', 'sort' => 'updated', 'order' => 'desc', 'page' => 1, 'per_page' => 100)
             )
             ->will($this->returnValue($expectedArray));
 


### PR DESCRIPTION
This PR will Add support to the paginator properties page, per_page. Default to the first page and 100 items per page limit.

With this, we can use the ResultPager and pass in the parameters such as `page` and `per_page` to paginate the API results according to https://developer.github.com/v3/guides/traversing-with-pagination/