### PR TITLE
Add Ability to Update a Pull Request Review

### DIFF
--- a/doc/pull_request/reviews.md
+++ b/doc/pull_request/reviews.md
@@ -44,3 +44,8 @@ $client->api('pull_request')->reviews()->remove('twbs', 'bootstrap', 12, $review
 ```php
 $client->api('pull_request')->reviews()->remove('twbs', 'bootstrap', 12, $reviewId);
 ```
+
+### Update a review
+```php
+$client->api('pull_request')->reviews()->update('twbs', 'bootstrap', 12, $reviewId, 'Review body (mandatory)')
+```

--- a/lib/Github/Api/PullRequest/Review.php
+++ b/lib/Github/Api/PullRequest/Review.php
@@ -174,4 +174,32 @@ class Review extends AbstractApi
           'message' => $message,
         ]);
     }
+
+    /**
+     * Update a pull request review by the username, repository, pull request number and the review id.
+     *
+     * @link https://developer.github.com/v3/pulls/reviews/#update-a-pull-request-review
+     *
+     * @param string $username    the username
+     * @param string $repository  the repository
+     * @param int    $pullRequest the pull request number
+     * @param int    $id          the review id
+     * @param string $body        a mandatory dismissal message
+     *
+     * @return array|string
+     */
+    public function update($username, $repository, $pullRequest, $id, $body)
+    {
+        if (!is_string($body)) {
+            throw new InvalidArgumentException(sprintf('"body" must be a valid string ("%s" given).', gettype($body)));
+        }
+
+        if (empty($body)) {
+            throw new InvalidArgumentException('"body" is mandatory and cannot be empty');
+        }
+
+        return $this->put('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.$pullRequest.'/reviews/'.$id, [
+            'body' => $body
+        ]);
+    }
 }

--- a/lib/Github/Api/PullRequest/Review.php
+++ b/lib/Github/Api/PullRequest/Review.php
@@ -199,7 +199,7 @@ class Review extends AbstractApi
         }
 
         return $this->put('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.$pullRequest.'/reviews/'.$id, [
-            'body' => $body
+            'body' => $body,
         ]);
     }
 }

--- a/test/Github/Tests/Api/PullRequest/ReviewTest.php
+++ b/test/Github/Tests/Api/PullRequest/ReviewTest.php
@@ -401,7 +401,7 @@ class ReviewTest extends TestCase
     {
         $expectedValue = [
             'id' => 80,
-            "node_id" => "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            'node_id' => 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=',
             'user' => [
                 'login' => 'octocat',
                 'id' => 1,

--- a/test/Github/Tests/Api/PullRequest/ReviewTest.php
+++ b/test/Github/Tests/Api/PullRequest/ReviewTest.php
@@ -394,6 +394,59 @@ class ReviewTest extends TestCase
         $this->assertSame($expectedValue, $api->dismiss('octocat', 'Hello-World', 12, 80, 'Dismiss reason'));
     }
 
+    /**
+     * @test
+     */
+    public function shouldUpdateReviewComment()
+    {
+        $expectedValue = [
+            'id' => 80,
+            "node_id" => "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+            'user' => [
+                'login' => 'octocat',
+                'id' => 1,
+                'avatar_url' => 'https://github.com/images/error/octocat_happy.gif',
+                'gravatar_id' => '',
+                'url' => 'https://api.github.com/users/octocat',
+                'html_url' => 'https://github.com/octocat',
+                'followers_url' => 'https://api.github.com/users/octocat/followers',
+                'following_url' => 'https://api.github.com/users/octocat/following{/other_user}',
+                'gists_url' => 'https://api.github.com/users/octocat/gists{/gist_id}',
+                'starred_url' => 'https://api.github.com/users/octocat/starred{/owner}{/repo}',
+                'subscriptions_url' => 'https://api.github.com/users/octocat/subscriptions',
+                'organizations_url' => 'https://api.github.com/users/octocat/orgs',
+                'repos_url' => 'https://api.github.com/users/octocat/repos',
+                'events_url' => 'https://api.github.com/users/octocat/events{/privacy}',
+                'received_events_url' => 'https://api.github.com/users/octocat/received_events',
+                'type' => 'User',
+                'site_admin' => false,
+            ],
+            'body' => 'Great stuff',
+            'commit_id' => 'ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091',
+            'state' => 'CHANGES_REQUESTED',
+            'html_url' => 'https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80',
+            'pull_request_url' => 'https://api.github.com/repos/octocat/Hello-World/pulls/12',
+            '_links' => [
+                'html' => [
+                    'href' => 'https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80',
+                ],
+                'pull_request' => [
+                    'href' => 'https://api.github.com/repos/octocat/Hello-World/pulls/12',
+                ],
+            ],
+        ];
+        $body = 'Nice change';
+
+        $api = $this->getApiMock();
+        $api
+            ->expects($this->once())
+            ->method('put')
+            ->with('/repos/octocat/Hello-World/pulls/12/reviews/80')
+            ->willReturn($expectedValue);
+
+        $this->assertSame($expectedValue, $api->update('octocat', 'Hello-World', 12, 80, $body));
+    }
+
     protected function getApiClass()
     {
         return Review::class;


### PR DESCRIPTION
Adding an `update` function to `Github\Api\PullRequest\Review` to support editing a pull request summary comment (see GitHub docs [here](https://developer.github.com/v3/pulls/reviews/#update-a-pull-request-review)).