### PR TITLE
Add support for "before" parameter on Notification API

### DIFF
--- a/lib/Github/Api/Notification.php
+++ b/lib/Github/Api/Notification.php
@@ -41,7 +41,6 @@ class Notification extends AbstractApi
             $parameters['before'] = $before->format(DateTime::ISO8601);
         }
 
-
         return $this->get('/notifications', $parameters);
     }
 

--- a/lib/Github/Api/Notification.php
+++ b/lib/Github/Api/Notification.php
@@ -26,7 +26,7 @@ class Notification extends AbstractApi
      *
      * @return array array of notifications
      */
-    public function all($includingRead = false, $participating = false, DateTime $since = null)
+    public function all($includingRead = false, $participating = false, DateTime $since = null, DateTime $before = null)
     {
         $parameters = [
             'all' => $includingRead,
@@ -36,6 +36,11 @@ class Notification extends AbstractApi
         if ($since !== null) {
             $parameters['since'] = $since->format(DateTime::ISO8601);
         }
+
+        if ($before !== null) {
+            $parameters['before'] = $before->format(DateTime::ISO8601);
+        }
+
 
         return $this->get('/notifications', $parameters);
     }

--- a/test/Github/Tests/Api/NotificationTest.php
+++ b/test/Github/Tests/Api/NotificationTest.php
@@ -48,6 +48,27 @@ class NotificationTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetNotificationsBefore()
+    {
+        $before = new DateTime('now');
+
+        $parameters = [
+            'all' => false,
+            'participating' => false,
+            'before' => $before->format(DateTime::ISO8601),
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/notifications', $parameters);
+
+        $api->all(false, false, null, $before);
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetNotificationsIncludingAndParticipating()
     {
         $parameters = [


### PR DESCRIPTION
Hello there 👋 

First of all thank you for this package, it's awesome !

Here, I just added the support for `before` parameter on Notification API w/ a simple test to allow better navigation.

Thank you again and keep up the amazing work 💪 