### PR TITLE
Set method getHttpClientBuilder public

### DIFF
--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -412,7 +412,7 @@ class Client
     /**
      * @return Builder
      */
-    protected function getHttpClientBuilder()
+    public function getHttpClientBuilder()
     {
         return $this->httpClientBuilder;
     }


### PR DESCRIPTION
In some case, it can be useful to handle Plugin **after** Client instantiation on runtime.
For this we need to access to the Builder object through getHttpClientBuilder() method.