### PR TITLE
[Bugfix] Allow symlink to files to be downloaded

### DIFF
--- a/lib/Github/Api/Repository/Contents.php
+++ b/lib/Github/Api/Repository/Contents.php
@@ -276,8 +276,8 @@ class Contents extends AbstractApi
     {
         $file = $this->show($username, $repository, $path, $reference);
 
-        if (!isset($file['type']) || 'file' !== $file['type']) {
-            throw new InvalidArgumentException(sprintf('Path "%s" is not a file.', $path));
+        if (!isset($file['type']) || !in_array($file['type'], ['file', 'symlink'], true)) {
+            throw new InvalidArgumentException(sprintf('Path "%s" is not a file or a symlink to a file.', $path));
         }
 
         if (!isset($file['content'])) {


### PR DESCRIPTION
Fix for #707 to allow symlinks to files to be downloaded through the php api