### PR TITLE
[POC] Describe request\response models as objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "php-http/discovery": "^1.0",
         "php-http/client-implementation": "^1.0",
         "php-http/client-common": "^1.6",
-        "php-http/cache-plugin": "^1.4"
+        "php-http/cache-plugin": "^1.4",
+        "makasim/values": "^0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.5 || ^6.0",

--- a/lib/Github/Api/Repository/Forks.php
+++ b/lib/Github/Api/Repository/Forks.php
@@ -3,6 +3,8 @@
 namespace Github\Api\Repository;
 
 use Github\Api\AbstractApi;
+use Github\Model\Fork;
+use function Makasim\Values\set_values;
 
 /**
  * @link   http://developer.github.com/v3/repos/forks/
@@ -11,17 +13,38 @@ use Github\Api\AbstractApi;
  */
 class Forks extends AbstractApi
 {
+    /**
+     * @return Fork[]
+     */
     public function all($username, $repository, array $params = [])
     {
         if (isset($params['sort']) && !in_array($params['sort'], ['newest', 'oldest', 'watchers'])) {
             $params['sort'] = 'newest';
         }
 
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/forks', array_merge(['page' => 1], $params));
+        $rawForks = $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/forks', array_merge(['page' => 1], $params));
+
+        $forks = [];
+        foreach ($rawForks as $rawFork) {
+            $fork = new Fork();
+            set_values($fork, $rawFork);
+
+            $forks[] = $fork;
+        }
+
+        return $forks;
     }
 
+    /**
+     * @return Fork
+     */
     public function create($username, $repository, array $params = [])
     {
-        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/forks', $params);
+        $rawFork = $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/forks', $params);
+
+        $fork = new Fork();
+        set_values($fork, $rawFork);
+
+        return $fork;
     }
 }

--- a/lib/Github/Api/Repository/Stargazers.php
+++ b/lib/Github/Api/Repository/Stargazers.php
@@ -4,6 +4,8 @@ namespace Github\Api\Repository;
 
 use Github\Api\AbstractApi;
 use Github\Api\AcceptHeaderTrait;
+use Github\Model\User;
+use function Makasim\Values\set_values;
 
 /**
  * @link   https://developer.github.com/v3/activity/starring/#list-stargazers
@@ -33,8 +35,21 @@ class Stargazers extends AbstractApi
         return $this;
     }
 
+    /**
+     * @return User[]
+     */
     public function all($username, $repository)
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/stargazers');
+        $rawStargazers = $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/stargazers');
+
+        $stargazers = [];
+        foreach ($rawStargazers as $rawStargazer) {
+            $stargazer = new User();
+            set_values($stargazer, $rawStargazer);
+
+            $stargazers[] = $stargazer;
+        }
+
+        return $stargazers;
     }
 }

--- a/lib/Github/Api/Search.php
+++ b/lib/Github/Api/Search.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Github\Api;
+
 use Github\Model\SearchIssuesResult;
 use function Makasim\Values\set_values;
 

