### PR TITLE
FIX GraphQL test warnings when they do not assert anything

### DIFF
--- a/test/Github/Tests/Api/GraphQLTest.php
+++ b/test/Github/Tests/Api/GraphQLTest.php
@@ -27,7 +27,8 @@ class GraphQLTest extends TestCase
     {
         $api = $this->getApiMock();
 
-        $api->method('post')
+        $api->expects($this->once())
+            ->method('post')
             ->with('/graphql', $this->arrayHasKey('variables'));
 
         $api->execute('bar', ['variable' => 'foo']);
@@ -40,7 +41,8 @@ class GraphQLTest extends TestCase
     {
         $api = $this->getApiMock();
 
-        $api->method('post')
+        $api->expects($this->once())
+            ->method('post')
             ->with('/graphql', $this->equalTo([
                 'query'=>'bar',
                 'variables' => '{"variable":"foo"}',


### PR DESCRIPTION
The tests are giving warnings at the moment because there are no assertions in them, this PR fixes that