### PR TITLE
Throw exception for graphql errors

### DIFF
--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -154,6 +154,29 @@ class GithubExceptionThrowerTest extends TestCase
                 ),
                 'exception' => new \Github\Exception\RuntimeException('Error message', 555),
             ],
+            'Graphql error response (200)' => [
+                'response' => new Response(
+                    200,
+                    [
+                        'content-type' => 'application/json',
+                    ],
+                    json_encode(
+                        [
+                            'errors' => [
+                                [
+                                    ['path' => ['query', 'repository']],
+                                    'message' => 'Field "xxxx" doesn\'t exist on type "Issue"',
+                                ],
+                                [
+                                    ['path' => ['query', 'repository']],
+                                    'message' => 'Field "dummy" doesn\'t exist on type "PullRequest"',
+                                ],
+                            ],
+                        ]
+                    )
+                ),
+                'exception' => new \Github\Exception\RuntimeException('Field "xxxx" doesn\'t exist on type "Issue", Field "dummy" doesn\'t exist on type "PullRequest"'),
+            ],
         ];
     }
 }


### PR DESCRIPTION
I noticed that errors from the graphql api didn't throw errors by our ExceptionThrower plugin. That's because the graphql api return HTTP code 200 even when the api had an error. 

> The GraphQL spec 6 doesn’t make any mention of HTTP status codes in the case of an error. Additionally, I would suggest that the error you show in your post is an application level error, not an HTTP protocol level error. It’s the same thing as when someone submits a value to an HTML form field that is incorrectly formatted … such as an invalid email address. Your web application returns a 200 HTTP status code because everything is fine at the HTTP protocol level, but displays an error message to the user asking them to supply a valid email address in the form.

See https://github.community/t/github-api-v4-error-returns-200-status-code/14178/2

So I've adjusted the exception thrower to check HTTP 200 responses for grapql errors, with the early return's in the check function the overhead should be minimal.