--- a/lib/Github/Api/Search.php
+++ b/lib/Github/Api/Search.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Github\Api;
+use Github\Model\SearchIssuesResult;
+use function Makasim\Values\set_values;
 
 /**
  * Implement the Search API.
@@ -38,11 +40,16 @@ class Search extends AbstractApi
      * @param string $sort  the sort field
      * @param string $order asc/desc
      *
-     * @return array list of issues found
+     * @return SearchIssuesResult
      */
     public function issues($q, $sort = 'updated', $order = 'desc')
     {
-        return $this->get('/search/issues', ['q' => $q, 'sort' => $sort, 'order' => $order]);
+        $rawResult = $this->get('/search/issues', ['q' => $q, 'sort' => $sort, 'order' => $order]);
+
+        $result = new SearchIssuesResult();
+        set_values($result, $rawResult);
+
+        return $result;
     }
 
     /**

--- a/lib/Github/Model/Fork.php
+++ b/lib/Github/Model/Fork.php
@@ -60,7 +60,7 @@ class Fork
 
     public function getUrl()
     {
-        return get_value($this, 'fork');
+        return get_value($this, 'url');
     }
 
     public function getForksUrl()

--- a/lib/Github/Model/Fork.php
+++ b/lib/Github/Model/Fork.php
@@ -1,0 +1,381 @@
+<?php
+namespace Github\Model;
+
+use function Makasim\Values\get_object;
+use function Makasim\Values\get_value;
+
+class Fork
+{
+    private $values = [];
+
+    private $objects = [];
+
+    public function getId()
+    {
+        return get_value($this, 'id');
+    }
+
+    public function getNodeId()
+    {
+        return get_value($this, 'node_id');
+    }
+
+    public function getName()
+    {
+        return get_value($this, 'name');
+    }
+
+    public function getFullName()
+    {
+        return get_value($this, 'full_name');
+    }
+
+    public function isPrivate()
+    {
+        return get_value($this, 'private');
+    }
+
+    /**
+     * @return User
+     */
+    public function getOwner()
+    {
+        return get_object($this, 'owner', User::class);
+    }
+
+    public function getHtmlUrl()
+    {
+        return get_value($this, 'html_url');
+    }
+
+    public function getDescription()
+    {
+        return get_value($this, 'description');
+    }
+
+    public function isFork()
+    {
+        return get_value($this, 'fork');
+    }
+
+    public function getUrl()
+    {
+        return get_value($this, 'fork');
+    }
+
+    public function getForksUrl()
+    {
+        return get_value($this, 'forks_url');
+    }
+
+    public function getKeysUrl()
+    {
+        return get_value($this, 'keys_url');
+    }
+
+    public function getCollaboratorsUrl()
+    {
+        return get_value($this, 'collaborators_url');
+    }
+
+    public function getTeamsUrl()
+    {
+        return get_value($this, 'teams_url');
+    }
+
+    public function getHooksUrl()
+    {
+        return get_value($this, 'hooks_url');
+    }
+
+    public function getIssueEventsUrl()
+    {
+        return get_value($this, 'issue_events_url');
+    }
+
+    public function getEventsUrl()
+    {
+        return get_value($this, 'events_url');
+    }
+
+    public function getAssigneesUrl()
+    {
+        return get_value($this, 'assignees_url');
+    }
+
+    public function getBranchesUrl()
+    {
+        return get_value($this, 'branches_url');
+    }
+
+    public function getTagsUrl()
+    {
+        return get_value($this, 'tags_url');
+    }
+
+    public function getBlobsUrl()
+    {
+        return get_value($this, 'blobs_url');
+    }
+
+    public function getGitTagsUrl()
+    {
+        return get_value($this, 'git_tags_url');
+    }
+
+    public function getGitRefsUrl()
+    {
+        return get_value($this, 'git_refs_url');
+    }
+
+    public function getTreesUrl()
+    {
+        return get_value($this, 'trees_url');
+    }
+
+    public function getStatusesUrl()
+    {
+        return get_value($this, 'statuses_url');
+    }
+
+    public function getLanguagesUrl()
+    {
+        return get_value($this, 'languages_url');
+    }
+
+    public function getStargazersUrl()
+    {
+        return get_value($this, 'stargazers_url');
+    }
+
+    public function getContributorsUrl()
+    {
+        return get_value($this, 'contributors_url');
+    }
+
+    public function getSubscribersUrl()
+    {
+        return get_value($this, 'subscribers_url');
+    }
+
+    public function getSubscriptionUrl()
+    {
+        return get_value($this, 'subscription_url');
+    }
+
+    public function getCommitsUrl()
+    {
+        return get_value($this, 'commits_url');
+    }
+
+    public function getGitCommitsUrl()
+    {
+        return get_value($this, 'git_commits_url');
+    }
+
+    public function getCommentsUrl()
+    {
+        return get_value($this, 'comments_url');
+    }
+
+    public function getIssueCommentUrl()
+    {
+        return get_value($this, 'issue_comment_url');
+    }
+
+    public function getContentsUrl()
+    {
+        return get_value($this, 'contents_url');
+    }
+
+    public function getCompareUrl()
+    {
+        return get_value($this, 'compare_url');
+    }
+
+    public function getMergesUrl()
+    {
+        return get_value($this, 'merges_url');
+    }
+
+    public function getArchiveUrl()
+    {
+        return get_value($this, 'archive_url');
+    }
+
+    public function getDownloadsUrl()
+    {
+        return get_value($this, 'downloads_url');
+    }
+
+    public function getIssuesUrl()
+    {
+        return get_value($this, 'issues_url');
+    }
+
+    public function getPullsUrl()
+    {
+        return get_value($this, 'pulls_url');
+    }
+
+    public function getMilestonesUrl()
+    {
+        return get_value($this, 'milestones_url');
+    }
+
+    public function getNotificationsUrl()
+    {
+        return get_value($this, 'notifications_url');
+    }
+
+    public function getLabelsUrl()
+    {
+        return get_value($this, 'labels_url');
+    }
+
+    public function getReleasesUrl()
+    {
+        return get_value($this, 'releases_url');
+    }
+
+    public function getDeploymentsUrl()
+    {
+        return get_value($this, 'deployments_url');
+    }
+
+    public function getCreatedAt()
+    {
+        return get_value($this, 'created_at');
+    }
+
+    public function getUpdatedAt()
+    {
+        return get_value($this, 'updated_at');
+    }
+
+    public function getPushedAt()
+    {
+        return get_value($this, 'pushed_at');
+    }
+
+    public function getGitUrl()
+    {
+        return get_value($this, 'git_url');
+    }
+
+    public function getSshUrl()
+    {
+        return get_value($this, 'ssh_url');
+    }
+
+    public function getCloneUrl()
+    {
+        return get_value($this, 'clone_url');
+    }
+
+    public function getSvnUrl()
+    {
+        return get_value($this, 'svn_url');
+    }
+
+    public function getHomepage()
+    {
+        return get_value($this, 'homepage');
+    }
+
+    public function getSize()
+    {
+        return get_value($this, 'size');
+    }
+
+    public function getStargazersCount()
+    {
+        return get_value($this, 'stargazers_count');
+    }
+
+    public function getWatchersCount()
+    {
+        return get_value($this, 'watchers_count');
+    }
+
+    public function hasIssues()
+    {
+        return get_value($this, 'has_issues');
+    }
+
+    public function hasProjects()
+    {
+        return get_value($this, 'has_projects');
+    }
+
+    public function hasDownloads()
+    {
+        return get_value($this, 'has_downloads');
+    }
+
+    public function hasWiki()
+    {
+        return get_value($this, 'has_wiki');
+    }
+
+    public function hasPages()
+    {
+        return get_value($this, 'has_pages');
+    }
+
+    public function getForksCount()
+    {
+        return get_value($this, 'forks_count');
+    }
+
+    public function getMirrorUrl()
+    {
+        return get_value($this, 'mirror_url');
+    }
+
+    public function getArchived()
+    {
+        return get_value($this, 'archived');
+    }
+
+    public function getOpenIssuesCount()
+    {
+        return get_value($this, 'open_issues_count');
+    }
+
+    /**
+     * @return License
+     */
+    public function getLicense()
+    {
+        return get_object($this, 'license', License::class);
+    }
+
+    public function getForks()
+    {
+        return get_value($this, 'forks');
+    }
+
+    public function getOpenIssues()
+    {
+        return get_value($this, 'open_issues');
+    }
+
+    public function getWatchers()
+    {
+        return get_value($this, 'watchers');
+    }
+
+    public function getDefaultBranch()
+    {
+        return get_value($this, 'default_branch');
+    }
+
+    /**
+     * @return Permissions
+     */
+    public function getPermissions()
+    {
+        return get_object($this, 'permissions', Permissions::class);
+    }
+}

