### PR TITLE
Allow create & remove to set and remove requests for teams

### DIFF
--- a/lib/Github/Api/PullRequest/ReviewRequest.php
+++ b/lib/Github/Api/PullRequest/ReviewRequest.php
@@ -39,12 +39,13 @@ class ReviewRequest extends AbstractApi
      * @param string $repository
      * @param int    $pullRequest
      * @param array  $reviewers
+     * @param array  $teamReviewers
      *
      * @return string
      */
-    public function create($username, $repository, $pullRequest, array $reviewers)
+    public function create($username, $repository, $pullRequest, array $reviewers = [], array $teamReviewers = [])
     {
-        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.$pullRequest.'/requested_reviewers', ['reviewers' => $reviewers]);
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.$pullRequest.'/requested_reviewers', ['reviewers' => $reviewers, 'team_reviewers' => $teamReviewers]);
     }
 
     /**
@@ -54,11 +55,12 @@ class ReviewRequest extends AbstractApi
      * @param string $repository
      * @param int    $pullRequest
      * @param array  $reviewers
+     * @param array  $teamReviewers
      *
      * @return string
      */
-    public function remove($username, $repository, $pullRequest, array $reviewers)
+    public function remove($username, $repository, $pullRequest, array $reviewers = [], array $teamReviewers = [])
     {
-        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.$pullRequest.'/requested_reviewers', ['reviewers' => $reviewers]);
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.$pullRequest.'/requested_reviewers', ['reviewers' => $reviewers, 'team_reviewers' => $teamReviewers]);
     }
 }

--- a/test/Github/Tests/Api/PullRequest/ReviewRequestTest.php
+++ b/test/Github/Tests/Api/PullRequest/ReviewRequestTest.php
@@ -35,10 +35,10 @@ class ReviewRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('/repos/octocat/Hello-World/pulls/12/requested_reviewers', ['reviewers' => ['testuser']])
+            ->with('/repos/octocat/Hello-World/pulls/12/requested_reviewers', ['reviewers' => ['testuser'], 'team_reviewers' => ['testteam']])
         ;
 
-        $api->create('octocat', 'Hello-World', 12, ['testuser']);
+        $api->create('octocat', 'Hello-World', 12, ['testuser'], ['testteam']);
     }
 
     /**
@@ -49,10 +49,10 @@ class ReviewRequestTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('/repos/octocat/Hello-World/pulls/12/requested_reviewers', ['reviewers' => ['testuser']])
+            ->with('/repos/octocat/Hello-World/pulls/12/requested_reviewers', ['reviewers' => ['testuser'], 'team_reviewers' => ['testteam']])
         ;
 
-        $api->remove('octocat', 'Hello-World', 12, ['testuser']);
+        $api->remove('octocat', 'Hello-World', 12, ['testuser'], ['testteam']);
     }
 
     /**


### PR DESCRIPTION
We very happily use this library to interact with the GH API. We recently came into the need for adding and removing review requests for from teams to pull requests across all of the repositories in our organization. This PR opens up `GitHub\Api\PullRequest\ReviewRequest::create() and `::remove()` methods to be able to do that. When removing teams from a PR, some value needs to be sent for the `reviewers`, hence the `$reviweres = []` change.