### PR TITLE
Corrected error handling in case of 502 GitHub response

### DIFF
--- a/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
+++ b/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
@@ -84,6 +84,17 @@ class GithubExceptionThrower implements Plugin
                 }
             }
 
+            if (502 == $response->getStatusCode() && isset($content['errors']) && is_array($content['errors'])) {
+                $errors = [];
+                foreach ($content['errors'] as $error) {
+                    if (isset($error['message'])) {
+                        $errors[] = $error['message'];
+                    }
+                }
+
+                throw new RuntimeException(implode(', ', $errors), 502);
+            }
+
             throw new RuntimeException(isset($content['message']) ? $content['message'] : $content, $response->getStatusCode());
         });
     }

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Github\Tests\HttpClient\Plugin;
+
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Github\Exception\ExceptionInterface;
+use Github\HttpClient\Plugin\GithubExceptionThrower;
+use GuzzleHttp\Promise\FulfilledPromise;
+
+/**
+ * @author Sergii Ivashchenko <serg.ivashchenko@gmail.com>
+ */
+class GithubExceptionThrowerTest extends TestCase
+{
+    /**
+     * @param ResponseInterface $response
+     * @param ExceptionInterface|\Exception|null $exception
+     * @dataProvider responseProvider
+     */
+    public function testHandleRequest(ResponseInterface $response, ExceptionInterface $exception = null)
+    {
+        /** @var RequestInterface $request */
+        $request = $this->getMockForAbstractClass(RequestInterface::class);
+
+        $promise = $this->getMockBuilder(FulfilledPromise::class)->disableOriginalConstructor()->getMock();
+        $promise->expects($this->once())
+            ->method('then')
+            ->willReturnCallback(function ($callback) use ($response) { return $callback($response); });
+
+        $plugin = new GithubExceptionThrower();
+
+        if ($exception) {
+            $this->expectExceptionObject($exception);
+        }
+
+        $plugin->handleRequest(
+            $request,
+            function (RequestInterface $request) use ($promise) { return $promise; },
+            function (RequestInterface $request) use ($promise) { return $promise; }
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public static function responseProvider()
+    {
+        return [
+            '200 Response' => [
+                'response' => new Response(),
+                'exception' => null,
+            ],
+            'Rate Limit Exceeded' => [
+                'response' => new Response(
+                    429,
+                    [
+                        'Content-Type' => 'application/json',
+                        'X-RateLimit-Remaining' => 0,
+                        'X-RateLimit-Limit' => 5000
+                    ],
+                    ''
+                ),
+                'exception' => new \Github\Exception\ApiLimitExceedException(5000)
+            ],
+            'Two Factor Authentication Required' => [
+                'response' => new Response(
+                    401,
+                    [
+                        'Content-Type' => 'application/json',
+                        'X-GitHub-OTP' => 'required; :2fa-type'
+                    ],
+                    ''
+                ),
+                'exception' => new \Github\Exception\TwoFactorAuthenticationRequiredException('2fa-type')
+            ],
+            '400 Bad Request' => [
+                'response' => new Response(
+                    400,
+                    [
+                        'Content-Type' => 'application/json'
+                    ],
+                    json_encode(
+                        [
+                            'message' => 'Bad Request'
+                        ]
+                    )
+                ),
+                'exception' => new \Github\Exception\ErrorException('Bad Request', 400)
+            ],
+            '422 Unprocessable Entity' => [
+                'response' => new Response(
+                    422,
+                    [
+                        'Content-Type' => 'application/json'
+                    ],
+                    json_encode(
+                        [
+                            'message' => 'Bad Request',
+                            'errors' => [
+                                [
+                                    'code' => 'missing',
+                                    'field' => 'field',
+                                    'value' => 'value',
+                                    'resource' => 'resource'
+                                ]
+                            ]
+                        ]
+                    )
+                ),
+                'exception' => new \Github\Exception\ErrorException('Validation Failed: The field value does not exist, for resource "resource"', 422)
+            ],
+            '502 Response' => [
+                'response' => new Response(
+                    502,
+                    [
+                        'Content-Type' => 'application/json'
+                    ],
+                    json_encode(
+                        [
+                            'errors' => [
+                                ['message' => 'Something went wrong with executing your query']
+                            ]
+                        ]
+                    )
+                ),
+                'exception' => new \Github\Exception\RuntimeException('Something went wrong with executing your query', 502)
+            ],
+            'Default handling' => [
+                'response' => new Response(
+                    555,
+                    [],
+                    'Error message'
+                ),
+                'exception' => new \Github\Exception\RuntimeException('Error message', 555)
+            ],
+        ];
+    }
+}

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -35,7 +35,9 @@ class GithubExceptionThrowerTest extends TestCase
         $plugin = new GithubExceptionThrower();
 
         if ($exception) {
-            $this->expectExceptionObject($exception);
+            $this->expectException(get_class($exception));
+            $this->expectExceptionCode($exception->getCode());
+            $this->expectExceptionMessage($exception->getMessage());
         }
 
         $plugin->handleRequest(

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -2,13 +2,13 @@
 
 namespace Github\Tests\HttpClient\Plugin;
 
+use Github\Exception\ExceptionInterface;
+use Github\HttpClient\Plugin\GithubExceptionThrower;
+use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Github\Exception\ExceptionInterface;
-use Github\HttpClient\Plugin\GithubExceptionThrower;
-use GuzzleHttp\Promise\FulfilledPromise;
 
 /**
  * @author Sergii Ivashchenko <serg.ivashchenko@gmail.com>
@@ -16,7 +16,7 @@ use GuzzleHttp\Promise\FulfilledPromise;
 class GithubExceptionThrowerTest extends TestCase
 {
     /**
-     * @param ResponseInterface $response
+     * @param ResponseInterface                  $response
      * @param ExceptionInterface|\Exception|null $exception
      * @dataProvider responseProvider
      */
@@ -28,7 +28,9 @@ class GithubExceptionThrowerTest extends TestCase
         $promise = $this->getMockBuilder(FulfilledPromise::class)->disableOriginalConstructor()->getMock();
         $promise->expects($this->once())
             ->method('then')
-            ->willReturnCallback(function ($callback) use ($response) { return $callback($response); });
+            ->willReturnCallback(function ($callback) use ($response) {
+                return $callback($response);
+            });
 
         $plugin = new GithubExceptionThrower();
 
@@ -38,8 +40,12 @@ class GithubExceptionThrowerTest extends TestCase
 
         $plugin->handleRequest(
             $request,
-            function (RequestInterface $request) use ($promise) { return $promise; },
-            function (RequestInterface $request) use ($promise) { return $promise; }
+            function (RequestInterface $request) use ($promise) {
+                return $promise;
+            },
+            function (RequestInterface $request) use ($promise) {
+                return $promise;
+            }
         );
     }
 
@@ -59,42 +65,42 @@ class GithubExceptionThrowerTest extends TestCase
                     [
                         'Content-Type' => 'application/json',
                         'X-RateLimit-Remaining' => 0,
-                        'X-RateLimit-Limit' => 5000
+                        'X-RateLimit-Limit' => 5000,
                     ],
                     ''
                 ),
-                'exception' => new \Github\Exception\ApiLimitExceedException(5000)
+                'exception' => new \Github\Exception\ApiLimitExceedException(5000),
             ],
             'Two Factor Authentication Required' => [
                 'response' => new Response(
                     401,
                     [
                         'Content-Type' => 'application/json',
-                        'X-GitHub-OTP' => 'required; :2fa-type'
+                        'X-GitHub-OTP' => 'required; :2fa-type',
                     ],
                     ''
                 ),
-                'exception' => new \Github\Exception\TwoFactorAuthenticationRequiredException('2fa-type')
+                'exception' => new \Github\Exception\TwoFactorAuthenticationRequiredException('2fa-type'),
             ],
             '400 Bad Request' => [
                 'response' => new Response(
                     400,
                     [
-                        'Content-Type' => 'application/json'
+                        'Content-Type' => 'application/json',
                     ],
                     json_encode(
                         [
-                            'message' => 'Bad Request'
+                            'message' => 'Bad Request',
                         ]
                     )
                 ),
-                'exception' => new \Github\Exception\ErrorException('Bad Request', 400)
+                'exception' => new \Github\Exception\ErrorException('Bad Request', 400),
             ],
             '422 Unprocessable Entity' => [
                 'response' => new Response(
                     422,
                     [
-                        'Content-Type' => 'application/json'
+                        'Content-Type' => 'application/json',
                     ],
                     json_encode(
                         [
@@ -104,29 +110,29 @@ class GithubExceptionThrowerTest extends TestCase
                                     'code' => 'missing',
                                     'field' => 'field',
                                     'value' => 'value',
-                                    'resource' => 'resource'
-                                ]
-                            ]
+                                    'resource' => 'resource',
+                                ],
+                            ],
                         ]
                     )
                 ),
