### PR TITLE
Improve to can specify parameters on issue comments api.

### DIFF
--- a/lib/Github/Api/Issue/Comments.php
+++ b/lib/Github/Api/Issue/Comments.php
@@ -41,18 +41,24 @@ class Comments extends AbstractApi
      *
      * @link https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
      *
-     * @param string $username
-     * @param string $repository
-     * @param int    $issue
-     * @param int    $page
+     * @param string    $username
+     * @param string    $repository
+     * @param int       $issue
+     * @param int|array $page
      *
      * @return array
      */
     public function all($username, $repository, $issue, $page = 1)
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/comments', [
-            'page' => $page,
-        ]);
+        if (is_array($page)) {
+            $parameters = $page;
+        } else {
+            $parameters = [
+                'page' => $page,
+            ];
+        }
+
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($issue).'/comments', $parameters);
     }
 
     /**

--- a/lib/Github/Api/Issue/Comments.php
+++ b/lib/Github/Api/Issue/Comments.php
@@ -44,7 +44,7 @@ class Comments extends AbstractApi
      * @param string    $username
      * @param string    $repository
      * @param int       $issue
-     * @param int|array $page
+     * @param int|array $page       Passing integer is deprecated and will throw an exception in php-github-api version 3.0. Pass an array instead.
      *
      * @return array
      */
@@ -53,6 +53,7 @@ class Comments extends AbstractApi
         if (is_array($page)) {
             $parameters = $page;
         } else {
+            @trigger_error(sprintf('Passing integer to the "page" argument in "%s" is deprecated and will throw an exception in php-github-api version 3.0. Pass an array instead.', __METHOD__), E_USER_DEPRECATED);
             $parameters = [
                 'page' => $page,
             ];

--- a/test/Github/Tests/Api/Issue/CommentsTest.php
+++ b/test/Github/Tests/Api/Issue/CommentsTest.php
@@ -25,6 +25,24 @@ class CommentsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllIssueCommentsBySpecifyParameters()
+    {
+        $expectedValue = [['comment1data'], ['comment2data']];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/issues/123/comments', ['since' => '1990-08-03T00:00:00Z'])
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', 123, [
+            'since' => '1990-08-03T00:00:00Z'
+        ]));
+    }
+
+    /**
+     * @test
+     */
     public function shouldShowIssueComment()
     {
         $expectedValue = ['comment1'];

--- a/test/Github/Tests/Api/Issue/CommentsTest.php
+++ b/test/Github/Tests/Api/Issue/CommentsTest.php
@@ -36,7 +36,7 @@ class CommentsTest extends TestCase
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', 123, [
-            'since' => '1990-08-03T00:00:00Z'
+            'since' => '1990-08-03T00:00:00Z',
         ]));
     }
 


### PR DESCRIPTION
I had try to get comments which updated after specific date but it couldn't because can't specify `since` parameters through this library.

Github API provide `since` parameter.

https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
![image](https://user-images.githubusercontent.com/7825234/66268605-05a71180-e87a-11e9-9622-9a3ca57c5b75.png)

but this library can specify `page` only.
https://github.com/KnpLabs/php-github-api/blob/master/lib/Github/Api/Issue/Comments.php#L39-L56

In this PR, will be able to specify array on 4th argument of Comments#all method.
