### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
-sudo: false
+
+dist: bionic
 
 cache:
   directories:
@@ -13,7 +14,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 matrix:
   include:
@@ -25,7 +26,7 @@ before_install:
     - if ! [ -z "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
 
 install:
-  - travis_retry composer install --no-interaction
+  - travis_retry composer install
 
 script:
   - $TEST_COMMAND


### PR DESCRIPTION
Test against PHP 7.4 stable. No interaction is already enabled via an env variable set by travis on composer.