### PR TITLE
fix: use new media type for branch protections

### DIFF
--- a/lib/Github/Api/Repository/Protection.php
+++ b/lib/Github/Api/Repository/Protection.php
@@ -34,6 +34,9 @@ class Protection extends AbstractApi
      */
     public function show($username, $repository, $branch)
     {
+        // Preview endpoint
+        $this->acceptHeaderValue = 'application/vnd.github.luke-cage-preview+json';
+
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/branches/'.rawurlencode($branch).'/protection');
     }
 
@@ -51,6 +54,9 @@ class Protection extends AbstractApi
      */
     public function update($username, $repository, $branch, array $params = [])
     {
+        // Preview endpoint
+        $this->acceptHeaderValue = 'application/vnd.github.luke-cage-preview+json';
+
         return $this->put('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/branches/'.rawurlencode($branch).'/protection', $params);
     }
 

--- a/lib/Github/Api/Repository/Protection.php
+++ b/lib/Github/Api/Repository/Protection.php
@@ -16,7 +16,7 @@ class Protection extends AbstractApi
 
     public function configure()
     {
-        $this->acceptHeaderValue = 'application/vnd.github.luke-cage-preview+json';
+        $this->acceptHeaderValue = 'application/vnd.github.loki-preview+json';
 
         return $this;
     }

--- a/lib/Github/Api/Repository/Protection.php
+++ b/lib/Github/Api/Repository/Protection.php
@@ -16,7 +16,7 @@ class Protection extends AbstractApi
 
     public function configure()
     {
-        $this->acceptHeaderValue = 'application/vnd.github.loki-preview+json';
+        $this->acceptHeaderValue = 'application/vnd.github.luke-cage-preview+json';
 
         return $this;
     }


### PR DESCRIPTION
Not sure when this changed, but `loki` is not the preview anymore. It is `luke-cage`. Without this fix you won't get back branch protection values. (like required amount of reviewers).

https://developer.github.com/v3/repos/branches/#get-branch-protection

If you need to support commit signature crud, that has a different media type under Protections, but I don't see that supported at this time.