### PR TITLE
Change DeployKeys::update method to match GitHub API

### DIFF
--- a/lib/Github/Api/Repository/DeployKeys.php
+++ b/lib/Github/Api/Repository/DeployKeys.php
@@ -37,7 +37,9 @@ class DeployKeys extends AbstractApi
             throw new MissingArgumentException(['title', 'key']);
         }
 
-        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/keys/'.rawurlencode($id), $params);
+        $this->remove($username, $repository, $id);
+
+        return $this->create($username, $repository, $params);
     }
 
     public function remove($username, $repository, $id)

--- a/test/Github/Tests/Api/Repository/DeployKeysTest.php
+++ b/test/Github/Tests/Api/Repository/DeployKeysTest.php
@@ -6,153 +6,161 @@ use Github\Tests\Api\TestCase;
 
 class DeployKeysTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function shouldGetAllRepositoryDeployKeys()
-    {
-        $expectedValue = [['name' => 'key']];
+	/**
+	 * @test
+	 */
+	public function shouldGetAllRepositoryDeployKeys()
+	{
+		$expectedValue = [['name' => 'key']];
 
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('/repos/KnpLabs/php-github-api/keys')
-            ->will($this->returnValue($expectedValue));
+		$api = $this->getApiMock();
+		$api->expects($this->once())
+		    ->method('get')
+		    ->with('/repos/KnpLabs/php-github-api/keys')
+		    ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
-    }
+		$this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));
+	}
 
-    /**
-     * @test
-     */
-    public function shouldShowDeployKey()
-    {
-        $expectedValue = ['key' => 'somename'];
+	/**
+	 * @test
+	 */
+	public function shouldShowDeployKey()
+	{
+		$expectedValue = ['key' => 'somename'];
 
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('/repos/KnpLabs/php-github-api/keys/123')
-            ->will($this->returnValue($expectedValue));
+		$api = $this->getApiMock();
+		$api->expects($this->once())
+		    ->method('get')
+		    ->with('/repos/KnpLabs/php-github-api/keys/123')
+		    ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
-    }
+		$this->assertEquals($expectedValue, $api->show('KnpLabs', 'php-github-api', 123));
+	}
 
-    /**
-     * @test
-     */
-    public function shouldRemoveDeployKey()
-    {
-        $expectedValue = ['someOutput'];
+	/**
+	 * @test
+	 */
+	public function shouldRemoveDeployKey()
+	{
+		$expectedValue = ['someOutput'];
 
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('delete')
-            ->with('/repos/KnpLabs/php-github-api/keys/123')
-            ->will($this->returnValue($expectedValue));
+		$api = $this->getApiMock();
+		$api->expects($this->once())
+		    ->method('delete')
+		    ->with('/repos/KnpLabs/php-github-api/keys/123')
+		    ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123));
-    }
+		$this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123));
+	}
 
-    /**
-     * @test
-     * @expectedException \Github\Exception\MissingArgumentException
-     */
-    public function shouldNotCreateDeployKeyWithoutName()
-    {
-        $data = ['config' => 'conf'];
+	/**
+	 * @test
+	 * @expectedException \Github\Exception\MissingArgumentException
+	 */
+	public function shouldNotCreateDeployKeyWithoutName()
+	{
+		$data = ['config' => 'conf'];
 
-        $api = $this->getApiMock();
-        $api->expects($this->never())
-            ->method('post');
+		$api = $this->getApiMock();
+		$api->expects($this->never())
+		    ->method('post');
 
-        $api->create('KnpLabs', 'php-github-api', $data);
-    }
+		$api->create('KnpLabs', 'php-github-api', $data);
+	}
 
-    /**
-     * @test
-     * @expectedException \Github\Exception\MissingArgumentException
-     */
-    public function shouldNotCreateDeployKeyWithoutColor()
-    {
-        $data = ['name' => 'test'];
+	/**
+	 * @test
+	 * @expectedException \Github\Exception\MissingArgumentException
+	 */
+	public function shouldNotCreateDeployKeyWithoutColor()
+	{
+		$data = ['name' => 'test'];
 
-        $api = $this->getApiMock();
-        $api->expects($this->never())
-            ->method('post');
+		$api = $this->getApiMock();
+		$api->expects($this->never())
+		    ->method('post');
 
-        $api->create('KnpLabs', 'php-github-api', $data);
-    }
+		$api->create('KnpLabs', 'php-github-api', $data);
+	}
 
-    /**
-     * @test
-     */
-    public function shouldCreateDeployKey()
-    {
-        $expectedValue = ['key' => 'somename'];
-        $data = ['title' => 'test', 'key' => 'ssh-rsa 1231234232'];
+	/**
+	 * @test
+	 */
+	public function shouldCreateDeployKey()
+	{
+		$expectedValue = ['key' => 'somename'];
+		$data = ['title' => 'test', 'key' => 'ssh-rsa 1231234232'];
 
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('post')
-            ->with('/repos/KnpLabs/php-github-api/keys', $data)
-            ->will($this->returnValue($expectedValue));
+		$api = $this->getApiMock();
+		$api->expects($this->once())
+		    ->method('post')
+		    ->with('/repos/KnpLabs/php-github-api/keys', $data)
+		    ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
-    }
+		$this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', $data));
+	}
 
