### PR TITLE
Added missing Apps endpoints

### DIFF
--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -94,6 +94,19 @@ class Apps extends AbstractApi
     }
 
     /**
+     * Get an installation of the application for a user
+     *
+     * @link https://developer.github.com/v3/apps/#get-a-user-installation
+     *
+     * @param $username
+     * @return array
+     */
+    public function getInstallationForUser($username)
+    {
+        return $this->get('/users/'.rawurldecode($username).'/installation');
+    }
+
+    /**
      * Delete an installation of the application
      *
      * @link https://developer.github.com/v3/apps/#delete-an-installation

--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -54,11 +54,12 @@ class Apps extends AbstractApi
     }
 
     /**
-     * Get an installation of the application
+     * Get an installation of the application.
      *
      * @link https://developer.github.com/v3/apps/#get-an-installation
      *
      * @param $installation_id An integration installation id
+     *
      * @return array
      */
     public function getInstallation($installation_id)
@@ -67,11 +68,12 @@ class Apps extends AbstractApi
     }
 
     /**
-     * Get an installation of the application for an organization
+     * Get an installation of the application for an organization.
      *
      * @link https://developer.github.com/v3/apps/#get-an-organization-installation
      *
      * @param $org An organization
+     *
      * @return array
      */
     public function getInstallationForOrganization($org)
@@ -80,12 +82,13 @@ class Apps extends AbstractApi
     }
 
     /**
-     * Get an installation of the application for a repository
+     * Get an installation of the application for a repository.
      *
      * @link https://developer.github.com/v3/apps/#get-a-repository-installation
      *
      * @param $owner the owner of a repository
      * @param $repo the name of the repository
+     *
      * @return array
      */
     public function getInstallationForRepo($owner, $repo)
@@ -94,11 +97,12 @@ class Apps extends AbstractApi
     }
 
     /**
-     * Get an installation of the application for a user
+     * Get an installation of the application for a user.
      *
      * @link https://developer.github.com/v3/apps/#get-a-user-installation
      *
      * @param $username
+     *
      * @return array
      */
     public function getInstallationForUser($username)
@@ -107,7 +111,7 @@ class Apps extends AbstractApi
     }
 
     /**
-     * Delete an installation of the application
+     * Delete an installation of the application.
      *
      * @link https://developer.github.com/v3/apps/#delete-an-installation
      *

--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -64,6 +64,8 @@ class Apps extends AbstractApi
      */
     public function getInstallation($installation_id)
     {
+        $this->configurePreviewHeader();
+
         return $this->get('/app/installations/'.rawurldecode($installation_id));
     }
 
@@ -78,6 +80,8 @@ class Apps extends AbstractApi
      */
     public function getInstallationForOrganization($org)
     {
+        $this->configurePreviewHeader();
+
         return $this->get('/org/'.rawurldecode($org).'/installation');
     }
 
@@ -93,6 +97,8 @@ class Apps extends AbstractApi
      */
     public function getInstallationForRepo($owner, $repo)
     {
+        $this->configurePreviewHeader();
+
         return $this->get('/repos/'.rawurldecode($owner).'/'.rawurldecode($repo).'/installation');
     }
 
@@ -107,6 +113,8 @@ class Apps extends AbstractApi
      */
     public function getInstallationForUser($username)
     {
+        $this->configurePreviewHeader();
+
         return $this->get('/users/'.rawurldecode($username).'/installation');
     }
 
@@ -119,6 +127,8 @@ class Apps extends AbstractApi
      */
     public function removeInstallation($installation_id)
     {
+        $this->configurePreviewHeader();
+
         $this->delete('/app/installations/'.rawurldecode($installation_id));
     }
 

