### PR TITLE
Drop support for unsupported php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
     - TEST_COMMAND="vendor/bin/phpunit --verbose --coverage-text"
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Uses [GitHub API v3](http://developer.github.com/v3/) & supports [GitHub API v4]
 
 ## Requirements
 
-* PHP >= 5.6
+* PHP >= 7.1
 * A [HTTP client](https://packagist.org/providers/php-http/client-implementation)
 * A [PSR-7 implementation](https://packagist.org/providers/psr/http-message-implementation)
 * (optional) PHPUnit to run tests.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "psr/http-message": "^1.0",
         "psr/cache": "^1.0",
         "php-http/httplug": "^1.1",
@@ -27,7 +27,7 @@
         "php-http/cache-plugin": "^1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5 || ^6.0",
+        "phpunit/phpunit": "^6.0",
         "php-http/guzzle6-adapter": "^1.0",
         "php-http/mock-client": "^1.0",
         "guzzlehttp/psr7": "^1.2",


### PR DESCRIPTION
This is a backport of #782, because v3 will still take some time. And with the removal of the unsupported php versions, we can also upgrade the unsupported phpunit versions we are using and it will make it easier to support php 7.4 

See https://www.php.net/supported-versions.php