--- a/lib/Github/Model/Fork.php
+++ b/lib/Github/Model/Fork.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Github\Model;
 
 use function Makasim\Values\get_object;

--- a/lib/Github/Model/Issue.php
+++ b/lib/Github/Model/Issue.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Github\Model;
 
 use function Makasim\Values\get_object;

--- a/lib/Github/Model/Issue.php
+++ b/lib/Github/Model/Issue.php
@@ -5,7 +5,7 @@ use function Makasim\Values\get_object;
 use function Makasim\Values\get_objects;
 use function Makasim\Values\get_value;
 
-class Issue
+final class Issue
 {
     private $values = [];
 

--- a/lib/Github/Model/Issue.php
+++ b/lib/Github/Model/Issue.php
@@ -1,0 +1,135 @@
+<?php
+namespace Github\Model;
+
+use function Makasim\Values\get_object;
+use function Makasim\Values\get_objects;
+use function Makasim\Values\get_value;
+
+class Issue
+{
+    private $values = [];
+
+    private $objects = [];
+
+    public function getUrl()
+    {
+        return get_value($this, 'url');
+    }
+
+    public function getRepositoryUrl()
+    {
+        return get_value($this, 'repository_url');
+    }
+
+    public function getLabelsUrl()
+    {
+        return get_value($this, 'labels_url');
+    }
+
+    public function getCommentsUrl()
+    {
+        return get_value($this, 'comments_url');
+    }
+
+    public function getEventsUrl()
+    {
+        return get_value($this, 'events_url');
+    }
+
+    public function getHtmlUrl()
+    {
+        return get_value($this, 'html_url');
+    }
+
+    public function getId()
+    {
+        return get_value($this, 'id');
+    }
+
+    public function getNodeId()
+    {
+        return get_value($this, 'node_id');
+    }
+
+    public function getNumber()
+    {
+        return get_value($this, 'number');
+    }
+
+    public function getTitle()
+    {
+        return get_value($this, 'title');
+    }
+
+    /**
+     * @return User
+     */
+    public function getUser()
+    {
+        return get_object($this, 'user', User::class);
+    }
+
+    /**
+     * @return Label[]
+     */
+    public function getLabels()
+    {
+        return get_objects($this, 'labels', Label::class);
+    }
+
+    public function getState()
+    {
+        return get_value($this, 'state');
+    }
+
+    /**
+     * @return User
+     */
+    public function getAssignee()
+    {
+        return get_object($this, 'assignee', User::class);
+    }
+
+    public function getMilestone()
+    {
+        return get_value($this, 'milestone');
+    }
+
+    public function getComments()
+    {
+        return get_value($this, 'comments');
+    }
+
+    public function getCreatedAt()
+    {
+        return get_value($this, 'created_at');
+    }
+
+    public function getUpdatedAt()
+    {
+        return get_value($this, 'updated_at');
+    }
+
+    public function getClosedAt()
+    {
+        return get_value($this, 'closed_at');
+    }
+
+    /**
+     * @return PullRequest
+     */
+    public function getPullRequest()
+    {
+        return get_object($this, 'pull_request', PullRequest::class);
+    }
+
+    public function getBody()
+    {
+        return get_value($this, 'body');
+    }
+
+    public function getScore()
+    {
+        return get_value($this, 'score');
+    }
+}

--- a/lib/Github/Model/Label.php
+++ b/lib/Github/Model/Label.php
@@ -3,7 +3,7 @@ namespace Github\Model;
 
 use function Makasim\Values\get_value;
 
-class Label
+final class Label
 {
     private $values = [];
 

--- a/lib/Github/Model/Label.php
+++ b/lib/Github/Model/Label.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Github\Model;
 
 use function Makasim\Values\get_value;

--- a/lib/Github/Model/Label.php
+++ b/lib/Github/Model/Label.php
@@ -1,0 +1,36 @@
+<?php
+namespace Github\Model;
+
+use function Makasim\Values\get_value;
+
+class Label
+{
+    private $values = [];
+
+    private $objects = [];
+
+    public function getId()
+    {
+        return get_value($this, 'id');
+    }
+
+    public function getNodeId()
+    {
+        return get_value($this, 'node_id');
+    }
+
+    public function getUrl()
+    {
+        return get_value($this, 'url');
+    }
+
+    public function getName()
+    {
+        return get_value($this, 'name');
+    }
+
+    public function getColor()
+    {
+        return get_value($this, 'color');
+    }
+}

--- a/lib/Github/Model/License.php
+++ b/lib/Github/Model/License.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Github\Model;
 
 use function Makasim\Values\get_value;

--- a/lib/Github/Model/License.php
+++ b/lib/Github/Model/License.php
@@ -1,0 +1,34 @@
+<?php
+namespace Github\Model;
+
+use function Makasim\Values\get_value;
+
+class License
+{
+    private $values = [];
+
+    public function getKey()
+    {
+        return get_value($this, 'key');
+    }
+
+    public function getName()
+    {
+        return get_value($this, 'name');
+    }
+
+    public function getSpdxId()
+    {
+        return get_value($this, 'spdx_id');
+    }
+
+    public function getUrl()
+    {
+        return get_value($this, 'url');
+    }
+
+    public function getNodeId()
+    {
+        return get_value($this, 'node_id');
+    }
+}

--- a/lib/Github/Model/License.php
+++ b/lib/Github/Model/License.php
@@ -3,7 +3,7 @@ namespace Github\Model;
 
 use function Makasim\Values\get_value;
 
-class License
+final class License
 {
     private $values = [];
 

--- a/lib/Github/Model/Permissions.php
+++ b/lib/Github/Model/Permissions.php
@@ -1,0 +1,24 @@
+<?php
+namespace Github\Model;
+
+use function Makasim\Values\get_value;
+
+class Permissions
+{
+    private $values = [];
+
+    public function isAdmin()
+    {
+        return get_value($this, 'admin');
+    }
+
+    public function isPush()
+    {
+        return get_value($this, 'push');
+    }
+
+    public function isPull()
+    {
+        return get_value($this, 'pull');
+    }
+}

--- a/lib/Github/Model/Permissions.php
+++ b/lib/Github/Model/Permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Github\Model;
 
 use function Makasim\Values\get_value;

--- a/lib/Github/Model/PullRequest.php
+++ b/lib/Github/Model/PullRequest.php
@@ -1,0 +1,24 @@
+<?php
+namespace Github\Model;
+
+use function Makasim\Values\get_value;
+
+class PullRequest
+{
+    private $values = [];
+
+    public function getHtmlUrl()
+    {
+        return get_value($this, 'html_url');
+    }
+
+    public function getDiffUrl()
+    {
+        return get_value($this, 'diff_url');
+    }
+
+    public function getPatchUrl()
+    {
+        return get_value($this, 'patch_url');
+    }
+}

--- a/lib/Github/Model/PullRequest.php
+++ b/lib/Github/Model/PullRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Github\Model;
 
 use function Makasim\Values\get_value;

--- a/lib/Github/Model/SearchIssuesResult.php
+++ b/lib/Github/Model/SearchIssuesResult.php
@@ -1,0 +1,30 @@
+<?php
+namespace Github\Model;
+
+use function Makasim\Values\get_objects;
+use function Makasim\Values\get_value;
+
+class SearchIssuesResult
+{
+    private $values = [];
+
+    private $objects = [];
+
+    public function getTotalCount()
+    {
+        return get_value($this, 'total_count');
+    }
+
+    public function getIncompleteResults()
+    {
+        return get_value($this, 'incomplete_results');
+    }
+
+    /**
+     * @return Issue[]
+     */
+    public function getItems()
+    {
+        return iterator_to_array(get_objects($this, 'items', Issue::class));
+    }
+}

--- a/lib/Github/Model/SearchIssuesResult.php
+++ b/lib/Github/Model/SearchIssuesResult.php
@@ -4,7 +4,7 @@ namespace Github\Model;
 use function Makasim\Values\get_objects;
 use function Makasim\Values\get_value;
 
-class SearchIssuesResult
+final class SearchIssuesResult
 {
     private $values = [];
 

--- a/lib/Github/Model/SearchIssuesResult.php
+++ b/lib/Github/Model/SearchIssuesResult.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Github\Model;
 
 use function Makasim\Values\get_objects;

--- a/lib/Github/Model/User.php
+++ b/lib/Github/Model/User.php
@@ -1,0 +1,99 @@
+<?php
+namespace Github\Model;
+
+use function Makasim\Values\get_value;
+
+class User
+{
+    private $values = [];
+
+    public function getLogin()
+    {
+        return get_value($this, 'login');
+    }
+
+    public function getId()
+    {
+        return get_value($this, 'id');
+    }
+
+    public function getNodeId()
+    {
+        return get_value($this, 'node_id');
+    }
+
+    public function getAvatarUrl()
+    {
+        return get_value($this, 'avatar_url');
+    }
+
+    public function getGravatarUrl()
+    {
+        return get_value($this, 'gravatar_id');
+    }
+
+    public function getUrl()
+    {
+        return get_value($this, 'url');
+    }
+
+    public function getHtmlUrl()
+    {
+        return get_value($this, 'html_url');
+    }
+
+    public function getFollowersUrl()
+    {
+        return get_value($this, 'followers_url');
+    }
+
+    public function getFollowingUrl()
+    {
+        return get_value($this, 'following_url');
+    }
+
+    public function getGistsUrl()
+    {
+        return get_value($this, 'gists_url');
+    }
+
+    public function getStarredUrl()
+    {
+        return get_value($this, 'starred_url');
+    }
+
+    public function getSubscriptionsUrl()
+    {
+        return get_value($this, 'subscriptions_url');
+    }
+
+    public function getOrganizationsUrl()
+    {
+        return get_value($this, 'organizations_url');
+    }
+
+    public function getReposUrl()
+    {
+        return get_value($this, 'repos_url');
+    }
+
+    public function getEventsUrl()
+    {
+        return get_value($this, 'events_url');
+    }
+
+    public function getReceivedEventsUrl()
+    {
+        return get_value($this, 'received_events_url');
+    }
+
+    public function getType()
+    {
+        return get_value($this, 'type');
+    }
+
+    public function isSiteAdmin()
+    {
+        return get_value($this, 'site_admin');
+    }
+}

--- a/lib/Github/Model/User.php
+++ b/lib/Github/Model/User.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Github\Model;
 
 use function Makasim\Values\get_value;

--- a/lib/Github/Model/User.php
+++ b/lib/Github/Model/User.php
@@ -3,7 +3,7 @@ namespace Github\Model;
 
 use function Makasim\Values\get_value;
 
-class User
+final class User
 {
     private $values = [];
 

--- a/lib/Github/ResultPager.php
+++ b/lib/Github/ResultPager.php
@@ -5,7 +5,6 @@ namespace Github;
 use Github\Api\ApiInterface;
 use Github\Api\Search;
 use Github\HttpClient\Message\ResponseMediator;
-use function Makasim\Values\set_objects;
 use function Makasim\Values\set_values;
 
 /**
@@ -86,7 +85,7 @@ class ResultPager implements ResultPagerInterface
 
             if ($isSearch && is_object($result)) {
                 $result = $result->getItems();
-            } else if ($isSearch) {
+            } elseif ($isSearch) {
                 $result = isset($result['items']) ? $result['items'] : $result;
             }
 
@@ -96,11 +95,11 @@ class ResultPager implements ResultPagerInterface
                 if ($isSearch && is_object($result)) {
                     $resultClass = get_class($result);
 
-                    $nextResult = new $resultClass;
+                    $nextResult = new $resultClass();
                     set_values($nextResult, $next);
 
                     $result = array_merge($result, $nextResult->getItems());
-                } else if ($isSearch) {
+                } elseif ($isSearch) {
                     $result = array_merge($result, $next['items']);
                 } else {
                     $result = array_merge($result, $next);

--- a/lib/Github/ResultPager.php
+++ b/lib/Github/ResultPager.php
@@ -5,6 +5,8 @@ namespace Github;
 use Github\Api\ApiInterface;
 use Github\Api\Search;
 use Github\HttpClient\Message\ResponseMediator;
+use function Makasim\Values\set_objects;
+use function Makasim\Values\set_values;
 
 /**
  * Pager class for supporting pagination in github classes.
@@ -82,14 +84,23 @@ class ResultPager implements ResultPagerInterface
             $result = $this->callApi($api, $method, $parameters);
             $this->postFetch();
 
-            if ($isSearch) {
+            if ($isSearch && is_object($result)) {
+                $result = $result->getItems();
+            } else if ($isSearch) {
                 $result = isset($result['items']) ? $result['items'] : $result;
             }
 
             while ($this->hasNext()) {
                 $next = $this->fetchNext();
 
-                if ($isSearch) {
+                if ($isSearch && is_object($result)) {
+                    $resultClass = get_class($result);
+
+                    $nextResult = new $resultClass;
+                    set_values($nextResult, $next);
+
+                    $result = array_merge($result, $nextResult->getItems());
+                } else if ($isSearch) {
                     $result = array_merge($result, $next['items']);
                 } else {
                     $result = array_merge($result, $next);


### PR DESCRIPTION
Right now, the API methods send and return plain arrays. 

This approach is simple but has some disadvantages:

* Hard to tell what fields an array  might have
* There is no autocomplete for available methods and properties. 
* Could not be used as a type hint in user code. 

I propose to introduce such models as array wrappers. [formapro/telegram-bot](https://github.com/formapro/telegram-bot-php)  is an example of such approach.

I could work on such addition. Would you be interested in such an addition?

* There is no serialization\deserialization logic
* It comes with no performance cost. 
* Easy to use
* Explicit API 