### PR TITLE
Add $params to files from pull request

### DIFF
--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -90,9 +90,14 @@ class PullRequest extends AbstractApi
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/commits');
     }
 
-    public function files($username, $repository, $id)
+    public function files($username, $repository, $id, array $params = [])
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/files');
+        $parameters = array_merge([
+            'page' => 1,
+            'per_page' => 30,
+        ], $params);
+
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/files', $parameters);
     }
 
     /**

--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -55,17 +55,12 @@ class PullRequest extends AbstractApi
      *
      * @param string $username   the username
      * @param string $repository the repository
-     * @param array  $params     a list of extra parameters.
+     * @param array  $parameters a list of extra parameters.
      *
      * @return array array of pull requests for the project
      */
-    public function all($username, $repository, array $params = [])
+    public function all($username, $repository, array $parameters = [])
     {
-        $parameters = array_merge([
-            'page' => 1,
-            'per_page' => 30,
-        ], $params);
-
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls', $parameters);
     }
 
@@ -90,13 +85,8 @@ class PullRequest extends AbstractApi
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/commits');
     }
 
-    public function files($username, $repository, $id, array $params = [])
+    public function files($username, $repository, $id, array $parameters = [])
     {
-        $parameters = array_merge([
-            'page' => 1,
-            'per_page' => 30,
-        ], $params);
-
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/files', $parameters);
     }
 

--- a/test/Github/Tests/Api/PullRequestTest.php
+++ b/test/Github/Tests/Api/PullRequestTest.php
@@ -32,7 +32,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/ezsystems/ezpublish/pulls', ['state' => 'open', 'per_page' => 30, 'page' => 1])
+            ->with('/repos/ezsystems/ezpublish/pulls', ['state' => 'open'])
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all('ezsystems', 'ezpublish', ['state' => 'open']));
@@ -48,7 +48,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/ezsystems/ezpublish/pulls', ['state' => 'closed', 'per_page' => 30, 'page' => 1])
+            ->with('/repos/ezsystems/ezpublish/pulls', ['state' => 'closed'])
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->all('ezsystems', 'ezpublish', ['state' => 'closed']));
@@ -97,7 +97,7 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/ezsystems/ezpublish/pulls/15/files', ['page' => 1, 'per_page' => 30])
+            ->with('/repos/ezsystems/ezpublish/pulls/15/files')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->files('ezsystems', 'ezpublish', '15'));

--- a/test/Github/Tests/Api/PullRequestTest.php
+++ b/test/Github/Tests/Api/PullRequestTest.php
@@ -97,10 +97,26 @@ class PullRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/ezsystems/ezpublish/pulls/15/files')
+            ->with('/repos/ezsystems/ezpublish/pulls/15/files', ['page' => 1, 'per_page' => 30])
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->files('ezsystems', 'ezpublish', '15'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowFilesFromPullRequestForPage()
+    {
+        $expectedArray = [['id' => 'id', 'sha' => '123123']];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/ezsystems/ezpublish/pulls/15/files', ['page' => 2, 'per_page' => 30])
+            ->willReturn($expectedArray);
+
+        $this->assertSame($expectedArray, $api->files('ezsystems', 'ezpublish', '15', ['page' => 2, 'per_page' => 30]));
     }
 
     /**
@@ -211,10 +227,10 @@ class PullRequestTest extends TestCase
     public function shouldCreatePullRequestUsingTitle()
     {
         $data = [
-            'base' => 'master',
-            'head' => 'virtualtestbranch',
+            'base'  => 'master',
+            'head'  => 'virtualtestbranch',
             'title' => 'TITLE: Testing pull-request creation from PHP Github API',
-            'body' => 'BODY: Testing pull-request creation from PHP Github API',
+            'body'  => 'BODY: Testing pull-request creation from PHP Github API',
         ];
 
         $api = $this->getApiMock();
@@ -231,8 +247,8 @@ class PullRequestTest extends TestCase
     public function shouldCreatePullRequestUsingIssueId()
     {
         $data = [
-            'base' => 'master',
-            'head' => 'virtualtestbranch',
+            'base'  => 'master',
+            'head'  => 'virtualtestbranch',
             'issue' => 25,
         ];
 
@@ -251,9 +267,9 @@ class PullRequestTest extends TestCase
     {
         $this->expectException(MissingArgumentException::class);
         $data = [
-            'head' => 'virtualtestbranch',
+            'head'  => 'virtualtestbranch',
             'title' => 'TITLE: Testing pull-request creation from PHP Github API',
-            'body' => 'BODY: Testing pull-request creation from PHP Github API',
+            'body'  => 'BODY: Testing pull-request creation from PHP Github API',
         ];
 
         $api = $this->getApiMock();
@@ -270,9 +286,9 @@ class PullRequestTest extends TestCase
     {
         $this->expectException(MissingArgumentException::class);
         $data = [
-            'base' => 'master',
+            'base'  => 'master',
             'title' => 'TITLE: Testing pull-request creation from PHP Github API',
-            'body' => 'BODY: Testing pull-request creation from PHP Github API',
+            'body'  => 'BODY: Testing pull-request creation from PHP Github API',
         ];
 
         $api = $this->getApiMock();
@@ -289,8 +305,8 @@ class PullRequestTest extends TestCase
     {
         $this->expectException(MissingArgumentException::class);
         $data = [
-            'base' => 'master',
-            'head' => 'virtualtestbranch',
+            'base'  => 'master',
+            'head'  => 'virtualtestbranch',
             'title' => 'TITLE: Testing pull-request creation from PHP Github API',
         ];
 


### PR DESCRIPTION
Example:

this PR: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3475

changes: 229 files
here: https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/pulls/3475/files we can see 30 files
here: https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/pulls/3475/files?per_page=100 we can see 100 files
here: https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/pulls/3475/files?page=3&per_page=100 we can see 29 files

