### PR TITLE
Added check to avoid github 422 error

### DIFF
--- a/lib/Github/Api/CurrentUser.php
+++ b/lib/Github/Api/CurrentUser.php
@@ -119,15 +119,25 @@ class CurrentUser extends AbstractApi
      *
      * @return array
      */
-    public function repositories($type = 'owner', $sort = 'full_name', $direction = 'asc', $visibility = 'all', $affiliation = 'owner,collaborator,organization_member')
+    public function repositories($type = 'owner', $sort = 'full_name', $direction = 'asc', $visibility = null, $affiliation = null)
     {
-        return $this->get('/user/repos', [
+        $params = [
             'type' => $type,
             'sort' => $sort,
             'direction' => $direction,
-            'visibility' => $visibility,
-            'affiliation' => $affiliation,
-        ]);
+        ];
+
+        if (null !== $visibility) {
+            unset($params['type']);
+            $params['visibility'] = $visibility;
+        }
+
+        if (null !== $affiliation) {
+            unset($params['type']);
+            $params['affiliation'] = $affiliation;
+        }
+
+        return $this->get('/user/repos', $params);
     }
 
     /**


### PR DESCRIPTION
The parameters introduced in #684 caused a 422 exception response when calling the github api. So I've added some logic to allow these parameters and avoid an unwanted 422 error

Fixes #685 

Can you verify this patch works @GrahamCampbell @hotmeteor? Thanks!