--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -67,6 +67,18 @@ class Apps extends AbstractApi
     }
 
     /**
+     * Delete an installation of the application
+     *
+     * @link https://developer.github.com/v3/apps/#delete-an-installation
+     *
+     * @param $installation_id An integration installation id
+     */
+    public function removeInstallation($installation_id)
+    {
+        $this->delete('/app/installations/'.rawurldecode($installation_id));
+    }
+
+    /**
      * List repositories that are accessible to the authenticated installation.
      *
      * @link https://developer.github.com/v3/apps/installations/#list-repositories

--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -67,6 +67,19 @@ class Apps extends AbstractApi
     }
 
     /**
+     * Get an installation of the application for an organization
+     *
+     * @link https://developer.github.com/v3/apps/#get-an-organization-installation
+     *
+     * @param $org An organization
+     * @return array
+     */
+    public function getInstallationForOrganization($org)
+    {
+        return $this->get('/org/'.rawurldecode($org).'/installation');
+    }
+
+    /**
      * Delete an installation of the application
      *
      * @link https://developer.github.com/v3/apps/#delete-an-installation

--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -80,6 +80,20 @@ class Apps extends AbstractApi
     }
 
     /**
+     * Get an installation of the application for a repository
+     *
+     * @link https://developer.github.com/v3/apps/#get-a-repository-installation
+     *
+     * @param $owner the owner of a repository
+     * @param $repo the name of the repository
+     * @return array
+     */
+    public function getInstallationForRepo($owner, $repo)
+    {
+        return $this->get('/repos/'.rawurldecode($owner).'/'.rawurldecode($repo).'/installation');
+    }
+
+    /**
      * Delete an installation of the application
      *
      * @link https://developer.github.com/v3/apps/#delete-an-installation

--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -54,6 +54,19 @@ class Apps extends AbstractApi
     }
 
     /**
+     * Get an installation of the application
+     *
+     * @link https://developer.github.com/v3/apps/#get-an-installation
+     *
+     * @param $installation_id An integration installation id
+     * @return array
+     */
+    public function getInstallation($installation_id)
+    {
+        return $this->get('/app/installations/'.rawurldecode($installation_id));
+    }
+
+    /**
      * List repositories that are accessible to the authenticated installation.
      *
      * @link https://developer.github.com/v3/apps/installations/#list-repositories

--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -58,15 +58,15 @@ class Apps extends AbstractApi
      *
      * @link https://developer.github.com/v3/apps/#get-an-installation
      *
-     * @param $installation_id An integration installation id
+     * @param $installationId An integration installation id
      *
      * @return array
      */
-    public function getInstallation($installation_id)
+    public function getInstallation($installationId)
     {
         $this->configurePreviewHeader();
 
-        return $this->get('/app/installations/'.rawurldecode($installation_id));
+        return $this->get('/app/installations/'.rawurldecode($installationId));
     }
 
     /**
@@ -123,13 +123,13 @@ class Apps extends AbstractApi
      *
      * @link https://developer.github.com/v3/apps/#delete-an-installation
      *
-     * @param $installation_id An integration installation id
+     * @param $installationId An integration installation id
      */
-    public function removeInstallation($installation_id)
+    public function removeInstallation($installationId)
     {
         $this->configurePreviewHeader();
 
-        $this->delete('/app/installations/'.rawurldecode($installation_id));
+        $this->delete('/app/installations/'.rawurldecode($installationId));
     }
 
     /**

--- a/test/Github/Tests/Api/AppTest.php
+++ b/test/Github/Tests/Api/AppTest.php
@@ -59,6 +59,22 @@ class AppTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetInstallationForOrganization()
+    {
+        $result = ['installation1'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/org/1234/installation')
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->getInstallationForOrganization('1234'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldDeleteInstallationForApplication()
     {
         $id = 123;

--- a/test/Github/Tests/Api/AppTest.php
+++ b/test/Github/Tests/Api/AppTest.php
@@ -75,6 +75,22 @@ class AppTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetInstallationForRepo()
+    {
+        $result = ['installation1'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/MyOrg/MyRepo/installation')
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->getInstallationForRepo('MyOrg', 'MyRepo'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldDeleteInstallationForApplication()
     {
         $id = 123;

--- a/test/Github/Tests/Api/AppTest.php
+++ b/test/Github/Tests/Api/AppTest.php
@@ -91,6 +91,22 @@ class AppTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetInstallationForUser()
+    {
+        $result = ['installation1'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/users/octocat/installation')
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->getInstallationForUser('octocat'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldDeleteInstallationForApplication()
     {
         $id = 123;

--- a/test/Github/Tests/Api/AppTest.php
+++ b/test/Github/Tests/Api/AppTest.php
@@ -27,7 +27,7 @@ class AppTest extends TestCase
     /**
      * @test
      */
-    public function shouldFindRepositoriesForApplication()
+    public function shouldFindInstallationsForApplication()
     {
         $result = ['installation1', 'installation2'];
 
@@ -38,6 +38,22 @@ class AppTest extends TestCase
             ->willReturn($result);
 
         $this->assertEquals($result, $api->findInstallations());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetInstallationForApplication()
+    {
+        $result = ['installation1'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/app/installations/1234')
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->getInstallation('1234'));
     }
 
     /**

--- a/test/Github/Tests/Api/AppTest.php
+++ b/test/Github/Tests/Api/AppTest.php
@@ -59,6 +59,20 @@ class AppTest extends TestCase
     /**
      * @test
      */
+    public function shouldDeleteInstallationForApplication()
+    {
+        $id = 123;
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('/app/installations/'.$id);
+
+        $api->removeInstallation($id);
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetRepositoriesFromInstallation()
     {
         $result = ['repo1', 'repo2'];


### PR DESCRIPTION
*Why make this change?*
Some endpoints available on https://developer.github.com/v3/apps/ are not available through this package. I also added the Accept header back for the preview Apps apis, which addresses this issue: https://github.com/KnpLabs/php-github-api/issues/800

*Considerations*
I did not include Create Github App from App-Manifest because that flow required additional scoping to fully understand the flow, which was beyond the scope of my needs at this time.

*Testing*
I have included tests for all added endpoints. 