### PR TITLE
Show user by ID

### DIFF
--- a/doc/users.md
+++ b/doc/users.md
@@ -36,6 +36,13 @@ $user = $client->api('user')->show('KnpLabs');
 
 Returns an array of information about the user.
 
+
+You can also use the User ID, but it will use an undocumented Github API
+
+```php
+$user = $client->api('user')->showById(202732);
+```
+
 ### Update user information
 
 > Requires [authentication](security.md).

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -58,10 +58,10 @@ class User extends AbstractApi
     {
         return $this->get('/users/'.rawurlencode($username));
     }
-    
+
     /**
      * Get extended information about a user by its id.
-     * Note: at time of writing this is an undocumented feature
+     * Note: at time of writing this is an undocumented feature but GitHub support have advised that it can be relied on.
      *
      * @link http://developer.github.com/v3/users/
      *

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -58,6 +58,21 @@ class User extends AbstractApi
     {
         return $this->get('/users/'.rawurlencode($username));
     }
+    
+    /**
+     * Get extended information about a user by its id.
+     * Note: at time of writing this is an undocumented feature
+     *
+     * @link http://developer.github.com/v3/users/
+     *
+     * @param int $id the id of the user to show
+     *
+     * @return array information about the user
+     */
+    public function showById($id)
+    {
+        return $this->get('/user/'.rawurlencode($id));
+    }
 
     /**
      * Get extended information about a user by its username.

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -71,7 +71,7 @@ class User extends AbstractApi
      */
     public function showById($id)
     {
-        return $this->get('/user/'.rawurlencode($id));
+        return $this->get('/user/'.$id);
     }
 
     /**

--- a/test/Github/Tests/Api/UserTest.php
+++ b/test/Github/Tests/Api/UserTest.php
@@ -23,6 +23,22 @@ class UserTest extends TestCase
     /**
      * @test
      */
+    public function shouldShowByIdUser()
+    {
+        $expectedArray = ['id' => 1, 'username' => 'l3l0'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/user/1')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->showById(1));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetUserOrganizations()
     {
         $expectedArray = [[


### PR DESCRIPTION
Revamp of https://github.com/KnpLabs/php-github-api/pull/372 which was abandonned, and following the example of https://github.com/KnpLabs/php-github-api/pull/579


As of 2020, gettting data by ID is still undocumented. I contacted Github support to make sure it could be relied on.


> <img width="691" alt="Screen Shot 2020-07-02 at 10 12 15 PM" src="https://user-images.githubusercontent.com/664857/86434021-2d17f700-bcb1-11ea-9f19-2008ce47412d.png">


------
I have been working with an old application and I have to deal with actions made by user that have changed their login since. The old login are now used by totally different people, which can be problematic.