### PR TITLE
ExceptionThrower: adjust rate limit detection

### DIFF
--- a/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
+++ b/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
@@ -37,7 +37,7 @@ class GithubExceptionThrower implements Plugin
 
             // If error:
             $remaining = ResponseMediator::getHeader($response, 'X-RateLimit-Remaining');
-            if (null !== $remaining && 1 > $remaining && 'rate_limit' !== substr($request->getRequestTarget(), 1, 10)) {
+            if ((429 === $response->getStatusCode()) && null !== $remaining && 1 > $remaining && 'rate_limit' !== substr($request->getRequestTarget(), 1, 10)) {
                 $limit = (int) ResponseMediator::getHeader($response, 'X-RateLimit-Limit');
                 $reset = (int) ResponseMediator::getHeader($response, 'X-RateLimit-Reset');
 

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -177,6 +177,25 @@ class GithubExceptionThrowerTest extends TestCase
                 ),
                 'exception' => new \Github\Exception\RuntimeException('Field "xxxx" doesn\'t exist on type "Issue", Field "dummy" doesn\'t exist on type "PullRequest"'),
             ],
+            'Grapql requires authentication' => [
+                'response' => new Response(
+                    401,
+                    [
+                        'content-type' => 'application/json',
+                        'X-RateLimit-Limit' => 0,
+                        'X-RateLimit-Remaining' => 0,
+                        'X-RateLimit-Reset' => 1609245810,
+                        'X-RateLimit-Used' => 0,
+                    ],
+                    json_encode(
+                        [
+                            'message' => 'This endpoint requires you to be authenticated.',
+                            'documentation_url' => 'https://docs.github.com/v3/#authentication',
+                        ]
+                    )
+                ),
+                'exception' => new \Github\Exception\RuntimeException('This endpoint requires you to be authenticated.', 401),
+            ],
         ];
     }
 }


### PR DESCRIPTION
GitHub returns 0 values for API limit headers on GraphQL endpoints in cases where no authentication is provided or the authentication is invalid. Running the following code currently triggers an `ApiLimitExceedException` because of that. Even though the GitHub API returns a 401 status code with the message `This endpoint requires you to be authenticated.`

```
<?php
require 'vendor/autoload.php';

$client = new \Github\Client();
$client->graphql()->execute('query { viewer { organizations(last: 100) { nodes { name } } } }');
```