### PR TITLE
Adding GitHub authentication to GraphQL documentation

### DIFF
--- a/doc/graphql.md
+++ b/doc/graphql.md
@@ -9,6 +9,16 @@ Wraps [GitHub v4 API (GraphQL API)](http://developer.github.com/v4/).
 $rateLimits = $client->api('graphql')->execute($query);
 ```
 
+#### Authentication
+
+To use [GitHub v4 API (GraphQL API)](http://developer.github.com/v4/) requests must [authenticated]((../security.md)).
+
+```php
+$client->authenticate($token, null, Github\Client::AUTH_ACCESS_TOKEN);
+
+$result = $client->api('graphql')->execute($query);
+```
+
 #### Use variables
 
 [Variables](https://developer.github.com/v4/guides/forming-calls/#working-with-variables) allow specifying of requested data without dynamical change of a query on a client side.
@@ -27,6 +37,8 @@ QUERY;
 $variables = [
     'organizationLogin' => 'KnpLabs'
 ];
+
+$client->authenticate('<your-token>', null, Github\Client::AUTH_ACCESS_TOKEN);
 
 $orgInfo = $client->api('graphql')->execute($query, $variables);
 ```


### PR DESCRIPTION
First of all: I love your library, great work 👍 

While discovering the official [GitHub GraphQL documentation](https://docs.github.com/en/free-pro-team@latest/graphql) and your repository, I recognized that is currently not possible to communicate with the GraphQL API without authenticating your requests.

I updated the documentation on behalf of GraphQL and added the `\Github\Client::authenticate` to the code examples. I also added small chapter with some links.

This may help other developers to get started with the GraphQL library 😄 