### PR TITLE
Allow to paginate and set limit for repos per app installation

### DIFF
--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -135,15 +135,15 @@ class Apps extends AbstractApi
     /**
      * List repositories that are accessible to the authenticated installation.
      *
-     * @link https://developer.github.com/v3/apps/installations/#list-repositories
+     * @link https://docs.github.com/en/rest/reference/apps#list-repositories-accessible-to-the-app-installation
      *
      * @param int $userId
+     * @param array $parameters
      *
      * @return array
      */
-    public function listRepositories($userId = null)
+    public function listRepositories($userId = null, array $parameters = [])
     {
-        $parameters = [];
         if ($userId) {
             $parameters['user_id'] = $userId;
         }


### PR DESCRIPTION
Docs: https://docs.github.com/en/rest/reference/apps#list-repositories-accessible-to-the-app-installation

Additionally, I want to admit that the user parameter is not supported for this endpoint and should be removed. But this would be a BC. What do you think?

Or, I can change PR like this:

```php
    public function listRepositories($parameters = [])
    {
        if (!is_array($parameters)) {
            $parameters = [];
        }

        $this->configurePreviewHeader();

        return $this->get('/installation/repositories', $parameters);
    }
```