### PR TITLE
Add accept header for the checks API

### DIFF
--- a/lib/Github/Api/Repository/Checks/CheckRuns.php
+++ b/lib/Github/Api/Repository/Checks/CheckRuns.php
@@ -3,12 +3,22 @@
 namespace Github\Api\Repository\Checks;
 
 use Github\Api\AbstractApi;
+use Github\Api\AcceptHeaderTrait;
 
 /**
  * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks
  */
 class CheckRuns extends AbstractApi
 {
+    use AcceptHeaderTrait;
+
+    public function configure()
+    {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
+        return $this;
+    }
+
     /**
      * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#create-a-check-run
      *

--- a/lib/Github/Api/Repository/Checks/CheckRuns.php
+++ b/lib/Github/Api/Repository/Checks/CheckRuns.php
@@ -12,13 +12,6 @@ class CheckRuns extends AbstractApi
 {
     use AcceptHeaderTrait;
 
-    public function configure()
-    {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
-        return $this;
-    }
-
     /**
      * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#create-a-check-run
      *
@@ -26,6 +19,8 @@ class CheckRuns extends AbstractApi
      */
     public function create(string $username, string $repository, array $params = [])
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs', $params);
     }
 
@@ -36,6 +31,8 @@ class CheckRuns extends AbstractApi
      */
     public function show(string $username, string $repository, int $checkRunId)
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs/'.$checkRunId);
     }
 
@@ -46,6 +43,8 @@ class CheckRuns extends AbstractApi
      */
     public function update(string $username, string $repository, int $checkRunId, array $params = [])
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs/'.$checkRunId, $params);
     }
 
@@ -56,6 +55,8 @@ class CheckRuns extends AbstractApi
      */
     public function annotations(string $username, string $repository, int $checkRunId)
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs/'.$checkRunId.'/annotations');
     }
 
@@ -66,6 +67,8 @@ class CheckRuns extends AbstractApi
      */
     public function allForCheckSuite(string $username, string $repository, int $checkSuiteId, array $params = [])
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-suites/'.$checkSuiteId.'/check-runs', $params);
     }
 
@@ -76,6 +79,8 @@ class CheckRuns extends AbstractApi
      */
     public function allForReference(string $username, string $repository, string $ref, array $params = [])
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($ref).'/check-runs', $params);
     }
 }

--- a/lib/Github/Api/Repository/Checks/CheckSuites.php
+++ b/lib/Github/Api/Repository/Checks/CheckSuites.php
@@ -12,13 +12,6 @@ class CheckSuites extends AbstractApi
 {
     use AcceptHeaderTrait;
 
-    public function configure()
-    {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
-        return $this;
-    }
-
     /**
      * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#create-a-check-suite
      *
@@ -26,6 +19,8 @@ class CheckSuites extends AbstractApi
      */
     public function create(string $username, string $repository, array $params = [])
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-suites', $params);
     }
 
@@ -36,6 +31,8 @@ class CheckSuites extends AbstractApi
      */
     public function updatePreferences(string $username, string $repository, array $params = [])
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-suites/preferences', $params);
     }
 
@@ -46,6 +43,8 @@ class CheckSuites extends AbstractApi
      */
     public function getCheckSuite(string $username, string $repository, int $checkSuiteId)
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-suites/'.$checkSuiteId);
     }
 
@@ -56,6 +55,8 @@ class CheckSuites extends AbstractApi
      */
     public function rerequest(string $username, string $repository, int $checkSuiteId)
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-suites/'.$checkSuiteId.'/rerequest');
     }
 
@@ -66,6 +67,8 @@ class CheckSuites extends AbstractApi
      */
     public function allForReference(string $username, string $repository, string $ref, array $params = [])
     {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($ref).'/check-suites', $params);
     }
 }

--- a/lib/Github/Api/Repository/Checks/CheckSuites.php
+++ b/lib/Github/Api/Repository/Checks/CheckSuites.php
@@ -3,12 +3,22 @@
 namespace Github\Api\Repository\Checks;
 
 use Github\Api\AbstractApi;
+use Github\Api\AcceptHeaderTrait;
 
 /**
  * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks
  */
 class CheckSuites extends AbstractApi
 {
+    use AcceptHeaderTrait;
+
+    public function configure()
+    {
+        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
+
+        return $this;
+    }
+
     /**
      * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#create-a-check-suite
      *


### PR DESCRIPTION
Fixes #967.

This PR adds the Accept header back for the Checks API. This is required to make this work on GitHub Enterprise 2.22 (the latest stable version), which still considers this API a preview.