### PR TITLE
[3.x] Make PHP 7.2.5 the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.2.5 || ^8.0",
         "php-http/cache-plugin": "^1.7.1",
         "php-http/client-common": "^2.3",
         "php-http/discovery": "^1.12",


### PR DESCRIPTION
Avoids some bugs in early releases of PHP 7.2, and matches the the same minimum PHP version of Laravel 6 LTS and Symfony 5.