### PR TITLE
Add repo community profile API endpoint

### DIFF
--- a/doc/repos.md
+++ b/doc/repos.md
@@ -312,6 +312,12 @@ $milestones = $client->api('repo')->milestones('ornicar', 'php-github-api');
 
 Returns a list of milestones.
 
+### Get the community profile metrics for a repository
+
+```php
+$communityProfile = $client->api('repo')->communityProfile('ornicar', 'php-github-api');
+```
+
 ### Get the contents of a repository's code of conduct
 
 ```php

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -628,6 +628,24 @@ class Repo extends AbstractApi
     }
 
     /**
+     * Get the community profile metrics for a repository.
+     *
+     * @link https://developer.github.com/v3/repos/community/#retrieve-community-profile-metrics
+     *
+     * @param string $username
+     * @param string $repository
+     *
+     * @return array
+     */
+    public function communityProfile($username, $repository)
+    {
+        //This api is in preview mode, so set the correct accept-header
+        $this->acceptHeaderValue = 'application/vnd.github.black-panther-preview+json';
+
+        return $this->get('/repos/'.rawurldecode($username).'/'.rawurldecode($repository).'/community/profile');
+    }
+
+    /**
      * Get the contents of a repository's code of conduct.
      *
      * @link https://developer.github.com/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -541,6 +541,22 @@ class RepoTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetRepositoryCommunityProfile()
+    {
+        $expectedArray = ['health_percentage' => 100, 'description' => 'A simple PHP GitHub API client...'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/community/profile')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->communityProfile('KnpLabs', 'php-github-api'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetRepositoryCodeOfConduct()
     {
         $expectedArray = ['name' => 'Contributor Covenant', 'url' => 'http://...'];


### PR DESCRIPTION
This PR adds a method `communityProfile` to access the community profile metrics API: https://developer.github.com/v3/repos/community/#retrieve-community-profile-metrics

It includes a test covering the new method and an entry in the docs.