### PR TITLE
Allow unspecified `event` when creating review

### DIFF
--- a/lib/Github/Api/PullRequest/Review.php
+++ b/lib/Github/Api/PullRequest/Review.php
@@ -112,11 +112,7 @@ class Review extends AbstractApi
      */
     public function create($username, $repository, $pullRequest, array $params = [])
     {
-        if (!isset($params['event'])) {
-            throw new MissingArgumentException('event');
-        }
-
-        if (!in_array($params['event'], ['APPROVE', 'REQUEST_CHANGES', 'COMMENT'], true)) {
+        if (array_key_exists('event', $params) && !in_array($params['event'], ['APPROVE', 'REQUEST_CHANGES', 'COMMENT'], true)) {
             throw new InvalidArgumentException(sprintf('"event" must be one of ["APPROVE", "REQUEST_CHANGES", "COMMENT"] ("%s" given).', $params['event']));
         }
 

--- a/test/Github/Tests/Api/PullRequest/ReviewTest.php
+++ b/test/Github/Tests/Api/PullRequest/ReviewTest.php
@@ -212,9 +212,8 @@ class ReviewTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Github\Exception\MissingArgumentException
      */
-    public function shouldNotCreateReviewWithoutEvent()
+    public function shouldCreatePendingReviewWithoutEvent()
     {
         $data = [
             'body' => 'Nice change',
@@ -222,8 +221,9 @@ class ReviewTest extends TestCase
 
         $api = $this->getApiMock();
         $api
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('post')
+            ->with('/repos/octocat/Hello-World/pulls/12/reviews')
         ;
 
         $api->create('octocat', 'Hello-World', 12, $data);


### PR DESCRIPTION
Documentation for `event` in "Create a pull request review" states that "By leaving this blank, you set the review action state to `PENDING`, which means you will need to submit the pull request review when you are ready." This means that omitting `event` is perfectly legal.