### PR TITLE
Replace deprecated Organization\Teams api calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ phpunit.xml
 composer.lock
 composer.phar
 vendor/*
-.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ phpunit.xml
 composer.lock
 composer.phar
 vendor/*
+.idea/*

--- a/lib/Github/Api/Organization/Teams.php
+++ b/lib/Github/Api/Organization/Teams.php
@@ -7,7 +7,6 @@ use Github\Exception\MissingArgumentException;
 
 /**
  * @link   http://developer.github.com/v3/orgs/teams/
- *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
 class Teams extends AbstractApi
@@ -37,11 +36,13 @@ class Teams extends AbstractApi
      */
     public function show($team, $organization = null)
     {
-        if ($organization) {
-            return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team));
+        if (null === $organization) {
+            @trigger_error('Not passing the $organisation parameter is deprecated in knpLabs/php-github-api v2.14 and will be mandatory in v3.0.', E_USER_DEPRECATED);
+
+            return $this->get('/teams/'.rawurlencode($team));
         }
 
-        return $this->get('/teams/'.rawurlencode($team));
+        return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team));
     }
 
     /**
@@ -56,11 +57,13 @@ class Teams extends AbstractApi
             $params['permission'] = 'pull';
         }
 
-        if ($organization) {
-            return $this->patch('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team), $params);
+        if (null === $organization) {
+            @trigger_error('Not passing the $organisation parameter is deprecated in knpLabs/php-github-api v2.14 and will be mandatory in v3.0.', E_USER_DEPRECATED);
+
+            return $this->patch('/teams/'.rawurlencode($team), $params);
         }
 
-        return $this->patch('/teams/'.rawurlencode($team), $params);
+        return $this->patch('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team), $params);
     }
 
     /**
@@ -68,11 +71,13 @@ class Teams extends AbstractApi
      */
     public function remove($team, $organization = null)
     {
-        if ($organization) {
-            return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team));
+        if (null === $organization) {
+            @trigger_error('Not passing the $organisation parameter is deprecated in knpLabs/php-github-api v2.14 and will be mandatory in v3.0.', E_USER_DEPRECATED);
+
+            return $this->delete('/teams/'.rawurlencode($team));
         }
 
