### PR TITLE
Add sort and direction for fetching organizations repos

### DIFF
--- a/lib/Github/Api/Notification.php
+++ b/lib/Github/Api/Notification.php
@@ -23,6 +23,7 @@ class Notification extends AbstractApi
      * @param bool          $includingRead
      * @param bool          $participating
      * @param DateTime|null $since
+     * @param DateTime|null $before
      *
      * @return array array of notifications
      */

--- a/lib/Github/Api/Organization.php
+++ b/lib/Github/Api/Organization.php
@@ -64,7 +64,7 @@ class Organization extends AbstractApi
             'type' => $type,
             'page' => $page,
             'sort' => $sort,
-            'direction' => $direction
+            'direction' => $direction,
         ]);
     }
 

--- a/lib/Github/Api/Organization.php
+++ b/lib/Github/Api/Organization.php
@@ -65,11 +65,11 @@ class Organization extends AbstractApi
             'page' => $page,
         ];
 
-        if($sort !== null){
+        if ($sort !== null) {
             $parameters['sort'] = $sort;
         }
 
-        if($direction !== null){
+        if ($direction !== null) {
             $parameters['direction'] = $direction;
         }
 

--- a/lib/Github/Api/Organization.php
+++ b/lib/Github/Api/Organization.php
@@ -53,14 +53,18 @@ class Organization extends AbstractApi
      * @param string $organization the user name
      * @param string $type         the type of repositories
      * @param int    $page         the page
+     * @param string $sort         sort by
+     * @param string $direction    direction of sort, asc or desc
      *
      * @return array the repositories
      */
-    public function repositories($organization, $type = 'all', $page = 1)
+    public function repositories($organization, $type = 'all', $page = 1, $sort = 'created', $direction = 'desc')
     {
         return $this->get('/orgs/'.rawurlencode($organization).'/repos', [
             'type' => $type,
             'page' => $page,
+            'sort' => $sort,
+            'direction' => $direction
         ]);
     }
 

--- a/lib/Github/Api/Organization.php
+++ b/lib/Github/Api/Organization.php
@@ -58,14 +58,22 @@ class Organization extends AbstractApi
      *
      * @return array the repositories
      */
-    public function repositories($organization, $type = 'all', $page = 1, $sort = 'created', $direction = 'desc')
+    public function repositories($organization, $type = 'all', $page = 1, $sort = null, $direction = null)
     {
-        return $this->get('/orgs/'.rawurlencode($organization).'/repos', [
+        $parameters = [
             'type' => $type,
             'page' => $page,
-            'sort' => $sort,
-            'direction' => $direction,
-        ]);
+        ];
+
+        if($sort !== null){
+            $parameters['sort'] = $sort;
+        }
+
+        if($direction !== null){
+            $parameters['direction'] = $direction;
+        }
+
+        return $this->get('/orgs/'.rawurlencode($organization).'/repos', $parameters);
     }
 
     /**

--- a/test/Github/Tests/Api/OrganizationTest.php
+++ b/test/Github/Tests/Api/OrganizationTest.php
@@ -62,7 +62,7 @@ class OrganizationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/orgs/KnpLabs/repos', ['type' => 'all', 'page' => 1, 'sort' => 'created', 'direction' => 'desc'])
+            ->with('/orgs/KnpLabs/repos', ['type' => 'all', 'page' => 1])
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->repositories('KnpLabs'));

--- a/test/Github/Tests/Api/OrganizationTest.php
+++ b/test/Github/Tests/Api/OrganizationTest.php
@@ -62,7 +62,7 @@ class OrganizationTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/orgs/KnpLabs/repos', ['type' => 'all', 'page' => 1])
+            ->with('/orgs/KnpLabs/repos', ['type' => 'all', 'page' => 1, 'sort' => 'created', 'direction' => 'desc'])
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->repositories('KnpLabs'));


### PR DESCRIPTION
Hi,

It's possible to sort repositories of organizations here : https://developer.github.com/v3/repos/#list-organization-repositories.

I added `$sort` and `$direction` parameters after actual parameters to avoid BC.

Associated tests are updated too.