### PR TITLE
Add Support For GitData Reference Matching Methods

### DIFF
--- a/doc/gitdata/references.md
+++ b/doc/gitdata/references.md
@@ -7,6 +7,11 @@
 $references = $client->api('gitData')->references()->all('KnpLabs', 'php-github-api');
 ```
 
+### List Matching references
+```php
+$references = $client->api('gitData')->references()->matching('KnpLabs', 'php-github-api', 'heads/branchName'); // use 'tags/tagName' for third argument if ref is tag
+```
+
 ### Show a reference
 
 ```php

--- a/lib/Github/Api/GitData/References.php
+++ b/lib/Github/Api/GitData/References.php
@@ -26,6 +26,34 @@ class References extends AbstractApi
     }
 
     /**
+     * Get all matching references for a particular branch of a repository.
+     *
+     * @param string $username
+     * @param string $repository
+     * @param string $branch
+     *
+     * @return array
+     */
+    public function matchingBranch($username, $repository, $branch)
+    {
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/heads/'.$branch);
+    }
+
+    /**
+     * Get all matching references for a particular branch of a repository.
+     *
+     * @param string $username
+     * @param string $repository
+     * @param string $tag
+     *
+     * @return array
+     */
+    public function matchingTag($username, $repository, $tag)
+    {
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/tags/'.$tag);
+    }
+
+    /**
      * Get all branches of a repository.
      *
      * @param string $username

--- a/lib/Github/Api/GitData/References.php
+++ b/lib/Github/Api/GitData/References.php
@@ -36,7 +36,9 @@ class References extends AbstractApi
      */
     public function matching(string $username, string $repository, string $reference): array
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/'.rawurlencode($reference));
+        $reference = $this->encodeReference($reference);
+
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/'.$reference);
     }
 
     /**

--- a/lib/Github/Api/GitData/References.php
+++ b/lib/Github/Api/GitData/References.php
@@ -34,9 +34,9 @@ class References extends AbstractApi
      *
      * @return array
      */
-    public function matchingBranch($username, $repository, $branch)
+    public function matchingBranch(string $username, string $repository, string $branch): array
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/heads/'.$branch);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/heads/'.rawurlencode($branch));
     }
 
     /**
@@ -48,9 +48,9 @@ class References extends AbstractApi
      *
      * @return array
      */
-    public function matchingTag($username, $repository, $tag)
+    public function matchingTag(string $username, string $repository, string $tag): array
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/tags/'.$tag);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/tags/'.rawurlencode($tag));
     }
 
     /**

--- a/lib/Github/Api/GitData/References.php
+++ b/lib/Github/Api/GitData/References.php
@@ -28,8 +28,6 @@ class References extends AbstractApi
     /**
      * Get all matching references for the supplied reference name
      *
-     * https://developer.github.com/v3/git/refs/#list-matching-references
-     *
      * @param string $username
      * @param string $repository
      * @param string $reference

--- a/lib/Github/Api/GitData/References.php
+++ b/lib/Github/Api/GitData/References.php
@@ -26,7 +26,7 @@ class References extends AbstractApi
     }
 
     /**
-     * Get all matching references for the supplied reference name
+     * Get all matching references for the supplied reference name.
      *
      * @param string $username
      * @param string $repository

--- a/lib/Github/Api/GitData/References.php
+++ b/lib/Github/Api/GitData/References.php
@@ -26,31 +26,19 @@ class References extends AbstractApi
     }
 
     /**
-     * Get all matching references for a particular branch of a repository.
+     * Get all matching references for the supplied reference name
+     *
+     * https://developer.github.com/v3/git/refs/#list-matching-references
      *
      * @param string $username
      * @param string $repository
-     * @param string $branch
+     * @param string $reference
      *
      * @return array
      */
-    public function matchingBranch(string $username, string $repository, string $branch): array
+    public function matching(string $username, string $repository, string $reference): array
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/heads/'.rawurlencode($branch));
-    }
-
-    /**
-     * Get all matching references for a particular branch of a repository.
-     *
-     * @param string $username
-     * @param string $repository
-     * @param string $tag
-     *
-     * @return array
-     */
-    public function matchingTag(string $username, string $repository, string $tag): array
-    {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/tags/'.rawurlencode($tag));
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/git/matching-refs/'.rawurlencode($reference));
     }
 
     /**

--- a/test/Github/Tests/Api/GitData/ReferencesTest.php
+++ b/test/Github/Tests/Api/GitData/ReferencesTest.php
@@ -74,33 +74,17 @@ class ReferencesTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetAllMatchingBranchRepoReferences()
+    public function shouldGetAllMatchingReferences()
     {
         $expectedValue = [['reference' => 'some data']];
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/l3l0/l3l0repo/git/matching-refs/heads/branchName')
+            ->with('/repos/l3l0/l3l0repo/git/matching-refs/refName')
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->matchingBranch('l3l0', 'l3l0repo', 'branchName'));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldGetAllMatchingTagRepoReferences()
-    {
-        $expectedValue = [['reference' => 'some data']];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('/repos/l3l0/l3l0repo/git/matching-refs/tags/tagName')
-            ->will($this->returnValue($expectedValue));
-
-        $this->assertEquals($expectedValue, $api->matchingTag('l3l0', 'l3l0repo', 'tagName'));
+        $this->assertEquals($expectedValue, $api->matching('l3l0', 'l3l0repo', 'refName'));
     }
 
     /**

--- a/test/Github/Tests/Api/GitData/ReferencesTest.php
+++ b/test/Github/Tests/Api/GitData/ReferencesTest.php
@@ -74,6 +74,38 @@ class ReferencesTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllMatchingBranchRepoReferences()
+    {
+        $expectedValue = [['reference' => 'some data']];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/l3l0/l3l0repo/git/matching-refs/heads/branchName')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->matchingBranch('l3l0', 'l3l0repo', 'branchName'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllMatchingTagRepoReferences()
+    {
+        $expectedValue = [['reference' => 'some data']];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/l3l0/l3l0repo/git/matching-refs/tags/tagName')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->matchingTag('l3l0', 'l3l0repo', 'tagName'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetAllRepoBranches()
     {
         $expectedValue = [['branch' => 'some data']];

--- a/test/Github/Tests/Api/GitData/ReferencesTest.php
+++ b/test/Github/Tests/Api/GitData/ReferencesTest.php
@@ -81,10 +81,10 @@ class ReferencesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/l3l0/l3l0repo/git/matching-refs/refName')
+            ->with('/repos/l3l0/l3l0repo/git/matching-refs/heads/refName')
             ->will($this->returnValue($expectedValue));
 
-        $this->assertEquals($expectedValue, $api->matching('l3l0', 'l3l0repo', 'refName'));
+        $this->assertEquals($expectedValue, $api->matching('l3l0', 'l3l0repo', 'heads/refName'));
     }
 
     /**


### PR DESCRIPTION
This PR adds two methods - `matchingBranch()` and `matchingTag()` to `GitHub/Api/GitData/References.php`.  These methods return the references for a given branch or tag, respectively.  

There are two more tests to `GitHub/Tests/Api/GitData/ReferencesTest.php`, `shouldGetAllMatchingBranchRepoReferences` and `shouldGetAllMatchingTagRepoReferences`.

Documentation here: https://developer.github.com/v3/git/refs/#list-matching-references
