### PR TITLE
Add parameters to PullRequest commits method

### DIFF
--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -80,9 +80,9 @@ class PullRequest extends AbstractApi
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.$id);
     }
 
-    public function commits($username, $repository, $id)
+    public function commits($username, $repository, $id, array $parameters = [])
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/commits');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/commits', $parameters);
     }
 
     public function files($username, $repository, $id, array $parameters = [])

--- a/test/Github/Tests/Api/PullRequestTest.php
+++ b/test/Github/Tests/Api/PullRequestTest.php
@@ -90,6 +90,22 @@ class PullRequestTest extends TestCase
     /**
      * @test
      */
+    public function shouldShowCommitsFromPullRequestForPage()
+    {
+        $expectedArray = [['id' => 'id', 'sha' => '123123']];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/ezsystems/ezpublish/pulls/15/commits', ['page' => 2, 'per_page' => 30])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->commits('ezsystems', 'ezpublish', '15', ['page' => 2, 'per_page' => 30]));
+    }
+
+    /**
+     * @test
+     */
     public function shouldShowFilesFromPullRequest()
     {
         $expectedArray = [['id' => 'id', 'sha' => '123123']];


### PR DESCRIPTION
Add a `$parameters` parameter to the `PullRequest::commits()` method to allow for pagination.

As per the docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/pulls#list-commits-on-a-pull-request