### PR TITLE
Fixes for API $params

### DIFF
--- a/lib/Github/Api/Authorizations.php
+++ b/lib/Github/Api/Authorizations.php
@@ -2,6 +2,8 @@
 
 namespace Github\Api;
 
+use Github\Exception\MissingArgumentException;
+
 /**
  * Creating, deleting and listing authorizations.
  *
@@ -43,6 +45,10 @@ class Authorizations extends AbstractApi
      */
     public function create(array $params, $OTPCode = null)
     {
+        if (!isset($params['note'])) {
+            throw new MissingArgumentException(['note']);
+        }
+
         $headers = null === $OTPCode ? [] : ['X-GitHub-OTP' => $OTPCode];
 
         return $this->post('/authorizations', $params, $headers);

--- a/lib/Github/Api/CurrentUser/Notifications.php
+++ b/lib/Github/Api/CurrentUser/Notifications.php
@@ -81,7 +81,7 @@ class Notifications extends AbstractApi
      *
      * @return array
      */
-    public function markAsRead($id, array $params)
+    public function markAsRead($id, array $params = [])
     {
         return $this->patch('/notifications/threads/'.rawurlencode($id), $params);
     }
@@ -124,7 +124,7 @@ class Notifications extends AbstractApi
      *
      * @return array
      */
-    public function createSubscription($id, array $params)
+    public function createSubscription($id, array $params = [])
     {
         return $this->put('/notifications/threads/'.rawurlencode($id).'/subscription', $params);
     }

--- a/lib/Github/Api/PullRequest/Review.php
+++ b/lib/Github/Api/PullRequest/Review.php
@@ -134,7 +134,7 @@ class Review extends AbstractApi
      *
      * @return array the pull request review
      */
-    public function submit($username, $repository, $pullRequest, $id, array $params = [])
+    public function submit($username, $repository, $pullRequest, $id, array $params)
     {
         if (!isset($params['event'])) {
             throw new MissingArgumentException('event');

--- a/lib/Github/Api/Repository/Commits.php
+++ b/lib/Github/Api/Repository/Commits.php
@@ -11,7 +11,7 @@ use Github\Api\AbstractApi;
  */
 class Commits extends AbstractApi
 {
-    public function all($username, $repository, array $params)
+    public function all($username, $repository, array $params = [])
     {
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits', $params);
     }

--- a/lib/Github/Api/Repository/Statuses.php
+++ b/lib/Github/Api/Repository/Statuses.php
@@ -52,7 +52,7 @@ class Statuses extends AbstractApi
      *
      * @return array
      */
-    public function create($username, $repository, $sha, array $params = [])
+    public function create($username, $repository, $sha, array $params)
     {
         if (!isset($params['state'])) {
             throw new MissingArgumentException('state');

--- a/test/Github/Tests/Api/AuthorizationsTest.php
+++ b/test/Github/Tests/Api/AuthorizationsTest.php
@@ -39,6 +39,21 @@ class AuthorizationsTest extends TestCase
 
     /**
      * @test
+     * @expectedException \Github\Exception\MissingArgumentException
+     */
+    public function shouldNotAuthorizationWithoutNote()
+    {
+        $input = [];
+
+        $api = $this->getApiMock();
+        $api->expects($this->never())
+            ->method('post');
+
+        $api->create($input);
+    }
+
+    /**
+     * @test
      */
     public function shouldAuthorization()
     {


### PR DESCRIPTION
Make sure `$params` are optional when they're not required, and a `Github\Exception\MissingArgumentException` is thrown when one is missing.