### PR TITLE
Don't use deprecated auth in examples

### DIFF
--- a/doc/currentuser/repositories.md
+++ b/doc/currentuser/repositories.md
@@ -25,6 +25,6 @@ There are three values that can be passed into the `repositories` method: `type`
 
 ```php
 $client = new \Github\Client(); 
-$client->authenticate($github_token, null, \Github\Client::AUTH_HTTP_TOKEN);
+$client->authenticate($github_token, null, \Github\Client::AUTH_ACCESS_TOKEN);
 $client->currentUser()->repositories();
 ```

--- a/doc/security.md
+++ b/doc/security.md
@@ -51,11 +51,11 @@ Note however that GitHub describes this method as deprecated. In most case you s
 ### Authenticating as an Integration
 
 To authenticate as an integration you need to supply a JSON Web Token with `Github\Client::AUTH_JWT` to request
-and installation access token which is then usable with `Github\Client::AUTH_HTTP_TOKEN`. [Github´s integration
+and installation access token which is then usable with `Github\Client::AUTH_ACCESS_TOKEN`. [Github´s integration
 authentication docs](https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-a-github-app) describe the flow in detail.
 It´s important for integration requests to use the custom Accept header `application/vnd.github.machine-man-preview`.
 
-The following sample code authenticates as an installation using [lcobucci/jwt](https://github.com/lcobucci/jwt/tree/3.2.0)
+The following sample code authenticates as an installation using [lcobucci/jwt](https://github.com/lcobucci/jwt/tree/3.3.2)
 to generate a JSON Web Token (JWT).
 
 ```php
@@ -78,7 +78,7 @@ $jwt = (new Builder)
 $github->authenticate($jwt, null, Github\Client::AUTH_JWT);
 
 $token = $github->api('apps')->createInstallationToken($installationId);
-$github->authenticate($token['token'], null, Github\Client::AUTH_HTTP_TOKEN);
+$github->authenticate($token['token'], null, Github\Client::AUTH_ACCESS_TOKEN);
 ```
 
 The `$integrationId` you can find in the about section of your github app.


### PR DESCRIPTION
`AUTH_HTTP_TOKEN` is deprecated, and all examples should instead use `AUTH_ACCESS_TOKEN`.