-    /**
-     * @test
-     * @expectedException \Github\Exception\MissingArgumentException
-     */
-    public function shouldNotUpdateDeployKeyWithoutTitle()
-    {
-        $data = ['key' => 'ssh-rsa 12323213'];
+	/**
+	 * @test
+	 * @expectedException \Github\Exception\MissingArgumentException
+	 */
+	public function shouldNotUpdateDeployKeyWithoutTitle()
+	{
+		$data = ['key' => 'ssh-rsa 12323213'];
 
-        $api = $this->getApiMock();
-        $api->expects($this->never())
-            ->method('patch');
+		$api = $this->getApiMock();
+		$api->expects($this->never())
+		    ->method('remove');
+		$api->expects($this->never())
+		    ->method('create');
 
-        $api->update('KnpLabs', 'php-github-api', 123, $data);
-    }
+		$api->update('KnpLabs', 'php-github-api', 123, $data);
+	}
 
-    /**
-     * @test
-     * @expectedException \Github\Exception\MissingArgumentException
-     */
-    public function shouldNotUpdateDeployKeyWithoutKey()
-    {
-        $data = ['title' => 'test'];
+	/**
+	 * @test
+	 * @expectedException \Github\Exception\MissingArgumentException
+	 */
+	public function shouldNotUpdateDeployKeyWithoutKey()
+	{
+		$data = ['title' => 'test'];
 
-        $api = $this->getApiMock();
-        $api->expects($this->never())
-            ->method('patch');
+		$api = $this->getApiMock();
+		$api->expects($this->never())
+		    ->method('remove');
+		$api->expects($this->never())
+		    ->method('create');
 
-        $api->update('KnpLabs', 'php-github-api', 123, $data);
-    }
+		$api->update('KnpLabs', 'php-github-api', 123, $data);
+	}
 
-    /**
-     * @test
-     */
-    public function shouldUpdateDeployKey()
-    {
-        $expectedValue = ['key' => 'somename'];
-        $data = ['title' => 'test', 'key' => 'ssh-rsa 12312312321...'];
+	/**
+	 * @test
+	 */
+	public function shouldUpdateDeployKey()
+	{
+		$expectedValue = ['key' => 'somename'];
+		$data = ['title' => 'test', 'key' => 'ssh-rsa 12312312321...'];
 
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('patch')
-            ->with('/repos/KnpLabs/php-github-api/keys/123', $data)
-            ->will($this->returnValue($expectedValue));
+		$api = $this->getApiMock();
+		$api->expects($this->once())
+		    ->method('delete')
+		    ->with('/repos/KnpLabs/php-github-api/keys/123')
+		    ->will($this->returnValue($expectedValue));
+		$api->expects($this->once())
+		    ->method('post')
+		    ->with('/repos/KnpLabs/php-github-api/keys', $data)
+		    ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 123, $data));
-    }
+		$this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 123, $data));
+	}
 
-    /**
-     * @return string
-     */
-    protected function getApiClass()
-    {
-        return \Github\Api\Repository\DeployKeys::class;
-    }
+	/**
+	 * @return string
+	 */
+	protected function getApiClass()
+	{
+		return \Github\Api\Repository\DeployKeys::class;
+	}
 }

--- a/test/Github/Tests/Api/Repository/DeployKeysTest.php
+++ b/test/Github/Tests/Api/Repository/DeployKeysTest.php
@@ -110,10 +110,10 @@ class DeployKeysTest extends TestCase
         $data = ['key' => 'ssh-rsa 12323213'];
 
         $api = $this->getApiMock();
-	    $api->expects($this->never())
-	        ->method('delete');
-	    $api->expects($this->never())
-	        ->method('post');
+        $api->expects($this->never())
+            ->method('delete');
+        $api->expects($this->never())
+            ->method('post');
 
         $api->update('KnpLabs', 'php-github-api', 123, $data);
     }
@@ -144,14 +144,14 @@ class DeployKeysTest extends TestCase
         $data = ['title' => 'test', 'key' => 'ssh-rsa 12312312321...'];
 
         $api = $this->getApiMock();
-	    $api->expects($this->once())
-	        ->method('delete')
-	        ->with('/repos/KnpLabs/php-github-api/keys/123')
-	        ->will($this->returnValue($expectedValue));
-	    $api->expects($this->once())
-	        ->method('post')
-	        ->with('/repos/KnpLabs/php-github-api/keys', $data)
-	        ->will($this->returnValue($expectedValue));
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('/repos/KnpLabs/php-github-api/keys/123')
+            ->will($this->returnValue($expectedValue));
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/KnpLabs/php-github-api/keys', $data)
+            ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->update('KnpLabs', 'php-github-api', 123, $data));
     }


### PR DESCRIPTION
There is an inconsistency between the client and the GitHub API, where when trying to `update` a deploy key on a repo, the client simply calls `patch`, but [this is not supported by the GitHub API](https://developer.github.com/v3/repos/keys/#edit-a-deploy-key), so a suitable workaround would instead be to call `remove` and then `create`.

I have created the pull request that provides this workaround now, and have altered the `DeployKeysTest` file to match.

Alternatively, to avoid deciding on this behaviour for the user, you could just remove the `update` method entirely, though I imagine this would be a breaking change.
