### PR TITLE
add existing checks to repo as described in the docs

### DIFF
--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -2,6 +2,7 @@
 
 namespace Github\Api;
 
+use Github\Api\Repository\Checks;
 use Github\Api\Repository\Collaborators;
 use Github\Api\Repository\Comments;
 use Github\Api\Repository\Commits;
@@ -681,5 +682,17 @@ class Repo extends AbstractApi
         $this->acceptHeaderValue = 'application/vnd.github.nightshade-preview+json';
 
         return $this->post('/repos/'.rawurldecode($username).'/'.rawurldecode($repository).'/transfer', ['new_owner' => $newOwner, 'team_id' => $teamId]);
+    }
+
+    /**
+     * Manage the checks of a repository.
+     *
+     * @link https://developer.github.com/v3/checks
+     *
+     * @return Checks
+     */
+    public function checks()
+    {
+        return new Checks($this->client);
     }
 }

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -608,6 +608,16 @@ class RepoTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function shouldGetChecksApiObject()
+    {
+        $api = $this->getApiMock();
+
+        $this->assertInstanceOf(\Github\Api\Repository\Checks::class, $api->checks());
+    }
+
+    /**
      * @return string
      */
     protected function getApiClass()


### PR DESCRIPTION
This PR completes https://github.com/KnpLabs/php-github-api/pull/788 as described in the documentation.

The documentation example wasn't implemented yet.

```
$checks = $client
    ->api('repo')
    ->checks()
    ->create('NimbleCI', 'docker-web-tester-behat', $params);
```