### PR TITLE
Add missing parameters for User/CurrentUser Repositories

### DIFF
--- a/lib/Github/Api/CurrentUser.php
+++ b/lib/Github/Api/CurrentUser.php
@@ -111,18 +111,22 @@ class CurrentUser extends AbstractApi
     /**
      * @link http://developer.github.com/v3/repos/#list-your-repositories
      *
-     * @param string $type      role in the repository
-     * @param string $sort      sort by
-     * @param string $direction direction of sort, asc or desc
+     * @param string $type          role in the repository
+     * @param string $sort          sort by
+     * @param string $direction     direction of sort, asc or desc
+     * @param string $visibility    visibility of repository
+     * @param string $affiliation   relationship to repository
      *
      * @return array
      */
-    public function repositories($type = 'owner', $sort = 'full_name', $direction = 'asc')
+    public function repositories($type = 'owner', $sort = 'full_name', $direction = 'asc', $visibility = 'all', $affiliation = 'owner,collaborator,organization_member')
     {
         return $this->get('/user/repos', [
             'type' => $type,
             'sort' => $sort,
             'direction' => $direction,
+            'visibility' => $visibility,
+            'affiliation' => $affiliation,
         ]);
     }
 

--- a/lib/Github/Api/CurrentUser.php
+++ b/lib/Github/Api/CurrentUser.php
@@ -111,11 +111,11 @@ class CurrentUser extends AbstractApi
     /**
      * @link http://developer.github.com/v3/repos/#list-your-repositories
      *
-     * @param string $type          role in the repository
-     * @param string $sort          sort by
-     * @param string $direction     direction of sort, asc or desc
-     * @param string $visibility    visibility of repository
-     * @param string $affiliation   relationship to repository
+     * @param string $type        role in the repository
+     * @param string $sort        sort by
+     * @param string $direction   direction of sort, asc or desc
+     * @param string $visibility  visibility of repository
+     * @param string $affiliation relationship to repository
      *
      * @return array
      */

--- a/lib/Github/Api/Repository/Collaborators.php
+++ b/lib/Github/Api/Repository/Collaborators.php
@@ -70,9 +70,11 @@ class Collaborators extends AbstractApi
 
     /**
      * @link https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
+     *
      * @param $username
      * @param $repository
      * @param $collaborator
+     *
      * @return array|string
      */
     public function permission($username, $repository, $collaborator)

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -173,19 +173,23 @@ class User extends AbstractApi
      *
      * @link https://developer.github.com/v3/repos/#list-user-repositories
      *
-     * @param string $username  the username
-     * @param string $type      role in the repository
-     * @param string $sort      sort by
-     * @param string $direction direction of sort, asc or desc
+     * @param string $username      the username
+     * @param string $type          role in the repository
+     * @param string $sort          sort by
+     * @param string $direction     direction of sort, asc or desc
+     * @param string $visibility    visibility of repository
+     * @param string $affiliation   relationship to repository
      *
      * @return array list of the user repositories
      */
-    public function repositories($username, $type = 'owner', $sort = 'full_name', $direction = 'asc')
+    public function repositories($username, $type = 'owner', $sort = 'full_name', $direction = 'asc', $visibility = 'all', $affiliation = 'owner,collaborator,organization_member')
     {
         return $this->get('/users/'.rawurlencode($username).'/repos', [
             'type' => $type,
             'sort' => $sort,
             'direction' => $direction,
+            'visibility' => $visibility,
+            'affiliation' => $affiliation,
         ]);
     }
 

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -173,12 +173,12 @@ class User extends AbstractApi
      *
      * @link https://developer.github.com/v3/repos/#list-user-repositories
      *
-     * @param string $username      the username
-     * @param string $type          role in the repository
-     * @param string $sort          sort by
-     * @param string $direction     direction of sort, asc or desc
-     * @param string $visibility    visibility of repository
-     * @param string $affiliation   relationship to repository
+     * @param string $username    the username
+     * @param string $type        role in the repository
+     * @param string $sort        sort by
+     * @param string $direction   direction of sort, asc or desc
+     * @param string $visibility  visibility of repository
+     * @param string $affiliation relationship to repository
      *
      * @return array list of the user repositories
      */

--- a/test/Github/Tests/Api/Repository/CollaboratorsTest.php
+++ b/test/Github/Tests/Api/Repository/CollaboratorsTest.php
@@ -75,7 +75,7 @@ class CollaboratorsTest extends TestCase
      */
     public function shouldGetRepositoryCollaboratorPermission()
     {
-        $expectedValue = array(array('permission' => 'admin', 'user' => 'l3l0'));
+        $expectedValue = [['permission' => 'admin', 'user' => 'l3l0']];
 
         $api = $this->getApiMock();
         $api->expects($this->once())

--- a/test/Github/Tests/Api/UserTest.php
+++ b/test/Github/Tests/Api/UserTest.php
@@ -194,7 +194,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/users/l3l0/repos', ['type' => 'owner', 'sort' => 'full_name', 'direction' => 'asc'])
+            ->with('/users/l3l0/repos', ['type' => 'owner', 'sort' => 'full_name', 'direction' => 'asc', 'visibility' => 'all', 'affiliation' => 'owner,collaborator,organization_member'])
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->repositories('l3l0'));


### PR DESCRIPTION
Adds `visibility` and `affiliation` filter parameters to the `repositories()` methods on `User` and `CurrentUser`

Github docs: https://developer.github.com/v3/repos/#list-your-repositories

