### PR TITLE
Update httplug and related packages version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,12 @@ env:
     - TEST_COMMAND="vendor/bin/phpunit --verbose --coverage-text"
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
 
 matrix:
   include:
-    - php: hhvm
-      dist: trusty
     - php: 7.2
       name: Backward compatibillity check
       env: DEPENDENCIES="roave/backward-compatibility-check" TEST_COMMAND="./vendor/bin/roave-backward-compatibility-check"

--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,18 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "psr/http-message": "^1.0",
         "psr/cache": "^1.0",
-        "php-http/httplug": "^1.1",
+        "php-http/httplug": "^2.0",
         "php-http/discovery": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "php-http/client-common": "^1.6",
+        "php-http/client-common": "^2.0",
         "php-http/cache-plugin": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.5 || ^6.0",
-        "php-http/guzzle6-adapter": "^1.0",
+        "php-http/guzzle6-adapter": "^2.0",
         "php-http/mock-client": "^1.0",
         "guzzlehttp/psr7": "^1.2",
         "cache/array-adapter": "^0.4"

--- a/lib/Github/HttpClient/Plugin/Authentication.php
+++ b/lib/Github/HttpClient/Plugin/Authentication.php
@@ -5,6 +5,7 @@ namespace Github\HttpClient\Plugin;
 use Github\Client;
 use Github\Exception\RuntimeException;
 use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -28,7 +29,7 @@ class Authentication implements Plugin
     /**
      * {@inheritdoc}
      */
-    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         switch ($this->method) {
             case Client::AUTH_HTTP_PASSWORD:

--- a/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
+++ b/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
@@ -9,6 +9,7 @@ use Github\Exception\TwoFactorAuthenticationRequiredException;
 use Github\Exception\ValidationFailedException;
 use Github\HttpClient\Message\ResponseMediator;
 use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -21,7 +22,7 @@ class GithubExceptionThrower implements Plugin
     /**
      * {@inheritdoc}
      */
-    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         return $next($request)->then(function (ResponseInterface $response) use ($request) {
             if ($response->getStatusCode() < 400 || $response->getStatusCode() > 600) {

--- a/lib/Github/HttpClient/Plugin/History.php
+++ b/lib/Github/HttpClient/Plugin/History.php
@@ -3,7 +3,7 @@
 namespace Github\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin\Journal;
-use Http\Client\Exception;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -32,7 +32,7 @@ class History implements Journal
         $this->lastResponse = $response;
     }
 
-    public function addFailure(RequestInterface $request, Exception $exception)
+    public function addFailure(RequestInterface $request, ClientExceptionInterface $exception)
     {
     }
 }

--- a/lib/Github/HttpClient/Plugin/PathPrepend.php
+++ b/lib/Github/HttpClient/Plugin/PathPrepend.php
@@ -3,6 +3,7 @@
 namespace Github\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -25,7 +26,7 @@ class PathPrepend implements Plugin
     /**
      * {@inheritdoc}
      */
-    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $currentPath = $request->getUri()->getPath();
         if (strpos($currentPath, $this->path) !== 0) {

--- a/test/Github/Tests/Api/AbstractApiTest.php
+++ b/test/Github/Tests/Api/AbstractApiTest.php
@@ -4,6 +4,7 @@ namespace Github\Tests\Api;
 
 use Github\Api\AbstractApi;
 use GuzzleHttp\Psr7\Response;
+use Http\Client\Common\HttpMethodsClientInterface;
 
 class AbstractApiTest extends TestCase
 {
@@ -213,9 +214,7 @@ class AbstractApiTest extends TestCase
     protected function getHttpMethodsMock(array $methods = [])
     {
         $methods = array_merge(['sendRequest'], $methods);
-        $mock = $this->getMockBuilder(\Http\Client\Common\HttpMethodsClient::class)
-            ->disableOriginalConstructor()
-            ->setMethods($methods)
+        $mock = $this->getMockBuilder(HttpMethodsClientInterface::class)
             ->getMock();
         $mock
             ->expects($this->any())

--- a/test/Github/Tests/HttpClient/PathPrependTest.php
+++ b/test/Github/Tests/HttpClient/PathPrependTest.php
@@ -4,6 +4,8 @@ namespace Github\Tests\HttpClient\Plugin;
 
 use Github\HttpClient\Plugin\PathPrepend;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Http\Promise\FulfilledPromise;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,6 +24,8 @@ class PathPrependTest extends TestCase
         $newRequest = null;
         $plugin->handleRequest($request, function ($request) use (&$newRequest) {
             $newRequest = $request;
+
+            return new FulfilledPromise(new Response());
         }, function () {
             throw new \RuntimeException('Did not expect plugin to call first');
         });

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -4,8 +4,9 @@ namespace Github\Tests\HttpClient\Plugin;
 
 use Github\Exception\ExceptionInterface;
 use Github\HttpClient\Plugin\GithubExceptionThrower;
-use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
+use Http\Promise\FulfilledPromise;
+use Http\Promise\Promise;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -25,11 +26,11 @@ class GithubExceptionThrowerTest extends TestCase
         /** @var RequestInterface $request */
         $request = $this->getMockForAbstractClass(RequestInterface::class);
 
-        $promise = $this->getMockBuilder(FulfilledPromise::class)->disableOriginalConstructor()->getMock();
+        $promise = $this->getMockBuilder(Promise::class)->getMock();
         $promise->expects($this->once())
             ->method('then')
             ->willReturnCallback(function ($callback) use ($response) {
-                return $callback($response);
+                return new FulfilledPromise($callback($response));
             });
 
         $plugin = new GithubExceptionThrower();


### PR DESCRIPTION
Update httplug to ^2.0 and related packages.

On this PullRequest, I did the following task.

* Update httplug, php-http/client-common, guzzle6-adapter
* Drop PHP 5.6 support and only support ^7.1 because client-common support ^7.1
* Fix test for above changes