### PR TITLE
Add support for updating descriptions in the Labels API

### DIFF
--- a/lib/Github/Api/Issue/Labels.php
+++ b/lib/Github/Api/Issue/Labels.php
@@ -100,17 +100,20 @@ class Labels extends AbstractApi
      * @param string $username
      * @param string $repository
      * @param string $label
-     * @param string $newName
-     * @param string $color
+     * @param array  $params
+     *
+     * @throws \Github\Exception\MissingArgumentException
      *
      * @return array
      */
-    public function update($username, $repository, $label, $newName, $color)
+    public function update($username, $repository, $label, array $params)
     {
-        $params = [
-            'name'  => $newName,
-            'color' => $color,
-        ];
+        if (!isset($params['name'])) {
+            throw new MissingArgumentException('name');
+        }
+        if (!isset($params['color'])) {
+            throw new MissingArgumentException('color');
+        }
 
         return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels/'.rawurlencode($label), $params);
     }


### PR DESCRIPTION
This mimics the functionality provided in creating a label, it enables the functionality for labels to be updated _with_ changing descriptions.

The way this is structured **is a breaking change**. If that's not ideal, simply adding a new optional description parameter to the function would solve the problem without breaking anything.

Closes #785 