### PR TITLE
Disable phpstan for HistoryTrait to prevent false positive error

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,3 +2,5 @@ parameters:
     level: 4
     paths:
         - lib
+    excludes_analyse:
+        - lib/Github/HttpClient/Plugin/HistoryTrait.php


### PR DESCRIPTION
I've noticed that phpstan tests are failing all the time. This is a possible "fix" to ignore the tricky file.