### PR TITLE
Convert the issue assignee parameter to array

### DIFF
--- a/lib/Github/Api/Issue/Assignees.php
+++ b/lib/Github/Api/Issue/Assignees.php
@@ -57,6 +57,12 @@ class Assignees extends AbstractApi
             throw new MissingArgumentException('assignees');
         }
 
+        if (!is_array($parameters['assignees'])) {
+            @trigger_error(sprintf('Passing the "assignees" parameter as a string in "%s" is deprecated and will throw an exception in php-github-api version 3.0. Pass an array of strings instead', __METHOD__), E_USER_DEPRECATED);
+
+            $parameters['assignees'] = [$parameters['assignees']];
+        }
+
         return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/assignees', $parameters);
     }
 


### PR DESCRIPTION
The `assignees` parameter should be an array, this will return an exception in the near future. See #737 