### PR TITLE
Update rate_limits.md to reflect actual implementation

### DIFF
--- a/doc/rate_limits.md
+++ b/doc/rate_limits.md
@@ -5,9 +5,17 @@ Get rate limit wrappers from [GitHub Rate Limit API](http://developer.github.com
 
 #### Get All Rate Limits
 
+##### new way
 ```php
 /** @var \Github\Api\RateLimit\RateLimitResource[] $rateLimits */
-$rateLimits = $client->api('rate_limit')->getLimits();
+$rateLimits = $client->api('rate_limit')->getResources();
+```
+
+##### deprecated way
+
+```php
+/** @var array $rateLimits */
+$rateLimits = $client->api('rate_limit')->getRateLimits();
 ```
 
 #### Get Core Rate Limit

--- a/doc/rate_limits.md
+++ b/doc/rate_limits.md
@@ -11,6 +11,57 @@ Get rate limit wrappers from [GitHub Rate Limit API](http://developer.github.com
 $rateLimits = $client->api('rate_limit')->getResources();
 ```
 
+var_dump() output:
+```
+array(4) {
+  ["core"]=>
+  object(Github\Api\RateLimit\RateLimitResource)#30 (4) {
+    ["name":"Github\Api\RateLimit\RateLimitResource":private]=>
+    string(4) "core"
+    ["limit":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(5000)
+    ["reset":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(1566137712)
+    ["remaining":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(5000)
+  }
+  ["search"]=>
+  object(Github\Api\RateLimit\RateLimitResource)#32 (4) {
+    ["name":"Github\Api\RateLimit\RateLimitResource":private]=>
+    string(6) "search"
+    ["limit":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(30)
+    ["reset":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(1566134172)
+    ["remaining":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(30)
+  }
+  ["graphql"]=>
+  object(Github\Api\RateLimit\RateLimitResource)#43 (4) {
+    ["name":"Github\Api\RateLimit\RateLimitResource":private]=>
+    string(7) "graphql"
+    ["limit":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(5000)
+    ["reset":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(1566137712)
+    ["remaining":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(5000)
+  }
+  ["integration_manifest"]=>
+  object(Github\Api\RateLimit\RateLimitResource)#44 (4) {
+    ["name":"Github\Api\RateLimit\RateLimitResource":private]=>
+    string(20) "integration_manifest"
+    ["limit":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(5000)
+    ["reset":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(1566137712)
+    ["remaining":"Github\Api\RateLimit\RateLimitResource":private]=>
+    int(5000)
+  }
+}
+```
+
+
 ##### deprecated way
 
 ```php


### PR DESCRIPTION
getLimits() was not implemented, and getRateLimits is deprecated, so I also included a more current way(did not check, if this part is also deprecated on githubs side)