### PR TITLE
Change getHttpClientBuilder() on Client to public

### DIFF
--- a/doc/request_any_route.md
+++ b/doc/request_any_route.md
@@ -2,7 +2,7 @@
 [Back to the navigation](README.md)
 
 The method you need does not exist yet? You can access any GitHub route by using the "get" and "post" methods.
-For example:
+For example, the following snippet returns an array describing the "php-github-api" repository.
 
 ```php
 $client   = new Github\Client();
@@ -10,6 +10,20 @@ $response = $client->getHttpClient()->get('repos/KnpLabs/php-github-api');
 $repo     = Github\HttpClient\Message\ResponseMediator::getContent($response);
 ```
 
-Returns an array describing the "php-github-api" repository.
+If you need to call any methods on the HTTP client before sending a request, for example setting a header you can access the HTTP client builder, call any methods and then get the configured client. For example, the following snippet gets the builder, adds a header and then performs a "put" request.
+
+```php
+$client = new Github\Client()
+
+$builder = $client->getHttpClientBuilder();
+
+$builder->addHeaders(['Content-Length' => 0]);
+
+$client = $builder->getHttpClient()
+
+$response = $client->put('user/starred/:owner/:repo')
+
+$content = Github\HttpClient\Message\ResponseMediator::getContent($response);
+```
 
 See all GitHub API routes: [http://developer.github.com/](http://developer.github.com/)

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -412,7 +412,7 @@ class Client
     /**
      * @return Builder
      */
-    protected function getHttpClientBuilder()
+    public function getHttpClientBuilder()
     {
         return $this->httpClientBuilder;
     }


### PR DESCRIPTION
Hello, 

I am requesting that the `getHttpClientBuilder()` method on the `Client` class be changed to public. This will allow users to configure the HTTP client as needed for calling non-implemented routes. 

My specific use-case example is starring a repo for the authenticated user. (See official [docs](https://developer.github.com/v3/activity/starring/#star-a-repository-for-the-authenticated-user)). This requires a header to be set. 

This PR allows you to access the underlying builder and add headers, plugins, etc. 

I also updated the docs with an example of how a user would interact with this method and perform  a request. 

Cheers and many thanks 🙂