### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,5 @@
 
 /doc export-ignore
 /test export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
-/.travis.yml export-ignore
+/.* export-ignore
 /phpunit.xml.dist export-ignore
-/README.markdown export-ignore


### PR DESCRIPTION
- All files staring with dot are internal, so should be excluded
- `README.md` should be in the distribution and it is - the excluded file was `README.markdown`