### PR TITLE
Add workflow dispatch and allow workflow names.

### DIFF
--- a/doc/repo/actions/workflow_runs.md
+++ b/doc/repo/actions/workflow_runs.md
@@ -14,7 +14,7 @@ $workflowRuns = $client->api('repo')->workflowRuns()->all('KnpLabs', 'php-github
 https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-runs
 
 ```php
-$runs = $client->api('repo')->workflowRuns()->listRuns('KnpLabs', 'php-github-api', $workflowId);
+$runs = $client->api('repo')->workflowRuns()->listRuns('KnpLabs', 'php-github-api', $workflow);
 ```
 
 ### Get a workflow run

--- a/doc/repo/actions/workflows.md
+++ b/doc/repo/actions/workflows.md
@@ -14,7 +14,7 @@ $workflows = $client->api('repo')->workflows()->all('KnpLabs', 'php-github-api')
 https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-workflow
 
 ```php
-$workflow = $client->api('repo')->workflows()->show('KnpLabs', 'php-github-api', $workflowId);
+$workflow = $client->api('repo')->workflows()->show('KnpLabs', 'php-github-api', $workflow);
 ```
 
 ### Get workflow usage
@@ -22,5 +22,13 @@ $workflow = $client->api('repo')->workflows()->show('KnpLabs', 'php-github-api',
 https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-workflow-usage
 
 ```php
-$usage = $client->api('repo')->workflows()->usage('KnpLabs', 'php-github-api', $workflowId);
+$usage = $client->api('repo')->workflows()->usage('KnpLabs', 'php-github-api', $workflow);
+```
+
+### Dispatch a workflow
+
+https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-a-workflow-dispatch-event
+
+```php
+$client->api('repo')->workflows()->dispatches('KnpLabs', 'php-github-api', $workflow, 'main');
 ```

--- a/lib/Github/Api/Repository/Actions/WorkflowRuns.php
+++ b/lib/Github/Api/Repository/Actions/WorkflowRuns.php
@@ -28,14 +28,14 @@ class WorkflowRuns extends AbstractApi
      *
      * @param string $username
      * @param string $repository
-     * @param string $workflowId
+     * @param string $workflow
      * @param array  $parameters
      *
      * @return array
      */
-    public function listRuns(string $username, string $repository, string $workflowId, array $parameters = [])
+    public function listRuns(string $username, string $repository, string $workflow, array $parameters = [])
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/actions/workflows/'.$workflowId.'/runs', $parameters);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/actions/workflows/'.rawurlencode($workflow).'/runs', $parameters);
     }
 
     /**

--- a/lib/Github/Api/Repository/Actions/Workflows.php
+++ b/lib/Github/Api/Repository/Actions/Workflows.php
@@ -26,28 +26,57 @@ class Workflows extends AbstractApi
     /**
      * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-workflow
      *
-     * @param string $username
-     * @param string $repository
-     * @param int    $workflowId
+     * @param string     $username
+     * @param string     $repository
+     * @param string|int $workflow
      *
      * @return array
      */
-    public function show(string $username, string $repository, int $workflowId)
+    public function show(string $username, string $repository, $workflow)
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/actions/workflows/'.$workflowId);
+        if (is_string($workflow)) {
+            $workflow = rawurlencode($workflow);
+        }
+
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/actions/workflows/'.$workflow);
     }
 
     /**
      * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-workflow-usage
      *
-     * @param string $username
-     * @param string $repository
-     * @param int    $workflowId
+     * @param string     $username
+     * @param string     $repository
+     * @param string|int $workflow
      *
      * @return array|string
      */
-    public function usage(string $username, string $repository, int $workflowId)
+    public function usage(string $username, string $repository, $workflow)
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/actions/workflows/'.$workflowId.'/timing');
+        if (is_string($workflow)) {
+            $workflow = rawurlencode($workflow);
+        }
+
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/actions/workflows/'.$workflow.'/timing');
+    }
+
+    /**
+     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-a-workflow-dispatch-event
+     *
+     * @param string     $username
+     * @param string     $repository
+     * @param string|int $workflow
+     * @param string     $ref
+     * @param array      $inputs
+     *
+     * @return array|string empty
+     */
+    public function dispatches(string $username, string $repository, $workflow, string $ref, array $inputs = null)
+    {
+        if (is_string($workflow)) {
+            $workflow = rawurlencode($workflow);
+        }
+        $parameters = array_filter(['ref' => $ref, 'inputs' => $inputs]);
+
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/actions/workflows/'.$workflow.'/dispatches', $parameters);
     }
 }

--- a/test/Github/Tests/Api/Repository/Actions/WorkflowsTest.php
+++ b/test/Github/Tests/Api/Repository/Actions/WorkflowsTest.php
@@ -89,6 +89,26 @@ class WorkflowsTest extends TestCase
         $this->assertEquals($expectedArray, $api->usage('KnpLabs', 'php-github-api', 1));
     }
 
+    /**
+     * @test
+     */
+    public function shouldDispatchWorkflow()
+    {
+        // empty
+        $expectedArray = [];
+
+        /** @var Workflows|MockObject $api */
+        $api = $this->getApiMock();
+
+        $api
+            ->expects($this->once())
+            ->method('post')
+            ->with('/repos/KnpLabs/php-github-api/actions/workflows/1/dispatches')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->dispatches('KnpLabs', 'php-github-api', 1, 'main'));
+    }
+
     protected function getApiClass()
     {
         return Workflows::class;


### PR DESCRIPTION
Adds the workflow dispatch proposed in #939.
This is different from the repository dispatch, as here it is clear what arguments to use, so that this is much more convenient to use.

Also update docs link.