### PR TITLE
Fix return type

### DIFF
--- a/lib/Github/Api/Repository/Contents.php
+++ b/lib/Github/Api/Repository/Contents.php
@@ -245,7 +245,7 @@ class Contents extends AbstractApi
      * @param string      $format     format of archive: tarball or zipball
      * @param null|string $reference  reference to a branch or commit
      *
-     * @return array information for archives
+     * @return string repository archive binary data
      */
     public function archive($username, $repository, $format, $reference = null)
     {


### PR DESCRIPTION
`\Github\Api\Repository\Contents::archive()` claims to return an array, but in my testing it returns a string.

```php
echo gettype(
    (new \Github\Client())->api('repo')
        ->contents()
        ->archive('twbs', 'bootstrap', 'tarball', 'tags/v4.0.0')
); // `string`
```

I spun up a small test project to test it. [Here's the gist](https://gist.github.com/ptrkcsk/57928b067fbd8303218d5d74d7efab07).
