### PR TITLE
Drop hhvm support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ php:
 
 matrix:
   include:
-    - php: hhvm
-      dist: trusty
     - php: 7.2
       name: Backward compatibillity check
       env: DEPENDENCIES="roave/backward-compatibility-check" TEST_COMMAND="./vendor/bin/roave-backward-compatibility-check"

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "2.11.x-dev"
+            "dev-master": "2.12.x-dev"
         }
     }
 }


### PR DESCRIPTION
The build is currently failing and hhvm is not widely used. So let's drop support for hhvm like other major frameworks and libraries do.