### PR TITLE
Allow httplug 2.0

### DIFF
--- a/.github/bc-test.sh
+++ b/.github/bc-test.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+#
+# This file is a hack to suppress warnings from Roave BC check
+#
+
+echo "Running..."
+
+# Capture output to variable
+OUTPUT=$(./vendor/bin/roave-backward-compatibility-check 2>&1)
+echo "$OUTPUT"
+
+# Remove rows we want to suppress
+OUTPUT=`echo "$OUTPUT" | sed '/The return type of Github\\\HttpClient\\\Plugin\\\Authentication#handleRequest() changed from no type to Http\\\Promise\\\Promise/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/The return type of Github\\\HttpClient\\\Plugin\\\Authentication#handleRequest() changed from no type to Http\\\Promise\\\Promise/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/The parameter $exception of Github\\\HttpClient\\\Plugin\\\History#addFailure() changed from Http\\\Client\\\Exception to a non-contravariant Psr\\\Http\\\Client\\\ClientExceptionInterface/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/The parameter $exception of Github\\\HttpClient\\\Plugin\\\History#addFailure() changed from Http\\\Client\\\Exception to Psr\\\Http\\\Client\\\ClientExceptionInterface/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/The return type of Github\\\HttpClient\\\Plugin\\\PathPrepend#handleRequest() changed from no type to Http\\\Promise\\\Promise/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/The return type of Github\\\HttpClient\\\Plugin\\\GithubExceptionThrower#handleRequest() changed from no type to Http\\\Promise\\\Promise/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/Method getMessage() was added to interface Github\\\Exception\\\ExceptionInterface/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/Method getCode() was added to interface Github\\\Exception\\\ExceptionInterface/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/Method getFile() was added to interface Github\\\Exception\\\ExceptionInterface/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/Method getLine() was added to interface Github\\\Exception\\\ExceptionInterface/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/Method getTrace() was added to interface Github\\\Exception\\\ExceptionInterface/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/Method getPrevious() was added to interface Github\\\Exception\\\ExceptionInterface/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/Method getTraceAsString() was added to interface Github\\\Exception\\\ExceptionInterface/'d`
+OUTPUT=`echo "$OUTPUT" | sed '/Method __toString() was added to interface Github\\\Exception\\\ExceptionInterface/'d`
+
+# Number of rows we found with "[BC]" in them
+BC_BREAKS=`echo "$OUTPUT" | grep -o '\[BC\]' | wc -l | awk '{ print $1 }'`
+
+# The last row of the output is "X backwards-incompatible changes detected". Find X.
+STATED_BREAKS=`echo "$OUTPUT" | tail -n 1 | awk -F' ' '{ print $1 }'`
+
+# If
+#   We found "[BC]" in the command output after we removed suppressed lines
+# OR
+#   We have suppressed X number of BC breaks. If $STATED_BREAKS is larger than X
+# THEN
+#   exit 1
+
+if [ $BC_BREAKS -gt 0 ] || [ $STATED_BREAKS -gt 13 ]; then
+    echo "EXIT 1"
+    exit 1
+fi
+
+# No BC breaks found
+echo "EXIT 0"
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 cache:
   directories:
-    - vendor
     - $HOME/.composer/cache
 
 env:
@@ -19,7 +18,7 @@ matrix:
   include:
     - php: 7.2
       name: Backward compatibillity check
-      env: DEPENDENCIES="roave/backward-compatibility-check" TEST_COMMAND="./vendor/bin/roave-backward-compatibility-check"
+      env: DEPENDENCIES="roave/backward-compatibility-check" TEST_COMMAND="./.github/bc-test.sh"
 
 before_install:
     - if ! [ -z "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
         "php": "^7.1",
         "psr/http-message": "^1.0",
         "psr/cache": "^1.0",
-        "php-http/httplug": "^1.1",
+        "php-http/httplug": "^1.1 || ^2.0",
         "php-http/discovery": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "php-http/client-common": "^1.6",
+        "php-http/client-common": "^1.6 || ^2.0",
         "php-http/cache-plugin": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0 || ^8.0",
-        "php-http/guzzle6-adapter": "^1.0",
-        "php-http/mock-client": "^1.0",
+        "php-http/guzzle6-adapter": "^1.0 || ^2.0",
+        "php-http/mock-client": "^1.2",
         "guzzlehttp/psr7": "^1.2",
         "cache/array-adapter": "^0.4"
     },

