### PR TITLE
Allow tags to be created without the tagger object.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ php:
 
 matrix:
   include:
-    - php: hhvm
-      dist: trusty
     - php: 7.2
       name: Backward compatibillity check
       env: DEPENDENCIES="roave/backward-compatibility-check" TEST_COMMAND="./vendor/bin/roave-backward-compatibility-check"

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "2.11.x-dev"
+            "dev-master": "2.12.x-dev"
         }
     }
 }

--- a/lib/Github/Api/GitData/Tags.php
+++ b/lib/Github/Api/GitData/Tags.php
@@ -56,11 +56,7 @@ class Tags extends AbstractApi
             throw new MissingArgumentException(['tag', 'message', 'object', 'type']);
         }
 
-        if (!isset($params['tagger'])) {
-            throw new MissingArgumentException('tagger');
-        }
-
-        if (!isset($params['tagger']['name'], $params['tagger']['email'], $params['tagger']['date'])) {
+        if (isset($params['tagger']) && !isset($params['tagger']['name'], $params['tagger']['email'], $params['tagger']['date'])) {
             throw new MissingArgumentException(['tagger.name', 'tagger.email', 'tagger.date']);
         }
 

--- a/test/Github/Tests/Api/GitData/TagsTest.php
+++ b/test/Github/Tests/Api/GitData/TagsTest.php
@@ -89,9 +89,8 @@ class TagsTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Github\Exception\MissingArgumentException
      */
-    public function shouldNotCreateTagWithoutTaggerParam()
+    public function shouldCreateTagWithoutTaggerParam()
     {
         $data = [
             'message' => 'some message',
@@ -101,7 +100,7 @@ class TagsTest extends TestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects($this->never())
+        $api->expects($this->once())
             ->method('post');
 
         $api->create('KnpLabs', 'php-github-api', $data);


### PR DESCRIPTION
The GitHub API does not require the `tagger` object when creating a new tag:

https://developer.github.com/v3/git/tags/#create-a-tag-object

This PR updates the create tag method to only check if the `tagger` properties are set when the `tagger` object is passed.