### PR TITLE
Fix call to test a webhook method

### DIFF
--- a/lib/Github/Api/Repository/Hooks.php
+++ b/lib/Github/Api/Repository/Hooks.php
@@ -47,7 +47,7 @@ class Hooks extends AbstractApi
 
     public function test($username, $repository, $id)
     {
-        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id).'/test');
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/hooks/'.rawurlencode($id).'/tests');
     }
 
     public function remove($username, $repository, $id)

--- a/test/Github/Tests/Api/Repository/HooksTest.php
+++ b/test/Github/Tests/Api/Repository/HooksTest.php
@@ -144,7 +144,7 @@ class HooksTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('/repos/KnpLabs/php-github-api/hooks/123/test')
+            ->with('/repos/KnpLabs/php-github-api/hooks/123/tests')
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->test('KnpLabs', 'php-github-api', 123));


### PR DESCRIPTION
See renamed URL in the note at https://docs.github.com/en/rest/reference/repos#test-the-push-repository-webhook

Using old URL gives an error "Resource not accessible by integration"