### PR TITLE
Add support for SSO errors coming from the API

### DIFF
--- a/lib/Github/Exception/SsoRequiredException.php
+++ b/lib/Github/Exception/SsoRequiredException.php
@@ -11,8 +11,8 @@ class SsoRequiredException extends RuntimeException
     private $url;
 
     /**
-     * @param string $url
-     * @param int $code
+     * @param string          $url
+     * @param int             $code
      * @param \Throwable|null $previous
      */
     public function __construct($url, $code = 0, $previous = null)

--- a/lib/Github/Exception/SsoRequiredException.php
+++ b/lib/Github/Exception/SsoRequiredException.php
@@ -16,10 +16,8 @@ class SsoRequiredException extends RuntimeException
         parent::__construct('Resource protected by organization SAML enforcement. You must grant your personal token access to this organization.', $code, $previous);
     }
 
-
     public function getUrl()
     {
         return $this->url;
     }
-
 }

--- a/lib/Github/Exception/SsoRequiredException.php
+++ b/lib/Github/Exception/SsoRequiredException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Github\Exception;
+
+/**
+ * SsoRequiredException.
+ */
+class SsoRequiredException extends RuntimeException
+{
+    private $url;
+
+    public function __construct($url, $code = 0, $previous = null)
+    {
+        $this->url = $url;
+
+        parent::__construct('Resource protected by organization SAML enforcement. You must grant your personal token access to this organization.', $code, $previous);
+    }
+
+
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+}

--- a/lib/Github/Exception/SsoRequiredException.php
+++ b/lib/Github/Exception/SsoRequiredException.php
@@ -7,8 +7,14 @@ namespace Github\Exception;
  */
 class SsoRequiredException extends RuntimeException
 {
+    /** @var string */
     private $url;
 
+    /**
+     * @param string $url
+     * @param int $code
+     * @param \Throwable|null $previous
+     */
     public function __construct($url, $code = 0, $previous = null)
     {
         $this->url = $url;
@@ -16,6 +22,9 @@ class SsoRequiredException extends RuntimeException
         parent::__construct('Resource protected by organization SAML enforcement. You must grant your personal token access to this organization.', $code, $previous);
     }
 
+    /**
+     * @return string
+     */
     public function getUrl()
     {
         return $this->url;

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -3,6 +3,7 @@
 namespace Github\Tests\HttpClient\Plugin;
 
 use Github\Exception\ExceptionInterface;
+use Github\Exception\SsoRequiredException;
 use Github\HttpClient\Plugin\GithubExceptionThrower;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
@@ -135,6 +136,16 @@ class GithubExceptionThrowerTest extends TestCase
                     )
                 ),
                 'exception' => new \Github\Exception\RuntimeException('Something went wrong with executing your query', 502),
+            ],
+            'Sso required Response' => [
+                'response' => new Response(
+                    403,
+                    [
+                        'Content-Type' => 'application/json',
+                        'X-GitHub-SSO' => 'required; url=https://github.com/orgs/octodocs-test/sso?authorization_request=AZSCKtL4U8yX1H3sCQIVnVgmjmon5fWxks5YrqhJgah0b2tlbl9pZM4EuMz4',
+                    ]
+                ),
+                'exception' => new \Github\Exception\SsoRequiredException('https://github.com/orgs/octodocs-test/sso?authorization_request=AZSCKtL4U8yX1H3sCQIVnVgmjmon5fWxks5YrqhJgah0b2tlbl9pZM4EuMz4')
             ],
             'Default handling' => [
                 'response' => new Response(

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -3,7 +3,6 @@
 namespace Github\Tests\HttpClient\Plugin;
 
 use Github\Exception\ExceptionInterface;
-use Github\Exception\SsoRequiredException;
 use Github\HttpClient\Plugin\GithubExceptionThrower;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -144,7 +144,7 @@ class GithubExceptionThrowerTest extends TestCase
                         'X-GitHub-SSO' => 'required; url=https://github.com/orgs/octodocs-test/sso?authorization_request=AZSCKtL4U8yX1H3sCQIVnVgmjmon5fWxks5YrqhJgah0b2tlbl9pZM4EuMz4',
                     ]
                 ),
-                'exception' => new \Github\Exception\SsoRequiredException('https://github.com/orgs/octodocs-test/sso?authorization_request=AZSCKtL4U8yX1H3sCQIVnVgmjmon5fWxks5YrqhJgah0b2tlbl9pZM4EuMz4')
+                'exception' => new \Github\Exception\SsoRequiredException('https://github.com/orgs/octodocs-test/sso?authorization_request=AZSCKtL4U8yX1H3sCQIVnVgmjmon5fWxks5YrqhJgah0b2tlbl9pZM4EuMz4'),
             ],
             'Default handling' => [
                 'response' => new Response(


### PR DESCRIPTION
Hello, thanks for this!

I just had a case where a token I used were throwing a runtimeexception because the org in question for the resource, had enforced SAML authentication. This was not something I could explicitly catch and do something with, so here is a PR fixing that.

Thanks again, keep up the good work!