### PR TITLE
Allow data about our plugin to show up in Symfony debug toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 2.8.0
+
+### Added
+
+- Allow our HTTP plugins to show up in the Symfony web profiler page. 
+
 ## 2.7.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php-http/httplug": "^1.1",
         "php-http/discovery": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "php-http/client-common": "^1.3",
+        "php-http/client-common": "^1.6",
         "php-http/cache-plugin": "^1.4"
     },
     "require-dev": {

--- a/lib/Github/HttpClient/Builder.php
+++ b/lib/Github/HttpClient/Builder.php
@@ -6,6 +6,7 @@ use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin\Cache\Generator\HeaderCacheKeyGenerator;
 use Http\Client\Common\PluginClient;
+use Http\Client\Common\PluginClientFactory;
 use Http\Client\HttpClient;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
@@ -102,7 +103,7 @@ class Builder
             }
 
             $this->pluginClient = new HttpMethodsClient(
-                new PluginClient($this->httpClient, $plugins),
+                (new PluginClientFactory())->createClient($this->httpClient, $plugins),
                 $this->requestFactory
             );
         }


### PR DESCRIPTION
This is a minor change that we need to do in increase the developer experience for Symfony users. This will make our custom plugins visible in the Symfony debug toolbar. 

FYI @fbourigault 