### PR TITLE
Allow PHP8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-versions: ['7.1', '7.2', '7.3', '7.4']
+                php-versions: ['7.2', '7.3', '7.4', '8.0']
 
         steps:
             - uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
 
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.1
+                  php-version: 7.2
                   coverage: none
 
             - name: Install Composer Dependencies

--- a/composer.json
+++ b/composer.json
@@ -17,27 +17,27 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2 || ^8.0",
+        "php-http/cache-plugin": "^1.7.1",
         "php-http/client-common": "^2.3",
-        "php-http/cache-plugin": "^1.7",
-        "php-http/discovery": "^1.11",
-        "php-http/httplug": "^2.1",
-        "php-http/multipart-stream-builder": "^1.1",
+        "php-http/discovery": "^1.12",
+        "php-http/httplug": "^2.2",
+        "php-http/multipart-stream-builder": "^1.1.2",
         "psr/cache": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "cache/array-adapter": "^1.0.1",
-        "guzzlehttp/psr7": "^1.5.2",
+        "symfony/cache": "^5.1.8",
+        "guzzlehttp/psr7": "^1.7",
         "http-interop/http-factory-guzzle": "^1.0",
-        "php-http/guzzle6-adapter": "^2.0.1",
-        "php-http/mock-client": "^1.4",
-        "phpstan/phpstan": "^0.12.32",
-        "phpstan/extension-installer": "^1.0.4",
-        "phpstan/phpstan-deprecation-rules": "^0.12.4",
-        "phpunit/phpunit": "^7.5.15 || ^8.4 || ^9.0"
+        "guzzlehttp/guzzle": "^7.2",
+        "php-http/mock-client": "^1.4.1",
+        "phpstan/phpstan": "^0.12.57",
+        "phpstan/extension-installer": "^1.0.5",
+        "phpstan/phpstan-deprecation-rules": "^0.12.5",
+        "phpunit/phpunit": "^8.5 || ^9.4"
     },
     "autoload": {
         "psr-4": { "Github\\": "lib/Github/" }

--- a/test/Github/Tests/Functional/CacheTest.php
+++ b/test/Github/Tests/Functional/CacheTest.php
@@ -2,9 +2,9 @@
 
 namespace Github\Tests\Functional;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use Github\Client;
 use GuzzleHttp\Psr7\Response;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * @group functional
@@ -23,7 +23,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $mockClient->addResponse($this->getCurrentUserResponse('octocat'));
 
         $github = Client::createWithHttpClient($mockClient);
-        $github->addCache(new ArrayCachePool(), ['default_ttl'=>600]);
+        $github->addCache(new ArrayAdapter(), ['default_ttl'=>600]);
 
         $github->authenticate('fake_token_aaa', Client::AUTH_ACCESS_TOKEN);
         $userA = $github->currentUser()->show();
@@ -43,7 +43,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $mockClient->addResponse($this->getCurrentUserResponse('octocat'));
 
         $github = Client::createWithHttpClient($mockClient);
-        $github->addCache(new ArrayCachePool(), ['default_ttl'=>600]);
+        $github->addCache(new ArrayAdapter(), ['default_ttl'=>600]);
 
         $github->authenticate('fake_token_aaa', Client::AUTH_ACCESS_TOKEN);
         $userA = $github->currentUser()->show();


### PR DESCRIPTION
Also switch the psr cache dev dependency to `symfony/cache` to allow php8 testing