### PR TITLE
Fixed: installation access token endpoint

### DIFF
--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -16,6 +16,8 @@ class Apps extends AbstractApi
      * @param int $userId         An optional user id on behalf of whom the
      *                            token will be requested
      *
+     * @link https://developer.github.com/v3/apps/#create-a-new-installation-token
+     *
      * @return array token and token metadata
      */
     public function createInstallationToken($installationId, $userId = null)
@@ -25,7 +27,7 @@ class Apps extends AbstractApi
             $parameters['user_id'] = $userId;
         }
 
-        return $this->post('/installations/'.rawurlencode($installationId).'/access_tokens', $parameters);
+        return $this->post('/app/installations/'.rawurlencode($installationId).'/access_tokens', $parameters);
     }
 
     /**

--- a/test/Github/Tests/Api/AppTest.php
+++ b/test/Github/Tests/Api/AppTest.php
@@ -7,6 +7,26 @@ class AppTest extends TestCase
     /**
      * @test
      */
+    public function shouldCreateInstallationTokenForInstallation()
+    {
+        $result = [
+            'token' => 'v1.1f699f1069f60xxx',
+            'expires_at' => '2016-07-11T22:14:10Z',
+        ];
+        $installationId = 'installation1';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/app/installations/'.$installationId.'/access_tokens', [])
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->createInstallationToken($installationId));
+    }
+
+    /**
+     * @test
+     */
     public function shouldFindRepositoriesForApplication()
     {
         $result = ['installation1', 'installation2'];


### PR DESCRIPTION
According to GitHub they will remove the old endpoint on September 4th, see: https://developer.github.com/changes/2018-08-16-renaming-and-deprecation-of-github-app-installation-access-token-route/