--- a/lib/Github/HttpClient/Plugin/Authentication.php
+++ b/lib/Github/HttpClient/Plugin/Authentication.php
@@ -14,6 +14,8 @@ use Psr\Http\Message\RequestInterface;
  */
 class Authentication implements Plugin
 {
+    use Plugin\VersionBridgePlugin;
+
     private $tokenOrLogin;
     private $password;
     private $method;
@@ -28,7 +30,7 @@ class Authentication implements Plugin
     /**
      * {@inheritdoc}
      */
-    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    public function doHandleRequest(RequestInterface $request, callable $next, callable $first)
     {
         switch ($this->method) {
             case Client::AUTH_HTTP_PASSWORD:

--- a/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
+++ b/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
@@ -18,10 +18,12 @@ use Psr\Http\Message\ResponseInterface;
  */
 class GithubExceptionThrower implements Plugin
 {
+    use Plugin\VersionBridgePlugin;
+
     /**
      * {@inheritdoc}
      */
-    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    public function doHandleRequest(RequestInterface $request, callable $next, callable $first)
     {
         return $next($request)->then(function (ResponseInterface $response) use ($request) {
             if ($response->getStatusCode() < 400 || $response->getStatusCode() > 600) {

--- a/lib/Github/HttpClient/Plugin/History.php
+++ b/lib/Github/HttpClient/Plugin/History.php
@@ -3,7 +3,6 @@
 namespace Github\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin\Journal;
-use Http\Client\Exception;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -14,6 +13,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class History implements Journal
 {
+    use HistoryTrait;
+
     /**
      * @var ResponseInterface
      */
@@ -30,9 +31,5 @@ class History implements Journal
     public function addSuccess(RequestInterface $request, ResponseInterface $response)
     {
         $this->lastResponse = $response;
-    }
-
-    public function addFailure(RequestInterface $request, Exception $exception)
-    {
     }
 }

--- a/lib/Github/HttpClient/Plugin/HistoryTrait.php
+++ b/lib/Github/HttpClient/Plugin/HistoryTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Github\HttpClient\Plugin;
+
+use Http\Client\Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Message\RequestInterface;
+
+/*
+ * Below is a some code to make the History plugin compatible with both 1.x and 2.x of php-client/client-common
+ */
+if (\interface_exists(\Http\Client\Common\HttpMethodsClientInterface::class)) {
+    /**
+     * @internal code for php-http/client-common:2.x
+     */
+    trait HistoryTrait
+    {
+        public function addFailure(RequestInterface $request, ClientExceptionInterface $exception)
+        {
+        }
+    }
+} else {
+    /**
+     * @internal code for php-http/client-common:1.x
+     */
+    trait HistoryTrait
+    {
+        public function addFailure(RequestInterface $request, Exception $exception)
+        {
+        }
+    }
+}

--- a/lib/Github/HttpClient/Plugin/PathPrepend.php
+++ b/lib/Github/HttpClient/Plugin/PathPrepend.php
@@ -12,6 +12,8 @@ use Psr\Http\Message\RequestInterface;
  */
 class PathPrepend implements Plugin
 {
+    use Plugin\VersionBridgePlugin;
+
     private $path;
 
     /**
@@ -25,7 +27,7 @@ class PathPrepend implements Plugin
     /**
      * {@inheritdoc}
      */
-    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    public function doHandleRequest(RequestInterface $request, callable $next, callable $first)
     {
         $currentPath = $request->getUri()->getPath();
         if (strpos($currentPath, $this->path) !== 0) {

--- a/test/Github/Tests/Api/AbstractApiTest.php
+++ b/test/Github/Tests/Api/AbstractApiTest.php
@@ -4,6 +4,7 @@ namespace Github\Tests\Api;
 
 use Github\Api\AbstractApi;
 use GuzzleHttp\Psr7\Response;
+use Http\Client\Common\HttpMethodsClientInterface;
 
 class AbstractApiTest extends TestCase
 {
@@ -212,26 +213,15 @@ class AbstractApiTest extends TestCase
      */
     protected function getHttpMethodsMock(array $methods = [])
     {
-        $methods = array_merge(['sendRequest'], $methods);
-        $mock = $this->getMockBuilder(\Http\Client\Common\HttpMethodsClient::class)
-            ->disableOriginalConstructor()
-            ->setMethods($methods)
-            ->getMock();
-        $mock
-            ->expects($this->any())
-            ->method('sendRequest');
-
-        return $mock;
-    }
-
-    /**
-     * @return \Http\Client\HttpClient
-     */
-    protected function getHttpClientMock()
-    {
-        $mock = $this->getMockBuilder(\Http\Client\HttpClient::class)
-            ->setMethods(['sendRequest'])
-            ->getMock();
+        if (interface_exists(HttpMethodsClientInterface::class)) {
+            $mock = $this->createMock(HttpMethodsClientInterface::class);
+        } else {
+            $methods = array_merge(['sendRequest'], $methods);
+            $mock = $this->getMockBuilder(\Http\Client\Common\HttpMethodsClient::class)
+                ->disableOriginalConstructor()
+                ->setMethods($methods)
+                ->getMock();
+        }
         $mock
             ->expects($this->any())
             ->method('sendRequest');

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -40,7 +40,7 @@ class GithubExceptionThrowerTest extends TestCase
             $this->expectExceptionMessage($exception->getMessage());
         }
 
-        $plugin->handleRequest(
+        $plugin->doHandleRequest(
             $request,
             function (RequestInterface $request) use ($promise) {
                 return $promise;

--- a/test/Github/Tests/HttpClient/Plugin/PathPrependTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/PathPrependTest.php
@@ -20,7 +20,7 @@ class PathPrependTest extends TestCase
         $plugin = new PathPrepend('/api/v3');
 
         $newRequest = null;
-        $plugin->handleRequest($request, function ($request) use (&$newRequest) {
+        $plugin->doHandleRequest($request, function ($request) use (&$newRequest) {
             $newRequest = $request;
         }, function () {
             throw new \RuntimeException('Did not expect plugin to call first');


### PR DESCRIPTION
A pr to try/test if we can support both v1 and v2 of httplug. Currently there are still errors regarding typehint incompatibilities, so still a WIP to get things up and running

/cc @Nyholm is it actually possible to support both versions?