### PR TITLE
[3.x] Added some additional scalar types and return types

### DIFF
--- a/lib/Github/Api/AbstractApi.php
+++ b/lib/Github/Api/AbstractApi.php
@@ -4,6 +4,7 @@ namespace Github\Api;
 
 use Github\Client;
 use Github\HttpClient\Message\ResponseMediator;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>
@@ -42,7 +43,7 @@ abstract class AbstractApi
      *
      * @return Client
      */
-    protected function getClient()
+    protected function getClient(): Client
     {
         return $this->client;
     }
@@ -52,13 +53,17 @@ abstract class AbstractApi
      *
      * @return string
      */
-    protected function getApiVersion()
+    protected function getApiVersion(): string
     {
         return $this->client->getApiVersion();
     }
 
+    /**
+     * @return $this
+     */
     public function configure()
     {
+        return $this;
     }
 
     /**
@@ -70,7 +75,7 @@ abstract class AbstractApi
      *
      * @return array|string
      */
-    protected function get($path, array $parameters = [], array $requestHeaders = [])
+    protected function get(string $path, array $parameters = [], array $requestHeaders = [])
     {
         if (null !== $this->perPage && !isset($parameters['per_page'])) {
             $parameters['per_page'] = $this->perPage;
@@ -96,9 +101,9 @@ abstract class AbstractApi
      * @param array  $parameters     HEAD parameters.
      * @param array  $requestHeaders Request headers.
      *
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return ResponseInterface
      */
-    protected function head($path, array $parameters = [], array $requestHeaders = [])
+    protected function head(string $path, array $parameters = [], array $requestHeaders = []): ResponseInterface
     {
         if (array_key_exists('ref', $parameters) && null === $parameters['ref']) {
             unset($parameters['ref']);
@@ -116,7 +121,7 @@ abstract class AbstractApi
      *
      * @return array|string
      */
-    protected function post($path, array $parameters = [], array $requestHeaders = [])
+    protected function post(string $path, array $parameters = [], array $requestHeaders = [])
     {
         return $this->postRaw(
             $path,
@@ -134,7 +139,7 @@ abstract class AbstractApi
      *
      * @return array|string
      */
-    protected function postRaw($path, $body, array $requestHeaders = [])
+    protected function postRaw(string $path, $body, array $requestHeaders = [])
     {
         $response = $this->client->getHttpClient()->post(
             $path,
@@ -154,7 +159,7 @@ abstract class AbstractApi
      *
      * @return array|string
      */
-    protected function patch($path, array $parameters = [], array $requestHeaders = [])
+    protected function patch(string $path, array $parameters = [], array $requestHeaders = [])
     {
         $response = $this->client->getHttpClient()->patch(
             $path,
@@ -174,7 +179,7 @@ abstract class AbstractApi
      *
      * @return array|string
      */
-    protected function put($path, array $parameters = [], array $requestHeaders = [])
+    protected function put(string $path, array $parameters = [], array $requestHeaders = [])
     {
         $response = $this->client->getHttpClient()->put(
             $path,
@@ -194,7 +199,7 @@ abstract class AbstractApi
      *
      * @return array|string
      */
-    protected function delete($path, array $parameters = [], array $requestHeaders = [])
+    protected function delete(string $path, array $parameters = [], array $requestHeaders = [])
     {
         $response = $this->client->getHttpClient()->delete(
             $path,
@@ -212,7 +217,7 @@ abstract class AbstractApi
      *
      * @return string|null
      */
-    protected function createJsonBody(array $parameters)
+    protected function createJsonBody(array $parameters): ?string
     {
         return (count($parameters) === 0) ? null : json_encode($parameters, empty($parameters) ? JSON_FORCE_OBJECT : 0);
     }

--- a/lib/Github/Api/AcceptHeaderTrait.php
+++ b/lib/Github/Api/AcceptHeaderTrait.php
@@ -2,6 +2,8 @@
 
 namespace Github\Api;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * A trait to make sure we add accept headers on all requests.
  *
@@ -12,37 +14,37 @@ trait AcceptHeaderTrait
     /** @var string */
     protected $acceptHeaderValue;
 
-    protected function get($path, array $parameters = [], array $requestHeaders = [])
+    protected function get(string $path, array $parameters = [], array $requestHeaders = [])
     {
         return parent::get($path, $parameters, $this->mergeHeaders($requestHeaders));
     }
 
-    protected function head($path, array $parameters = [], array $requestHeaders = [])
+    protected function head(string $path, array $parameters = [], array $requestHeaders = []): ResponseInterface
     {
         return parent::head($path, $parameters, $this->mergeHeaders($requestHeaders));
     }
 
-    protected function post($path, array $parameters = [], array $requestHeaders = [])
+    protected function post(string $path, array $parameters = [], array $requestHeaders = [])
     {
         return parent::post($path, $parameters, $this->mergeHeaders($requestHeaders));
     }
 
-    protected function postRaw($path, $body, array $requestHeaders = [])
+    protected function postRaw(string $path, $body, array $requestHeaders = [])
     {
         return parent::postRaw($path, $body, $this->mergeHeaders($requestHeaders));
     }
 
-    protected function patch($path, array $parameters = [], array $requestHeaders = [])
+    protected function patch(string $path, array $parameters = [], array $requestHeaders = [])
     {
         return parent::patch($path, $parameters, $this->mergeHeaders($requestHeaders));
     }
 
-    protected function put($path, array $parameters = [], array $requestHeaders = [])
+    protected function put(string $path, array $parameters = [], array $requestHeaders = [])
     {
         return parent::put($path, $parameters, $this->mergeHeaders($requestHeaders));
     }
 
-    protected function delete($path, array $parameters = [], array $requestHeaders = [])
+    protected function delete(string $path, array $parameters = [], array $requestHeaders = [])
     {
         return parent::delete($path, $parameters, $this->mergeHeaders($requestHeaders));
     }
@@ -52,7 +54,7 @@ trait AcceptHeaderTrait
      *
      * @return array
      */
-    private function mergeHeaders(array $headers = [])
+    private function mergeHeaders(array $headers = []): array
     {
         $default = [];
         if ($this->acceptHeaderValue) {

--- a/lib/Github/Api/CurrentUser/Starring.php
+++ b/lib/Github/Api/CurrentUser/Starring.php
@@ -21,7 +21,7 @@ class Starring extends AbstractApi
      *
      * @param string $bodyType
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null)
     {

--- a/lib/Github/Api/Gist/Comments.php
+++ b/lib/Github/Api/Gist/Comments.php
@@ -21,7 +21,7 @@ class Comments extends AbstractApi
      *
      * @param string|null $bodyType
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null)
     {

--- a/lib/Github/Api/Gists.php
+++ b/lib/Github/Api/Gists.php
@@ -24,7 +24,7 @@ class Gists extends AbstractApi
      *
      * @param string|null $bodyType
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null)
     {

--- a/lib/Github/Api/GitData/Blobs.php
+++ b/lib/Github/Api/GitData/Blobs.php
@@ -21,7 +21,7 @@ class Blobs extends AbstractApi
      *
      * @param string|null $bodyType
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null)
     {

--- a/lib/Github/Api/Issue.php
+++ b/lib/Github/Api/Issue.php
@@ -29,7 +29,7 @@ class Issue extends AbstractApi
      *
      * @param string|null $bodyType
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null)
     {

--- a/lib/Github/Api/Issue/Comments.php
+++ b/lib/Github/Api/Issue/Comments.php
@@ -23,7 +23,7 @@ class Comments extends AbstractApi
      *
      * @param string|null $bodyType
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null)
     {

--- a/lib/Github/Api/Project/AbstractProjectApi.php
+++ b/lib/Github/Api/Project/AbstractProjectApi.php
@@ -14,7 +14,7 @@ abstract class AbstractProjectApi extends AbstractApi
      *
      * @see https://developer.github.com/v3/repos/projects/#projects
      *
-     * @return self
+     * @return $this
      */
     public function configure()
     {

--- a/lib/Github/Api/Project/Cards.php
+++ b/lib/Github/Api/Project/Cards.php
@@ -15,7 +15,7 @@ class Cards extends AbstractApi
      *
      * @see https://developer.github.com/v3/repos/projects/#projects
      *
-     * @return self
+     * @return $this
      */
     public function configure()
     {

--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -27,7 +27,7 @@ class PullRequest extends AbstractApi
      * @param string|null $bodyType
      * @param string|null $apiVersion
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null, $apiVersion = null)
     {

--- a/lib/Github/Api/PullRequest/Comments.php
+++ b/lib/Github/Api/PullRequest/Comments.php
@@ -23,7 +23,7 @@ class Comments extends AbstractApi
      * @param string|null $bodyType
      * @param string|null $apiVersion
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null, $apiVersion = null)
     {

--- a/lib/Github/Api/Repository/Comments.php
+++ b/lib/Github/Api/Repository/Comments.php
@@ -23,7 +23,7 @@ class Comments extends AbstractApi
      *
      * @param string|null $bodyType
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null)
     {

--- a/lib/Github/Api/Repository/Contents.php
+++ b/lib/Github/Api/Repository/Contents.php
@@ -25,7 +25,7 @@ class Contents extends AbstractApi
      *
      * @param string|null $bodyType
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null)
     {

--- a/lib/Github/Api/Repository/Stargazers.php
+++ b/lib/Github/Api/Repository/Stargazers.php
@@ -22,7 +22,7 @@ class Stargazers extends AbstractApi
      *
      * @param string $bodyType
      *
-     * @return self
+     * @return $this
      */
     public function configure($bodyType = null)
     {

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -15,6 +15,7 @@ use Http\Client\Common\Plugin;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Simple yet very cool PHP GitHub client.
@@ -142,7 +143,7 @@ class Client
      *
      * @return Client
      */
-    public static function createWithHttpClient(ClientInterface $httpClient)
+    public static function createWithHttpClient(ClientInterface $httpClient): self
     {
         $builder = new Builder($httpClient);
 
@@ -156,7 +157,7 @@ class Client
      *
      * @return AbstractApi
      */
-    public function api($name)
+    public function api($name): AbstractApi
     {
         switch ($name) {
             case 'me':
@@ -311,7 +312,7 @@ class Client
      *
      * @return void
      */
-    public function authenticate($tokenOrLogin, $password = null, $authMethod = null)
+    public function authenticate($tokenOrLogin, $password = null, $authMethod = null): void
     {
         if (null === $authMethod && (self::AUTH_JWT === $password || self::AUTH_ACCESS_TOKEN === $password)) {
             $authMethod = $password;
@@ -333,7 +334,7 @@ class Client
      *
      * @return void
      */
-    private function setEnterpriseUrl($enterpriseUrl)
+    private function setEnterpriseUrl($enterpriseUrl): void
     {
         $builder = $this->getHttpClientBuilder();
         $builder->removePlugin(Plugin\AddHostPlugin::class);
@@ -346,7 +347,7 @@ class Client
     /**
      * @return string
      */
-    public function getApiVersion()
+    public function getApiVersion(): string
     {
         return $this->apiVersion;
     }
@@ -359,7 +360,7 @@ class Client
      *
      * @return void
      */
-    public function addCache(CacheItemPoolInterface $cachePool, array $config = [])
+    public function addCache(CacheItemPoolInterface $cachePool, array $config = []): void
     {
         $this->getHttpClientBuilder()->addCache($cachePool, $config);
     }
@@ -369,7 +370,7 @@ class Client
      *
      * @return void
      */
-    public function removeCache()
+    public function removeCache(): void
     {
         $this->getHttpClientBuilder()->removeCache();
     }
@@ -380,7 +381,7 @@ class Client
      *
      * @return AbstractApi
      */
-    public function __call($name, $args)
+    public function __call($name, $args): AbstractApi
     {
         try {
             return $this->api($name);
@@ -392,7 +393,7 @@ class Client
     /**
      * @return null|\Psr\Http\Message\ResponseInterface
      */
-    public function getLastResponse()
+    public function getLastResponse(): ?ResponseInterface
     {
         return $this->responseHistory->getLastResponse();
     }
@@ -400,7 +401,7 @@ class Client
     /**
      * @return HttpMethodsClientInterface
      */
-    public function getHttpClient()
+    public function getHttpClient(): HttpMethodsClientInterface
     {
         return $this->getHttpClientBuilder()->getHttpClient();
     }
@@ -408,7 +409,7 @@ class Client
     /**
      * @return Builder
      */
-    protected function getHttpClientBuilder()
+    protected function getHttpClientBuilder(): Builder
     {
         return $this->httpClientBuilder;
     }

--- a/lib/Github/Exception/ApiLimitExceedException.php
+++ b/lib/Github/Exception/ApiLimitExceedException.php
@@ -2,9 +2,9 @@
 
 namespace Github\Exception;
 
+use Throwable;
+
 /**
- * ApiLimitExceedException.
- *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
 class ApiLimitExceedException extends RuntimeException
@@ -15,12 +15,12 @@ class ApiLimitExceedException extends RuntimeException
     private $reset;
 
     /**
-     * @param int             $limit
-     * @param int             $reset
-     * @param int             $code
-     * @param \Throwable|null $previous
+     * @param int            $limit
+     * @param int            $reset
+     * @param int            $code
+     * @param Throwable|null $previous
      */
-    public function __construct($limit = 5000, $reset = 1800, $code = 0, $previous = null)
+    public function __construct(int $limit = 5000, int $reset = 1800, int $code = 0, Throwable $previous = null)
     {
         $this->limit = (int) $limit;
         $this->reset = (int) $reset;
@@ -31,7 +31,7 @@ class ApiLimitExceedException extends RuntimeException
     /**
      * @return int
      */
-    public function getLimit()
+    public function getLimit(): int
     {
         return $this->limit;
     }
@@ -39,7 +39,7 @@ class ApiLimitExceedException extends RuntimeException
     /**
      * @return int
      */
-    public function getResetTime()
+    public function getResetTime(): int
     {
         return $this->reset;
     }

--- a/lib/Github/Exception/BadMethodCallException.php
+++ b/lib/Github/Exception/BadMethodCallException.php
@@ -3,8 +3,6 @@
 namespace Github\Exception;
 
 /**
- * BadMethodCallException.
- *
  * @author James Brooks <jbrooksuk@me.com>
  */
 class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface

--- a/lib/Github/Exception/ErrorException.php
+++ b/lib/Github/Exception/ErrorException.php
@@ -3,8 +3,6 @@
 namespace Github\Exception;
 
 /**
- * ErrorException.
- *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
 class ErrorException extends \ErrorException implements ExceptionInterface

--- a/lib/Github/Exception/InvalidArgumentException.php
+++ b/lib/Github/Exception/InvalidArgumentException.php
@@ -3,8 +3,6 @@
 namespace Github\Exception;
 
 /**
- * InvalidArgumentException.
- *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface

--- a/lib/Github/Exception/MissingArgumentException.php
+++ b/lib/Github/Exception/MissingArgumentException.php
@@ -2,19 +2,19 @@
 
 namespace Github\Exception;
 
+use Throwable;
+
 /**
- * MissingArgumentException.
- *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
 class MissingArgumentException extends ErrorException
 {
     /**
-     * @param string|array    $required
-     * @param int             $code
-     * @param \Throwable|null $previous
+     * @param string|array   $required
+     * @param int            $code
+     * @param Throwable|null $previous
      */
-    public function __construct($required, $code = 0, $previous = null)
+    public function __construct($required, int $code = 0, Throwable $previous = null)
     {
         if (is_string($required)) {
             $required = [$required];

--- a/lib/Github/Exception/RuntimeException.php
+++ b/lib/Github/Exception/RuntimeException.php
@@ -3,8 +3,6 @@
 namespace Github\Exception;
 
 /**
- * RuntimeException.
- *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
 class RuntimeException extends \RuntimeException implements ExceptionInterface

--- a/lib/Github/Exception/SsoRequiredException.php
+++ b/lib/Github/Exception/SsoRequiredException.php
@@ -2,20 +2,19 @@
 
 namespace Github\Exception;
 
-/**
- * SsoRequiredException.
- */
+use Throwable;
+
 class SsoRequiredException extends RuntimeException
 {
     /** @var string */
     private $url;
 
     /**
-     * @param string          $url
-     * @param int             $code
-     * @param \Throwable|null $previous
+     * @param string         $url
+     * @param int            $code
+     * @param Throwable|null $previous
      */
-    public function __construct($url, $code = 0, $previous = null)
+    public function __construct(string $url, int $code = 0, Throwable $previous = null)
     {
         $this->url = $url;
 

--- a/lib/Github/Exception/TwoFactorAuthenticationRequiredException.php
+++ b/lib/Github/Exception/TwoFactorAuthenticationRequiredException.php
@@ -2,17 +2,19 @@
 
 namespace Github\Exception;
 
+use Throwable;
+
 class TwoFactorAuthenticationRequiredException extends RuntimeException
 {
     /** @var string */
     private $type;
 
     /**
-     * @param string          $type
-     * @param int             $code
-     * @param \Throwable|null $previous
+     * @param string         $type
+     * @param int            $code
+     * @param Throwable|null $previous
      */
-    public function __construct($type, $code = 0, $previous = null)
+    public function __construct(string $type, int $code = 0, Throwable $previous = null)
     {
         $this->type = $type;
         parent::__construct('Two factor authentication is enabled on this account', $code, $previous);
@@ -21,7 +23,7 @@ class TwoFactorAuthenticationRequiredException extends RuntimeException
     /**
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }

--- a/lib/Github/HttpClient/Builder.php
+++ b/lib/Github/HttpClient/Builder.php
@@ -90,7 +90,7 @@ class Builder
     /**
      * @return HttpMethodsClientInterface
      */
-    public function getHttpClient()
+    public function getHttpClient(): HttpMethodsClientInterface
     {
         if ($this->httpClientModified) {
             $this->httpClientModified = false;
@@ -117,7 +117,7 @@ class Builder
      *
      * @return void
      */
-    public function addPlugin(Plugin $plugin)
+    public function addPlugin(Plugin $plugin): void
     {
         $this->plugins[] = $plugin;
         $this->httpClientModified = true;
@@ -130,7 +130,7 @@ class Builder
      *
      * @return void
      */
-    public function removePlugin($fqcn)
+    public function removePlugin(string $fqcn): void
     {
         foreach ($this->plugins as $idx => $plugin) {
             if ($plugin instanceof $fqcn) {
@@ -145,7 +145,7 @@ class Builder
      *
      * @return void
      */
-    public function clearHeaders()
+    public function clearHeaders(): void
     {
         $this->headers = [];
 
@@ -158,7 +158,7 @@ class Builder
      *
      * @return void
      */
-    public function addHeaders(array $headers)
+    public function addHeaders(array $headers): void
     {
         $this->headers = array_merge($this->headers, $headers);
 
@@ -172,7 +172,7 @@ class Builder
      *
      * @return void
      */
-    public function addHeaderValue($header, $headerValue)
+    public function addHeaderValue(string $header, string $headerValue): void
     {
         if (!isset($this->headers[$header])) {
             $this->headers[$header] = $headerValue;
@@ -192,7 +192,7 @@ class Builder
      *
      * @return void
      */
-    public function addCache(CacheItemPoolInterface $cachePool, array $config = [])
+    public function addCache(CacheItemPoolInterface $cachePool, array $config = []): void
     {
         if (!isset($config['cache_key_generator'])) {
             $config['cache_key_generator'] = new HeaderCacheKeyGenerator(['Authorization', 'Cookie', 'Accept', 'Content-type']);
@@ -206,7 +206,7 @@ class Builder
      *
      * @return void
      */
-    public function removeCache()
+    public function removeCache(): void
     {
         $this->cachePlugin = null;
         $this->httpClientModified = true;

--- a/lib/Github/HttpClient/Message/ResponseMediator.php
+++ b/lib/Github/HttpClient/Message/ResponseMediator.php
@@ -30,7 +30,7 @@ class ResponseMediator
      *
      * @return array<string,string>
      */
-    public static function getPagination(ResponseInterface $response)
+    public static function getPagination(ResponseInterface $response): array
     {
         $header = self::getHeader($response, 'Link');
 
@@ -56,7 +56,7 @@ class ResponseMediator
      *
      * @return string|null
      */
-    public static function getApiLimit(ResponseInterface $response)
+    public static function getApiLimit(ResponseInterface $response): ?string
     {
         $remainingCallsHeader = self::getHeader($response, 'X-RateLimit-Remaining');
 
@@ -81,7 +81,7 @@ class ResponseMediator
      *
      * @return string|null
      */
-    public static function getHeader(ResponseInterface $response, string $name)
+    public static function getHeader(ResponseInterface $response, string $name): ?string
     {
         $headers = $response->getHeader($name);
 

--- a/lib/Github/HttpClient/Plugin/Authentication.php
+++ b/lib/Github/HttpClient/Plugin/Authentication.php
@@ -35,7 +35,7 @@ class Authentication implements Plugin
      * @param string|null $password     GitHub password/secret (optionally can contain $method)
      * @param string|null $method       One of the AUTH_* class constants
      */
-    public function __construct($tokenOrLogin, $password, $method)
+    public function __construct(string $tokenOrLogin, ?string $password, ?string $method)
     {
         $this->tokenOrLogin = $tokenOrLogin;
         $this->password = $password;

--- a/lib/Github/HttpClient/Plugin/History.php
+++ b/lib/Github/HttpClient/Plugin/History.php
@@ -22,7 +22,7 @@ class History implements Journal
     /**
      * @return ResponseInterface|null
      */
-    public function getLastResponse()
+    public function getLastResponse(): ?ResponseInterface
     {
         return $this->lastResponse;
     }
@@ -30,7 +30,7 @@ class History implements Journal
     /**
      * @return void
      */
-    public function addSuccess(RequestInterface $request, ResponseInterface $response)
+    public function addSuccess(RequestInterface $request, ResponseInterface $response): void
     {
         $this->lastResponse = $response;
     }
@@ -38,7 +38,7 @@ class History implements Journal
     /**
      * @return void
      */
-    public function addFailure(RequestInterface $request, ClientExceptionInterface $exception)
+    public function addFailure(RequestInterface $request, ClientExceptionInterface $exception): void
     {
     }
 }

--- a/lib/Github/HttpClient/Plugin/PathPrepend.php
+++ b/lib/Github/HttpClient/Plugin/PathPrepend.php
@@ -21,7 +21,7 @@ class PathPrepend implements Plugin
     /**
      * @param string $path
      */
-    public function __construct($path)
+    public function __construct(string $path)
     {
         $this->path = $path;
     }

--- a/lib/Github/ResultPager.php
+++ b/lib/Github/ResultPager.php
@@ -2,6 +2,8 @@
 
 namespace Github;
 
+use Closure;
+use Generator;
 use Github\Api\AbstractApi;
 use Github\HttpClient\Message\ResponseMediator;
 use ValueError;
@@ -71,10 +73,10 @@ class ResultPager implements ResultPagerInterface
     /**
      * {@inheritdoc}
      */
-    public function fetch(AbstractApi $api, string $method, array $parameters = [])
+    public function fetch(AbstractApi $api, string $method, array $parameters = []): array
     {
         $paginatorPerPage = $this->perPage;
-        $closure = \Closure::bind(function (AbstractApi $api) use ($paginatorPerPage) {
+        $closure = Closure::bind(function (AbstractApi $api) use ($paginatorPerPage) {
             $clone = clone $api;
             $clone->perPage = $paginatorPerPage;
 
@@ -92,7 +94,7 @@ class ResultPager implements ResultPagerInterface
     /**
      * {@inheritdoc}
      */
-    public function fetchAll(AbstractApi $api, string $method, array $parameters = [])
+    public function fetchAll(AbstractApi $api, string $method, array $parameters = []): array
     {
         return iterator_to_array($this->fetchAllLazy($api, $method, $parameters));
     }
@@ -100,7 +102,7 @@ class ResultPager implements ResultPagerInterface
     /**
      * {@inheritdoc}
      */
-    public function fetchAllLazy(AbstractApi $api, string $method, array $parameters = [])
+    public function fetchAllLazy(AbstractApi $api, string $method, array $parameters = []): Generator
     {
         $result = $this->fetch($api, $method, $parameters);
 
@@ -122,7 +124,7 @@ class ResultPager implements ResultPagerInterface
     /**
      * {@inheritdoc}
      */
-    public function postFetch()
+    public function postFetch(): void
     {
         $this->pagination = ResponseMediator::getPagination($this->client->getLastResponse());
     }
@@ -130,7 +132,7 @@ class ResultPager implements ResultPagerInterface
     /**
      * {@inheritdoc}
      */
-    public function hasNext()
+    public function hasNext(): bool
     {
         return isset($this->pagination['next']);
     }
@@ -138,7 +140,7 @@ class ResultPager implements ResultPagerInterface
     /**
      * {@inheritdoc}
      */
-    public function fetchNext()
+    public function fetchNext(): array
     {
         return $this->get('next');
     }
@@ -146,7 +148,7 @@ class ResultPager implements ResultPagerInterface
     /**
      * {@inheritdoc}
      */
-    public function hasPrevious()
+    public function hasPrevious(): bool
     {
         return isset($this->pagination['prev']);
     }
@@ -154,7 +156,7 @@ class ResultPager implements ResultPagerInterface
     /**
      * {@inheritdoc}
      */
-    public function fetchPrevious()
+    public function fetchPrevious(): array
     {
         return $this->get('prev');
     }
@@ -162,7 +164,7 @@ class ResultPager implements ResultPagerInterface
     /**
      * {@inheritdoc}
      */
-    public function fetchFirst()
+    public function fetchFirst(): array
     {
         return $this->get('first');
     }
@@ -170,7 +172,7 @@ class ResultPager implements ResultPagerInterface
     /**
      * {@inheritdoc}
      */
-    public function fetchLast()
+    public function fetchLast(): array
     {
         return $this->get('last');
     }
@@ -180,7 +182,7 @@ class ResultPager implements ResultPagerInterface
      *
      * @return array
      */
-    protected function get(string $key)
+    protected function get(string $key): array
     {
         if (!isset($this->pagination[$key])) {
             return [];

--- a/lib/Github/ResultPagerInterface.php
+++ b/lib/Github/ResultPagerInterface.php
@@ -2,6 +2,7 @@
 
 namespace Github;
 
+use Generator;
 use Github\Api\AbstractApi;
 
 /**
@@ -22,7 +23,7 @@ interface ResultPagerInterface
      *
      * @return array returns the result of the Api::$method() call
      */
-    public function fetch(AbstractApi $api, string $method, array $parameters = []);
+    public function fetch(AbstractApi $api, string $method, array $parameters = []): array;
 
     /**
      * Fetch all results (pages) from an api call.
@@ -35,7 +36,7 @@ interface ResultPagerInterface
      *
      * @return array returns a merge of the results of the Api::$method() call
      */
-    public function fetchAll(AbstractApi $api, string $method, array $parameters = []);
+    public function fetchAll(AbstractApi $api, string $method, array $parameters = []): array;
 
     /**
      * Lazily fetch all results (pages) from an api call.
@@ -48,54 +49,54 @@ interface ResultPagerInterface
      *
      * @return \Generator returns a merge of the results of the Api::$method() call
      */
-    public function fetchAllLazy(AbstractApi $api, string $method, array $parameters = []);
+    public function fetchAllLazy(AbstractApi $api, string $method, array $parameters = []): Generator;
 
     /**
      * Method that performs the actual work to refresh the pagination property.
      *
      * @return void
      */
-    public function postFetch();
+    public function postFetch(): void;
 
     /**
      * Check to determine the availability of a next page.
      *
      * @return bool
      */
-    public function hasNext();
+    public function hasNext(): bool;
 
     /**
      * Check to determine the availability of a previous page.
      *
      * @return bool
      */
-    public function hasPrevious();
+    public function hasPrevious(): bool;
 
     /**
      * Fetch the next page.
      *
      * @return array
      */
-    public function fetchNext();
+    public function fetchNext(): array;
 
     /**
      * Fetch the previous page.
      *
      * @return array
      */
-    public function fetchPrevious();
+    public function fetchPrevious(): array;
 
     /**
      * Fetch the first page.
      *
      * @return array
      */
-    public function fetchFirst();
+    public function fetchFirst(): array;
 
     /**
      * Fetch the last page.
      *
      * @return array
      */
-    public function fetchLast();
+    public function fetchLast(): array;
 }

--- a/test/Github/Tests/ResultPagerTest.php
+++ b/test/Github/Tests/ResultPagerTest.php
@@ -110,7 +110,7 @@ class ResultPagerTest extends \PHPUnit\Framework\TestCase
 
     public function testFetch()
     {
-        $result = 'foo';
+        $result = ['foo'];
         $method = 'all';
         $parameters = ['baz'];
         $api = $this->getMockBuilder(Members::class)


### PR DESCRIPTION
I've **not** added return types to all the API methods. If that is wanted, it could be followed up with an additional PR, but we'd have to be very confident all the return type phpdoc was correct before making them real return types (indeed, not all the methods in there even have documented return types)!

---

Depends on https://github.com/KnpLabs/php-github-api/pull/950.