### PR TITLE
Fixed issues with ResultPager and various github responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
+        "ext-json": "*",
         "php-http/cache-plugin": "^1.7.1",
         "php-http/client-common": "^2.3",
         "php-http/discovery": "^1.12",

--- a/lib/Github/ResultPager.php
+++ b/lib/Github/ResultPager.php
@@ -104,19 +104,25 @@ class ResultPager implements ResultPagerInterface
     {
         $result = $this->fetch($api, $method, $parameters);
 
-        foreach ($result['items'] ?? $result as $item) {
-            yield $item;
+        foreach ($result['items'] ?? $result as $key => $item) {
+            if (is_string($key)) {
+                yield $key => $item;
+            } else {
+                yield $item;
+            }
         }
 
         while ($this->hasNext()) {
             $result = $this->fetchNext();
 
-            foreach ($result['items'] ?? $result as $item) {
-                yield $item;
+            foreach ($result['items'] ?? $result as $key => $item) {
+                if (is_string($key)) {
+                    yield $key => $item;
+                } else {
+                    yield $item;
+                }
             }
         }
-
-        return $result;
     }
 
     /**


### PR DESCRIPTION
I was testing the upcoming 3.0 version in a project using the resultpager and the current changes broke some of the expected responses.

For example when calling the commit status endpoints, it returns a general "state" property and a "statuses" property with the individual state values for each check. In this case the string keys have to be preserved.

@GrahamCampbell Can you review this PR as you did the initial improvements?