-                'exception' => new \Github\Exception\ErrorException('Validation Failed: The field value does not exist, for resource "resource"', 422)
+                'exception' => new \Github\Exception\ErrorException('Validation Failed: The field value does not exist, for resource "resource"', 422),
             ],
             '502 Response' => [
                 'response' => new Response(
                     502,
                     [
-                        'Content-Type' => 'application/json'
+                        'Content-Type' => 'application/json',
                     ],
                     json_encode(
                         [
                             'errors' => [
-                                ['message' => 'Something went wrong with executing your query']
-                            ]
+                                ['message' => 'Something went wrong with executing your query'],
+                            ],
                         ]
                     )
                 ),
-                'exception' => new \Github\Exception\RuntimeException('Something went wrong with executing your query', 502)
+                'exception' => new \Github\Exception\RuntimeException('Something went wrong with executing your query', 502),
             ],
             'Default handling' => [
                 'response' => new Response(
@@ -134,7 +140,7 @@ class GithubExceptionThrowerTest extends TestCase
                     [],
                     'Error message'
                 ),
-                'exception' => new \Github\Exception\RuntimeException('Error message', 555)
+                'exception' => new \Github\Exception\RuntimeException('Error message', 555),
             ],
         ];
     }


### PR DESCRIPTION
In case when  GitHub returns a 502 response, the structure of returned content is not handled by `GithubExceptionThrower` correctly and results in the following error:

    PHP Fatal error:  Uncaught Error: Wrong parameters for Github\Exception\RuntimeException([string $message [, long $code [, Throwable $previous = NULL]]]) in /var/www/html/vendor/knplabs/github-api/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php:87
    Stack trace:
    #0 /var/www/html/vendor/knplabs/github-api/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php(87): Exception->__construct(Array, 502)
    #1 /var/www/html/vendor/php-http/httplug/src/Promise/HttpFulfilledPromise.php(34): Github\HttpClient\Plugin\GithubExceptionThrower->Github\HttpClient\Plugin\{closure}(Object(GuzzleHttp\Psr7\Response))
    #2 /var/www/html/vendor/knplabs/github-api/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php(88): Http\Client\Promise\HttpFulfilledPromise->then(Object(Closure))
    #3 /var/www/html/vendor/php-http/client-common/src/PluginClient.php(160): Github\HttpClient\Plugin\GithubExceptionThrower->handleRequest(Object(GuzzleHttp\Psr7\Request), Object(Closure), Object(Closure))
    #4 /var/www/html/vendor/php-http/client-common/src/PluginClie in /var/www/html/vendor/knplabs/github-api/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php on line 87

That happen i.e. when trying to do too many GraphQL requests in a short period of time.

See debug screenshot:

![image](https://user-images.githubusercontent.com/2028541/49868995-b50c8680-fe17-11e8-82ff-4ab7b997b442.png)

Added a proper handling.