-        return $this->delete('/teams/'.rawurlencode($team));
+        return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team));
     }
 
     /**
@@ -80,11 +85,13 @@ class Teams extends AbstractApi
      */
     public function members($team, $organization = null)
     {
-        if ($organization) {
-            return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/members');
+        if (null === $organization) {
+            @trigger_error('Not passing the $organisation parameter is deprecated in knpLabs/php-github-api v2.14 and will be mandatory in v3.0.', E_USER_DEPRECATED);
+
+            return $this->get('/teams/'.rawurlencode($team).'/members');
         }
 
-        return $this->get('/teams/'.rawurlencode($team).'/members');
+        return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/members');
     }
 
     /**
@@ -92,11 +99,13 @@ class Teams extends AbstractApi
      */
     public function check($team, $username, $organization = null)
     {
-        if ($organization) {
-            return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        if (null === $organization) {
+            @trigger_error('Not passing the $organisation parameter is deprecated in knpLabs/php-github-api v2.14 and will be mandatory in v3.0.', E_USER_DEPRECATED);
+
+            return $this->get('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
         }
 
-        return $this->get('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
     /**
@@ -104,11 +113,13 @@ class Teams extends AbstractApi
      */
     public function addMember($team, $username, $organization = null)
     {
-        if ($organization) {
-            return $this->put('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        if (null === $organization) {
+            @trigger_error('Not passing the $organisation parameter is deprecated in knpLabs/php-github-api v2.14 and will be mandatory in v3.0.', E_USER_DEPRECATED);
+
+            return $this->put('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
         }
 
-        return $this->put('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        return $this->put('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
     /**
@@ -116,11 +127,13 @@ class Teams extends AbstractApi
      */
     public function removeMember($team, $username, $organization = null)
     {
-        if ($organization) {
-            return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        if (null === $organization) {
+            @trigger_error('Not passing the $organisation parameter is deprecated in knpLabs/php-github-api v2.14 and will be mandatory in v3.0.', E_USER_DEPRECATED);
+
+            return $this->delete('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
         }
 
-        return $this->delete('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
     public function repositories($team)

--- a/lib/Github/Api/Organization/Teams.php
+++ b/lib/Github/Api/Organization/Teams.php
@@ -38,7 +38,7 @@ class Teams extends AbstractApi
     public function show($team, $organization = null)
     {
         if ($organization) {
-            return $this->get('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team));
+            return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team));
         }
 
         return $this->get('/teams/'.rawurlencode($team));
@@ -57,10 +57,10 @@ class Teams extends AbstractApi
         }
 
         if ($organization) {
-            return $this->patch('/teams/' . rawurlencode($team), $params);
+            return $this->patch('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team), $params);
         }
 
-        return $this->patch('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team), $params);
+        return $this->patch('/teams/'.rawurlencode($team), $params);
     }
 
     /**
@@ -69,10 +69,10 @@ class Teams extends AbstractApi
     public function remove($team, $organization = null)
     {
         if ($organization) {
-            return $this->delete('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team));
+            return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team));
         }
 
-        return $this->delete('/teams/' . rawurlencode($team));
+        return $this->delete('/teams/'.rawurlencode($team));
     }
 
     /**
@@ -81,10 +81,10 @@ class Teams extends AbstractApi
     public function members($team, $organization = null)
     {
         if ($organization) {
-            return $this->get('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team) . '/members');
+            return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team) . '/members');
         }
 
-        return $this->get('/teams/' . rawurlencode($team) . '/members');
+        return $this->get('/teams/'.rawurlencode($team).'/members');
     }
 
     /**
@@ -93,7 +93,7 @@ class Teams extends AbstractApi
     public function check($team, $username, $organization = null)
     {
         if ($organization) {
-            return $this->get('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team) . '/memberships/' . rawurlencode($username));
+            return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team) . '/memberships/' . rawurlencode($username));
         }
 
         return $this->get('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
@@ -105,10 +105,10 @@ class Teams extends AbstractApi
     public function addMember($team, $username, $organization = null)
     {
         if ($organization) {
-            return $this->put('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team) . '/memberships/' . rawurlencode($username));
+            return $this->put('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team) . '/memberships/' . rawurlencode($username));
         }
 
-        return $this->put('/teams/' . rawurlencode($team) . '/memberships/' . rawurlencode($username));
+        return $this->put('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
     /**
@@ -117,10 +117,10 @@ class Teams extends AbstractApi
     public function removeMember($team, $username, $organization = null)
     {
         if ($organization) {
-            return $this->delete('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team) . '/memberships/' . rawurlencode($username));
+            return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team) . '/memberships/' . rawurlencode($username));
         }
 
-        return $this->delete('/teams/' . rawurlencode($team) . '/memberships/' . rawurlencode($username));
+        return $this->delete('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
     public function repositories($team)

--- a/lib/Github/Api/Organization/Teams.php
+++ b/lib/Github/Api/Organization/Teams.php
@@ -7,6 +7,7 @@ use Github\Exception\MissingArgumentException;
 
 /**
  * @link   http://developer.github.com/v3/orgs/teams/
+ *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
 class Teams extends AbstractApi

--- a/lib/Github/Api/Organization/Teams.php
+++ b/lib/Github/Api/Organization/Teams.php
@@ -32,12 +32,18 @@ class Teams extends AbstractApi
         return $this->post('/orgs/'.rawurlencode($organization).'/teams', $params);
     }
 
-    public function show($team)
+    /**
+     * @link https://developer.github.com/v3/teams/#list-teams
+     */
+    public function show($team, $organization)
     {
-        return $this->get('/teams/'.rawurlencode($team));
+        return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team));
     }
 
-    public function update($team, array $params)
+    /**
+     * @link https://developer.github.com/v3/teams/#edit-team
+     */
+    public function update($team, array $params, $organization)
     {
         if (!isset($params['name'])) {
             throw new MissingArgumentException('name');
@@ -46,32 +52,47 @@ class Teams extends AbstractApi
             $params['permission'] = 'pull';
         }
 
-        return $this->patch('/teams/'.rawurlencode($team), $params);
+        return $this->patch('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team), $params);
     }
 
-    public function remove($team)
+    /**
+     * @link https://developer.github.com/v3/teams/#delete-team
+     */
+    public function remove($team, $organization)
     {
-        return $this->delete('/teams/'.rawurlencode($team));
+        return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team));
     }
 
-    public function members($team)
+    /**
+     * @link https://developer.github.com/v3/teams/members/#list-team-members
+     */
+    public function members($team, $organization)
     {
-        return $this->get('/teams/'.rawurlencode($team).'/members');
+        return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/members');
     }
 
-    public function check($team, $username)
+    /**
+     * @link https://developer.github.com/v3/teams/members/#get-team-membership
+     */
+    public function check($team, $username, $organization)
     {
-        return $this->get('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
-    public function addMember($team, $username)
+    /**
+     * @link https://developer.github.com/v3/teams/members/#add-or-update-team-membership
+     */
+    public function addMember($team, $username, $organization)
     {
-        return $this->put('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        return $this->put('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
-    public function removeMember($team, $username)
+    /**
+     * @link https://developer.github.com/v3/teams/members/#remove-team-membership
+     */
+    public function removeMember($team, $username, $organization)
     {
-        return $this->delete('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
     public function repositories($team)

--- a/lib/Github/Api/Organization/Teams.php
+++ b/lib/Github/Api/Organization/Teams.php
@@ -81,7 +81,7 @@ class Teams extends AbstractApi
     public function members($team, $organization = null)
     {
         if ($organization) {
-            return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team) . '/members');
+            return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/members');
         }
 
         return $this->get('/teams/'.rawurlencode($team).'/members');
@@ -93,7 +93,7 @@ class Teams extends AbstractApi
     public function check($team, $username, $organization = null)
     {
         if ($organization) {
-            return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team) . '/memberships/' . rawurlencode($username));
+            return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
         }
 
         return $this->get('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
@@ -105,7 +105,7 @@ class Teams extends AbstractApi
     public function addMember($team, $username, $organization = null)
     {
         if ($organization) {
-            return $this->put('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team) . '/memberships/' . rawurlencode($username));
+            return $this->put('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
         }
 
         return $this->put('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
@@ -117,7 +117,7 @@ class Teams extends AbstractApi
     public function removeMember($team, $username, $organization = null)
     {
         if ($organization) {
-            return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team) . '/memberships/' . rawurlencode($username));
+            return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
         }
 
         return $this->delete('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));

--- a/lib/Github/Api/Organization/Teams.php
+++ b/lib/Github/Api/Organization/Teams.php
@@ -35,15 +35,19 @@ class Teams extends AbstractApi
     /**
      * @link https://developer.github.com/v3/teams/#list-teams
      */
-    public function show($team, $organization)
+    public function show($team, $organization = null)
     {
-        return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team));
+        if ($organization) {
+            return $this->get('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team));
+        }
+
+        return $this->get('/teams/'.rawurlencode($team));
     }
 
     /**
      * @link https://developer.github.com/v3/teams/#edit-team
      */
-    public function update($team, array $params, $organization)
+    public function update($team, array $params, $organization = null)
     {
         if (!isset($params['name'])) {
             throw new MissingArgumentException('name');
@@ -52,47 +56,71 @@ class Teams extends AbstractApi
             $params['permission'] = 'pull';
         }
 
-        return $this->patch('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team), $params);
+        if ($organization) {
+            return $this->patch('/teams/' . rawurlencode($team), $params);
+        }
+
+        return $this->patch('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team), $params);
     }
 
     /**
      * @link https://developer.github.com/v3/teams/#delete-team
      */
-    public function remove($team, $organization)
+    public function remove($team, $organization = null)
     {
-        return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team));
+        if ($organization) {
+            return $this->delete('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team));
+        }
+
+        return $this->delete('/teams/' . rawurlencode($team));
     }
 
     /**
      * @link https://developer.github.com/v3/teams/members/#list-team-members
      */
-    public function members($team, $organization)
+    public function members($team, $organization = null)
     {
-        return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/members');
+        if ($organization) {
+            return $this->get('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team) . '/members');
+        }
+
+        return $this->get('/teams/' . rawurlencode($team) . '/members');
     }
 
     /**
      * @link https://developer.github.com/v3/teams/members/#get-team-membership
      */
-    public function check($team, $username, $organization)
+    public function check($team, $username, $organization = null)
     {
-        return $this->get('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        if ($organization) {
+            return $this->get('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team) . '/memberships/' . rawurlencode($username));
+        }
+
+        return $this->get('/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
     }
 
     /**
      * @link https://developer.github.com/v3/teams/members/#add-or-update-team-membership
      */
-    public function addMember($team, $username, $organization)
+    public function addMember($team, $username, $organization = null)
     {
-        return $this->put('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        if ($organization) {
+            return $this->put('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team) . '/memberships/' . rawurlencode($username));
+        }
+
+        return $this->put('/teams/' . rawurlencode($team) . '/memberships/' . rawurlencode($username));
     }
 
     /**
      * @link https://developer.github.com/v3/teams/members/#remove-team-membership
      */
-    public function removeMember($team, $username, $organization)
+    public function removeMember($team, $username, $organization = null)
     {
-        return $this->delete('/orgs/'.rawurlencode($organization).'/teams/'.rawurlencode($team).'/memberships/'.rawurlencode($username));
+        if ($organization) {
+            return $this->delete('/orgs/' . rawurlencode($organization) . '/teams/' . rawurlencode($team) . '/memberships/' . rawurlencode($username));
+        }
+
+        return $this->delete('/teams/' . rawurlencode($team) . '/memberships/' . rawurlencode($username));
     }
 
     public function repositories($team)

--- a/test/Github/Tests/Api/Organization/TeamsTest.php
+++ b/test/Github/Tests/Api/Organization/TeamsTest.php
@@ -33,10 +33,10 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/teams/KnpWorld/memberships/l3l0')
+            ->with('/orgs/KnpLabs/teams/KnpWorld/memberships/l3l0')
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->check('KnpWorld', 'l3l0'));
+        $this->assertEquals($expectedValue, $api->check('KnpWorld', 'l3l0', 'KnpLabs'));
     }
 
     /**
@@ -49,10 +49,10 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('/teams/KnpWorld')
+            ->with('/orgs/KnpLabs/teams/KnpWorld')
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->remove('KnpWorld'));
+        $this->assertEquals($expectedValue, $api->remove('KnpWorld', 'KnpLabs'));
     }
 
     /**
@@ -65,10 +65,10 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/teams/KnpWorld')
+            ->with('/orgs/KnpLabs/teams/KnpWorld')
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->show('KnpWorld'));
+        $this->assertEquals($expectedValue, $api->show('KnpWorld', 'KnpLabs'));
     }
 
     /**
@@ -81,10 +81,10 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/teams/KnpWorld/members')
+            ->with('/orgs/KnpLabs/teams/KnpWorld/members')
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->members('KnpWorld'));
+        $this->assertEquals($expectedValue, $api->members('KnpWorld', 'KnpLabs'));
     }
 
     /**
@@ -97,10 +97,10 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('/teams/KnpWorld/memberships/l3l0')
+            ->with('/orgs/KnpLabs/teams/KnpWorld/memberships/l3l0')
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->addMember('KnpWorld', 'l3l0'));
+        $this->assertEquals($expectedValue, $api->addMember('KnpWorld', 'l3l0', 'KnpLabs'));
     }
 
     /**
@@ -113,10 +113,10 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('/teams/KnpWorld/memberships/l3l0')
+            ->with('/orgs/KnpLabs/teams/KnpWorld/memberships/l3l0')
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->removeMember('KnpWorld', 'l3l0'));
+        $this->assertEquals($expectedValue, $api->removeMember('KnpWorld', 'l3l0', 'KnpLabs'));
     }
 
     /**
@@ -261,7 +261,7 @@ class TeamsTest extends TestCase
         $api->expects($this->never())
             ->method('patch');
 
-        $api->update('KnpWorld', $data);
+        $api->update('KnpWorld', $data, 'KnpLabs');
     }
 
     /**
@@ -275,10 +275,10 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('/teams/KnpWorld', $data)
+            ->with('/orgs/KnpLabs/teams/KnpWorld', $data)
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->update('KnpWorld', $data));
+        $this->assertEquals($expectedValue, $api->update('KnpWorld', $data, 'KnpLabs'));
     }
 
     /**
@@ -292,10 +292,10 @@ class TeamsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
-            ->with('/teams/KnpWorld', ['name' => 'KnpWorld', 'permission' => 'pull'])
+            ->with('/orgs/KnpLabs/teams/KnpWorld', ['name' => 'KnpWorld', 'permission' => 'pull'])
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->update('KnpWorld', $data));
+        $this->assertEquals($expectedValue, $api->update('KnpWorld', $data, 'KnpLabs'));
     }
 
     /**


### PR DESCRIPTION
This Pull Request fixes the API calls for the functions:
- \Github\Api\Organization\Teams::show
- \Github\Api\Organization\Teams::update
- \Github\Api\Organization\Teams::remove
- \Github\Api\Organization\Teams::members
- \Github\Api\Organization\Teams::check
- \Github\Api\Organization\Teams::addMember
- \Github\Api\Organization\Teams::removeMember

based on the official Github's v3 API documentation:
- https://developer.github.com/v3/teams/
- https://developer.github.com/v3/teams/members/

since those functions incorrectly threw `Github\Exception\RuntimeException: Not Found`