### PR TITLE
Update new GitHub doc links in repo.

### DIFF
--- a/doc/organization/actions/secrets.md
+++ b/doc/organization/actions/secrets.md
@@ -3,7 +3,7 @@
 
 ### List organization secrets
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-organization-secrets
+https://docs.github.com/en/rest/reference/actions#list-organization-secrets
 
 ```php
 $secrets = $client->organization()->secrets()->all('KnpLabs');
@@ -11,7 +11,7 @@ $secrets = $client->organization()->secrets()->all('KnpLabs');
 
 ### Get an organization secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-an-organization-secret
+https://docs.github.com/en/rest/reference/actions#get-an-organization-secret
 
 ```php
 $secret = $client->organization()->secrets()->show('KnpLabs', $secretName);
@@ -19,7 +19,7 @@ $secret = $client->organization()->secrets()->show('KnpLabs', $secretName);
 
 ### Create an organization secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-or-update-an-organization-secret
+https://docs.github.com/en/rest/reference/actions#create-or-update-an-organization-secret
 
 ```php
 $client->organization()->secrets()->create('KnpLabs', $secretName, [
@@ -31,7 +31,7 @@ $client->organization()->secrets()->create('KnpLabs', $secretName, [
 
 ### Update an organization secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-or-update-an-organization-secret
+https://docs.github.com/en/rest/reference/actions#create-or-update-an-organization-secret
 
 ```php
 $client->organization()->secrets()->update('KnpLabs', $secretName, [
@@ -43,7 +43,7 @@ $client->organization()->secrets()->update('KnpLabs', $secretName, [
 
 ### Delete an organization secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-an-organization-secret
+https://docs.github.com/en/rest/reference/actions#delete-an-organization-secret
 
 ```php
 $client->organization()->secrets()->remove('KnpLabs', $secretName);
@@ -51,7 +51,7 @@ $client->organization()->secrets()->remove('KnpLabs', $secretName);
 
 ### List selected repositories for organization secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-selected-repositories-for-an-organization-secret
+https://docs.github.com/en/rest/reference/actions#list-selected-repositories-for-an-organization-secret
 
 ```php
 $client->organization()->secrets()->selectedRepositories('KnpLabs', $secretName);
@@ -59,7 +59,7 @@ $client->organization()->secrets()->selectedRepositories('KnpLabs', $secretName)
 
 ### Set selected repositories for an organization secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#set-selected-repositories-for-an-organization-secret
+https://docs.github.com/en/rest/reference/actions#set-selected-repositories-for-an-organization-secret
 
 ```php
 $client->organization()->secrets()->setSelectedRepositories('KnpLabs', 'secretName', [
@@ -69,7 +69,7 @@ $client->organization()->secrets()->setSelectedRepositories('KnpLabs', 'secretNa
 
 ### Remove selected repository from an organization secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#remove-selected-repository-from-an-organization-secret
+https://docs.github.com/en/rest/reference/actions#remove-selected-repository-from-an-organization-secret
 
 ```php
 $client->organization()->secrets()->addSecret('KnpLabs', $repositoryId, $secretName);
@@ -77,7 +77,7 @@ $client->organization()->secrets()->addSecret('KnpLabs', $repositoryId, $secretN
 
 ### Get an organization public key
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-an-organization-public-key
+https://docs.github.com/en/rest/reference/actions#get-an-organization-public-key
 
 ```php
 $client->organization()->secrets()->publicKey('KnpLabs');

--- a/doc/repo/actions/artifacts.md
+++ b/doc/repo/actions/artifacts.md
@@ -3,7 +3,7 @@
 
 ### List artifacts for a repository
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-artifacts-for-a-repository
+https://docs.github.com/en/rest/reference/actions#list-artifacts-for-a-repository
 
 ```php
 $artifacts = $client->api('repo')->artifacts()->all('KnpLabs');
@@ -11,7 +11,7 @@ $artifacts = $client->api('repo')->artifacts()->all('KnpLabs');
 
 ### List workflow run artifacts
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-run-artifacts
+https://docs.github.com/en/rest/reference/actions#list-workflow-run-artifacts
 
 ```php
 $runArtifacts = $client->api('repo')->artifacts()->runArtifacts('KnpLabs', 'php-github-api', $runId);
@@ -19,7 +19,7 @@ $runArtifacts = $client->api('repo')->artifacts()->runArtifacts('KnpLabs', 'php-
 
 ### Get an artifact
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-an-artifact
+https://docs.github.com/en/rest/reference/actions#get-an-artifact
 
 ```php
 $artifact = $client->api('repo')->artifacts()->show('KnpLabs', 'php-github-api', $artifactId);
@@ -27,7 +27,7 @@ $artifact = $client->api('repo')->artifacts()->show('KnpLabs', 'php-github-api',
 
 ### Delete an artifact
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-an-artifact
+https://docs.github.com/en/rest/reference/actions#delete-an-artifact
 
 ```php
 $client->api('repo')->artifacts()->delete('KnpLabs', 'php-github-api', $artifactId);
@@ -36,7 +36,7 @@ $client->api('repo')->artifacts()->delete('KnpLabs', 'php-github-api', $artifact
 
 ### Download an artifact
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#download-an-artifact
+https://docs.github.com/en/rest/reference/actions#download-an-artifact
 
 ```php
 $artifactFile = $client->api('repo')->artifacts()->download('KnpLabs', 'php-github-api', $artifactId, $format = 'zip');

--- a/doc/repo/actions/secrets.md
+++ b/doc/repo/actions/secrets.md
@@ -3,7 +3,7 @@
 
 ### List repository secrets
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-repository-secrets
+https://docs.github.com/en/rest/reference/actions#list-repository-secrets
 
 ```php
 $secrets = $client->api('repo')->secrets()->all('KnpLabs', 'php-github-api');
@@ -11,7 +11,7 @@ $secrets = $client->api('repo')->secrets()->all('KnpLabs', 'php-github-api');
 
 ### Get a repository secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-repository-secret
+https://docs.github.com/en/rest/reference/actions#get-a-repository-secret
 
 ```php
 $secret = $client->api('repo')->secrets()->show('KnpLabs', 'php-github-api', $secretName);
@@ -19,7 +19,7 @@ $secret = $client->api('repo')->secrets()->show('KnpLabs', 'php-github-api', $se
 
 ### Create a repository secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-or-update-a-repository-secret
+https://docs.github.com/en/rest/reference/actions#create-or-update-a-repository-secret
 
 ```php
 $client->api('repo')->secrets()->create('KnpLabs', 'php-github-api', $secretName, [
@@ -29,7 +29,7 @@ $client->api('repo')->secrets()->create('KnpLabs', 'php-github-api', $secretName
 
 ### Update a repository secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-or-update-a-repository-secret
+https://docs.github.com/en/rest/reference/actions#create-or-update-a-repository-secret
 
 ```php
 $client->api('repo')->secrets()->update('KnpLabs', 'php-github-api', $secretName, [
@@ -39,7 +39,7 @@ $client->api('repo')->secrets()->update('KnpLabs', 'php-github-api', $secretName
 
 ### Delete a repository secret
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-a-repository-secret
+https://docs.github.com/en/rest/reference/actions#delete-a-repository-secret
 
 ```php
 $client->api('repo')->secrets()->remove('KnpLabs', 'php-github-api', $secretName);
@@ -47,7 +47,7 @@ $client->api('repo')->secrets()->remove('KnpLabs', 'php-github-api', $secretName
 
 ### Get a repository public key
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-repository-public-key
+https://docs.github.com/en/rest/reference/actions#get-a-repository-public-key
 
 ```php
 $publicKey = $client->api('repo')->secrets()->publicKey('KnpLabs', 'php-github-api');

--- a/doc/repo/actions/self_hosted_runners.md
+++ b/doc/repo/actions/self_hosted_runners.md
@@ -3,7 +3,7 @@
 
 # List self-hosted runners for a repository
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-self-hosted-runners-for-a-repository
+https://docs.github.com/en/rest/reference/actions#list-self-hosted-runners-for-a-repository
 
 ```php
 $runners = $client->api('repo')->selfHostedRunners()->all('KnpLabs', 'php-github-api');
@@ -11,7 +11,7 @@ $runners = $client->api('repo')->selfHostedRunners()->all('KnpLabs', 'php-github
 
 # Get a self-hosted runner for a repository
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-self-hosted-runner-for-a-repository
+https://docs.github.com/en/rest/reference/actions#get-a-self-hosted-runner-for-a-repository
 
 ```php
 $runner = $client->api('repo')->selfHostedRunners()->show('KnpLabs', 'php-github-api', $runnerId);
@@ -19,7 +19,7 @@ $runner = $client->api('repo')->selfHostedRunners()->show('KnpLabs', 'php-github
 
 # Delete a self-hosted runner from a repository
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-a-self-hosted-runner-from-a-repository
+https://docs.github.com/en/rest/reference/actions#delete-a-self-hosted-runner-from-a-repository
 
 ```php
 $client->api('repo')->selfHostedRunners()->remove('KnpLabs', 'php-github-api', $runnerId);
@@ -27,7 +27,7 @@ $client->api('repo')->selfHostedRunners()->remove('KnpLabs', 'php-github-api', $
 
 # List runner applications for a repository
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-runner-applications-for-a-repository
+https://docs.github.com/en/rest/reference/actions#list-runner-applications-for-a-repository
 
 ```php
 $applications = $client->api('repo')->selfHostedRunners()->applications('KnpLabs', 'php-github-api');

--- a/doc/repo/actions/workflow_jobs.md
+++ b/doc/repo/actions/workflow_jobs.md
@@ -3,7 +3,7 @@
 
 ### List jobs for a workflow run
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-jobs-for-a-workflow-run
+https://docs.github.com/en/rest/reference/actions#list-jobs-for-a-workflow-run
 
 ```php
 $client->api('repo')->workflowJobs()->all('KnpLabs', 'php-github-api', $runId);
@@ -11,7 +11,7 @@ $client->api('repo')->workflowJobs()->all('KnpLabs', 'php-github-api', $runId);
 
 ### Get a job for a workflow run
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-job-for-a-workflow-run
+https://docs.github.com/en/rest/reference/actions#get-a-job-for-a-workflow-run
 
 ```php
 $job = $client->api('repo')->workflowJobs()->all('KnpLabs', 'php-github-api', $jobId);
@@ -19,7 +19,7 @@ $job = $client->api('repo')->workflowJobs()->all('KnpLabs', 'php-github-api', $j
 
 ### Download job logs for a workflow run
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#download-job-logs-for-a-workflow-run
+https://docs.github.com/en/rest/reference/actions#download-job-logs-for-a-workflow-run
 
 ```php
 $jobLogs = $client->api('repo')->workflowJobs()->downloadLogs('KnpLabs', 'php-github-api', $jobId);

--- a/doc/repo/actions/workflow_runs.md
+++ b/doc/repo/actions/workflow_runs.md
@@ -3,7 +3,7 @@
 
 ### List workflow runs for a repository
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-runs-for-a-repository
+https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
 
 ```php
 $workflowRuns = $client->api('repo')->workflowRuns()->all('KnpLabs', 'php-github-api');
@@ -11,7 +11,7 @@ $workflowRuns = $client->api('repo')->workflowRuns()->all('KnpLabs', 'php-github
 
 ### List workflow runs
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-runs
+https://docs.github.com/en/rest/reference/actions#list-workflow-runs
 
 ```php
 $runs = $client->api('repo')->workflowRuns()->listRuns('KnpLabs', 'php-github-api', $workflow);
@@ -19,7 +19,7 @@ $runs = $client->api('repo')->workflowRuns()->listRuns('KnpLabs', 'php-github-ap
 
 ### Get a workflow run
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-workflow-run
+https://docs.github.com/en/rest/reference/actions#get-a-workflow-run
 
 ```php
 $workflowRun = $client->api('repo')->workflowRuns()->show('KnpLabs', 'php-github-api', $runId);
@@ -27,7 +27,7 @@ $workflowRun = $client->api('repo')->workflowRuns()->show('KnpLabs', 'php-github
 
 ### Delete a workflow run
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-a-workflow-run
+https://docs.github.com/en/rest/reference/actions#delete-a-workflow-run
 
 ```php
 $client->api('repo')->workflowRuns()->remove('KnpLabs', 'php-github-api', $runId);
@@ -35,7 +35,7 @@ $client->api('repo')->workflowRuns()->remove('KnpLabs', 'php-github-api', $runId
 
 ### Re-run a workflow
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#re-run-a-workflow
+https://docs.github.com/en/rest/reference/actions#re-run-a-workflow
 
 ```php
 $client->api('repo')->workflowRuns()->rerun('KnpLabs', 'php-github-api', $runId);
@@ -43,7 +43,7 @@ $client->api('repo')->workflowRuns()->rerun('KnpLabs', 'php-github-api', $runId)
 
 ### Cancel a workflow run
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#cancel-a-workflow-run
+https://docs.github.com/en/rest/reference/actions#cancel-a-workflow-run
 
 ```php
 $client->api('repo')->workflowRuns()->cancel('KnpLabs', 'php-github-api', $runId);
@@ -51,7 +51,7 @@ $client->api('repo')->workflowRuns()->cancel('KnpLabs', 'php-github-api', $runId
 
 ### Get workflow run usage
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-workflow-run-usage
+https://docs.github.com/en/rest/reference/actions#get-workflow-run-usage
 
 ```php
 $workflowUsage = $client->api('repo')->workflowRuns()->usage('KnpLabs', 'php-github-api', $runId);
@@ -59,7 +59,7 @@ $workflowUsage = $client->api('repo')->workflowRuns()->usage('KnpLabs', 'php-git
 
 ### Download workflow run logs
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#download-workflow-run-logs
+https://docs.github.com/en/rest/reference/actions#download-workflow-run-logs
 
 ```php
 $logs = $client->api('repo')->workflowRuns()->downloadLogs('KnpLabs', 'php-github-api', $runId);
@@ -69,7 +69,7 @@ file_put_contents('logs.zip', $logs);
 
 ### Delete workflow run logs
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-workflow-run-logs
+https://docs.github.com/en/rest/reference/actions#delete-workflow-run-logs
 
 ```php
 $client->api('repo')->workflowRuns()->deleteLogs('KnpLabs', 'php-github-api', $runId);

--- a/doc/repo/actions/workflows.md
+++ b/doc/repo/actions/workflows.md
@@ -3,7 +3,7 @@
 
 ### List repository workflows
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-repository-workflows
+https://docs.github.com/en/rest/reference/actions#list-repository-workflows
 
 ```php
 $workflows = $client->api('repo')->workflows()->all('KnpLabs', 'php-github-api');
@@ -11,7 +11,7 @@ $workflows = $client->api('repo')->workflows()->all('KnpLabs', 'php-github-api')
 
 ### Get a workflow
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-workflow
+https://docs.github.com/en/rest/reference/actions#get-a-workflow
 
 ```php
 $workflow = $client->api('repo')->workflows()->show('KnpLabs', 'php-github-api', $workflow);
@@ -19,7 +19,7 @@ $workflow = $client->api('repo')->workflows()->show('KnpLabs', 'php-github-api',
 
 ### Get workflow usage
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-workflow-usage
+https://docs.github.com/en/rest/reference/actions#get-workflow-usage
 
 ```php
 $usage = $client->api('repo')->workflows()->usage('KnpLabs', 'php-github-api', $workflow);
@@ -27,7 +27,7 @@ $usage = $client->api('repo')->workflows()->usage('KnpLabs', 'php-github-api', $
 
 ### Dispatch a workflow
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-a-workflow-dispatch-event
+https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
 
 ```php
 $client->api('repo')->workflows()->dispatches('KnpLabs', 'php-github-api', $workflow, 'main');

--- a/doc/repo/check_runs.md
+++ b/doc/repo/check_runs.md
@@ -3,7 +3,7 @@
 
 ### Create a check run
 
-[Visit GitHub for a full of list of parameters and their descriptions.](https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#create-a-check-run)
+[Visit GitHub for a full of list of parameters and their descriptions.](https://docs.github.com/en/rest/reference/checks#create-a-check-run)
 
 ```php
 $params = [
@@ -17,7 +17,7 @@ $check = $client->api('repo')->checkRuns()->create('KnpLabs', 'php-github-api', 
 
 ### Get a check run
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#get-a-check-run
+https://docs.github.com/en/rest/reference/checks#get-a-check-run
 
 ```php
 $check = $client->api('repo')->checkRuns()->show('KnpLabs', 'php-github-api', $checkRunId);
@@ -25,7 +25,7 @@ $check = $client->api('repo')->checkRuns()->show('KnpLabs', 'php-github-api', $c
 
 ### Update an existing check run
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#update-a-check-run
+https://docs.github.com/en/rest/reference/checks#update-a-check-run
 
 ```php
 $params = [
@@ -38,7 +38,7 @@ $check = $client->api('repo')->checkRuns()->update('KnpLabs', 'php-github-api', 
 
 ### List check run annotations
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#list-check-run-annotations
+https://docs.github.com/en/rest/reference/checks#list-check-run-annotations
 
 ```php
 $annotations = $client->api('repo')->checkRuns()->annotations('KnpLabs', 'php-github-api', $checkRunId);
@@ -46,7 +46,7 @@ $annotations = $client->api('repo')->checkRuns()->annotations('KnpLabs', 'php-gi
 
 ### List check runs for a check suite
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#list-check-runs-in-a-check-suite
+https://docs.github.com/en/rest/reference/checks#list-check-runs-in-a-check-suite
 
 ```php
 $params = [/*...*/];
@@ -55,7 +55,7 @@ $checks = $client->api('repo')->checkRuns()->allForCheckSuite('KnpLabs', 'php-gi
 
 ### List check runs for a Git reference
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#list-check-runs-for-a-git-reference
+https://docs.github.com/en/rest/reference/checks#list-check-runs-for-a-git-reference
 
 ```php
 $params = [/*...*/];

--- a/doc/repo/check_suites.md
+++ b/doc/repo/check_suites.md
@@ -3,7 +3,7 @@
 
 ### Create a check suite
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#create-a-check-suite
+https://docs.github.com/en/rest/reference/checks#create-a-check-suite
 
 ```php
 $params = [
@@ -14,7 +14,7 @@ $check = $client->api('repo')->checkSuites()->create('KnpLabs', 'php-github-api'
 
 ### Update check suite preferences
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#update-repository-preferences-for-check-suites
+https://docs.github.com/en/rest/reference/checks#update-repository-preferences-for-check-suites
 
 ```php
 $params = [/*...*/];
@@ -23,7 +23,7 @@ $check = $client->api('repo')->checkSuites()->updatePreferences('KnpLabs', 'php-
 
 ### Get a check suite
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#get-a-check-suite
+https://docs.github.com/en/rest/reference/checks#get-a-check-suite
 
 ```php
 $check = $client->api('repo')->checkSuites()->getCheckSuite('KnpLabs', 'php-github-api', $checkSuiteId);
@@ -31,7 +31,7 @@ $check = $client->api('repo')->checkSuites()->getCheckSuite('KnpLabs', 'php-gith
 
 ### Rerequest a check suite
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#rerequest-a-check-suite
+https://docs.github.com/en/rest/reference/checks#rerequest-a-check-suite
 
 ```php
 $annotations = $client->api('repo')->checkSuites()->rerequest('KnpLabs', 'php-github-api', $checkSuiteId);
@@ -40,7 +40,7 @@ $annotations = $client->api('repo')->checkSuites()->rerequest('KnpLabs', 'php-gi
 
 ### List check suites for a Git reference
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#list-check-suites-for-a-git-reference
+https://docs.github.com/en/rest/reference/checks#list-check-suites-for-a-git-reference
 
 ```php
 $params = [/*...*/];

--- a/doc/repos.md
+++ b/doc/repos.md
@@ -273,7 +273,7 @@ Returns a list of languages.
 
 ### Enable automated security fixes
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#enable-automated-security-fixes
+https://docs.github.com/en/rest/reference/repos#enable-automated-security-fixes
 
 ```php
 $client->api('repo')->enableAutomatedSecurityFixes('KnpLabs', 'php-github-api');
@@ -281,7 +281,7 @@ $client->api('repo')->enableAutomatedSecurityFixes('KnpLabs', 'php-github-api');
 
 ### Disable automated security fixes
 
-https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#disable-automated-security-fixes
+https://docs.github.com/en/rest/reference/repos#disable-automated-security-fixes
 
 ```php
 $client->api('repo')->disableAutomatedSecurityFixes('KnpLabs', 'php-github-api');

--- a/lib/Github/Api/Organization/Actions/Secrets.php
+++ b/lib/Github/Api/Organization/Actions/Secrets.php
@@ -5,12 +5,12 @@ namespace Github\Api\Organization\Actions;
 use Github\Api\AbstractApi;
 
 /**
- * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#secrets
+ * @link https://docs.github.com/en/rest/reference/actions#secrets
  */
 class Secrets extends AbstractApi
 {
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-organization-secrets
+     * @link https://docs.github.com/en/rest/reference/actions#list-organization-secrets
      *
      * @param string $organization
      *
@@ -22,7 +22,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-an-organization-secret
+     * @link https://docs.github.com/en/rest/reference/actions#get-an-organization-secret
      *
      * @param string $organization
      * @param string $secretName
@@ -35,7 +35,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-or-update-an-organization-secret
+     * @link https://docs.github.com/en/rest/reference/actions#create-or-update-an-organization-secret
      *
      * @param string $organization
      * @param string $secretName
@@ -49,7 +49,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-or-update-an-organization-secret
+     * @link https://docs.github.com/en/rest/reference/actions#create-or-update-an-organization-secret
      *
      * @param string $organization
      * @param string $secretName
@@ -63,7 +63,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-an-organization-secret
+     * @link https://docs.github.com/en/rest/reference/actions#delete-an-organization-secret
      *
      * @param string $organization
      * @param string $secretName
@@ -76,7 +76,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-selected-repositories-for-an-organization-secret
+     * @link https://docs.github.com/en/rest/reference/actions#list-selected-repositories-for-an-organization-secret
      *
      * @param string $organization
      * @param string $secretName
@@ -89,7 +89,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#set-selected-repositories-for-an-organization-secret
+     * @link https://docs.github.com/en/rest/reference/actions#set-selected-repositories-for-an-organization-secret
      *
      * @param string $organization
      * @param string $secretName
@@ -103,7 +103,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#add-selected-repository-to-an-organization-secret
+     * @link https://docs.github.com/en/rest/reference/actions#add-selected-repository-to-an-organization-secret
      *
      * @param string $organization
      * @param string $repositoryId
@@ -117,7 +117,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#remove-selected-repository-from-an-organization-secret
+     * @link https://docs.github.com/en/rest/reference/actions#remove-selected-repository-from-an-organization-secret
      *
      * @param string $organization
      * @param string $repositoryId
@@ -131,7 +131,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-an-organization-public-key
+     * @link https://docs.github.com/en/rest/reference/actions#get-an-organization-public-key
      *
      * @param string $organization
      *

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -323,7 +323,7 @@ class Repo extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#check-runs
+     * @link https://docs.github.com/en/rest/reference/checks#check-runs
      */
     public function checkRuns(): CheckRuns
     {
@@ -331,7 +331,7 @@ class Repo extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#check-suites
+     * @link https://docs.github.com/en/rest/reference/checks#check-suites
      */
     public function checkSuites(): CheckSuites
     {
@@ -347,7 +347,7 @@ class Repo extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#workflows
+     * @link https://docs.github.com/en/rest/reference/actions#workflows
      */
     public function workflows(): Workflows
     {
@@ -355,7 +355,7 @@ class Repo extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#workflow-runs
+     * @link https://docs.github.com/en/rest/reference/actions#workflow-runs
      */
     public function workflowRuns(): WorkflowRuns
     {
@@ -363,7 +363,7 @@ class Repo extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#workflow-jobs
+     * @link https://docs.github.com/en/rest/reference/actions#workflow-jobs
      */
     public function workflowJobs(): WorkflowJobs
     {
@@ -371,7 +371,7 @@ class Repo extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#self-hosted-runners
+     * @link https://docs.github.com/en/rest/reference/actions#self-hosted-runners
      */
     public function selfHostedRunners(): SelfHostedRunners
     {
@@ -379,7 +379,7 @@ class Repo extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#secrets
+     * @link https://docs.github.com/en/rest/reference/actions#secrets
      */
     public function secrets(): Secrets
     {
@@ -646,7 +646,7 @@ class Repo extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#enable-automated-security-fixes
+     * @link https://docs.github.com/en/rest/reference/repos#enable-automated-security-fixes
      *
      * @param string $username
      * @param string $repository
@@ -661,7 +661,7 @@ class Repo extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#disable-automated-security-fixes
+     * @link https://docs.github.com/en/rest/reference/repos#disable-automated-security-fixes
      *
      * @param string $username
      * @param string $repository

--- a/lib/Github/Api/Repository/Actions/Artifacts.php
+++ b/lib/Github/Api/Repository/Actions/Artifacts.php
@@ -5,12 +5,12 @@ namespace Github\Api\Repository\Actions;
 use Github\Api\AbstractApi;
 
 /**
- * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#artifacts
+ * @link https://docs.github.com/en/rest/reference/actions#artifacts
  */
 class Artifacts extends AbstractApi
 {
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-artifacts-for-a-repository
+     * @link https://docs.github.com/en/rest/reference/actions#list-artifacts-for-a-repository
      *
      * @param string $username
      * @param string $repository
@@ -24,7 +24,7 @@ class Artifacts extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-run-artifacts
+     * @link https://docs.github.com/en/rest/reference/actions#list-workflow-run-artifacts
      *
      * @param string $username
      * @param string $repository
@@ -38,7 +38,7 @@ class Artifacts extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-an-artifact
+     * @link https://docs.github.com/en/rest/reference/actions#get-an-artifact
      *
      * @param string $username
      * @param string $repository
@@ -52,7 +52,7 @@ class Artifacts extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-an-artifact
+     * @link https://docs.github.com/en/rest/reference/actions#delete-an-artifact
      *
      * @param string $username
      * @param string $repository
@@ -66,7 +66,7 @@ class Artifacts extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#download-an-artifact
+     * @link https://docs.github.com/en/rest/reference/actions#download-an-artifact
      *
      * @param string $username
      * @param string $repository

--- a/lib/Github/Api/Repository/Actions/Secrets.php
+++ b/lib/Github/Api/Repository/Actions/Secrets.php
@@ -5,12 +5,12 @@ namespace Github\Api\Repository\Actions;
 use Github\Api\AbstractApi;
 
 /**
- * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#secrets
+ * @link https://docs.github.com/en/rest/reference/actions#secrets
  */
 class Secrets extends AbstractApi
 {
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-repository-secrets
+     * @link https://docs.github.com/en/rest/reference/actions#list-repository-secrets
      *
      * @param string $username
      * @param string $repository
@@ -23,7 +23,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-repository-secret
+     * @link https://docs.github.com/en/rest/reference/actions#get-a-repository-secret
      *
      * @param string $username
      * @param string $repository
@@ -37,7 +37,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-or-update-a-repository-secret
+     * @link https://docs.github.com/en/rest/reference/actions#create-or-update-a-repository-secret
      *
      * @param string $username
      * @param string $repository
@@ -52,7 +52,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-or-update-a-repository-secret
+     * @link https://docs.github.com/en/rest/reference/actions#create-or-update-a-repository-secret
      *
      * @param string $username
      * @param string $repository
@@ -67,7 +67,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-a-repository-secret
+     * @link https://docs.github.com/en/rest/reference/actions#delete-a-repository-secret
      *
      * @param string $username
      * @param string $repository
@@ -81,7 +81,7 @@ class Secrets extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-repository-public-key
+     * @link https://docs.github.com/en/rest/reference/actions#get-a-repository-public-key
      *
      * @param string $username
      * @param string $repository

--- a/lib/Github/Api/Repository/Actions/SelfHostedRunners.php
+++ b/lib/Github/Api/Repository/Actions/SelfHostedRunners.php
@@ -5,12 +5,12 @@ namespace Github\Api\Repository\Actions;
 use Github\Api\AbstractApi;
 
 /**
- * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#self-hosted-runners
+ * @link https://docs.github.com/en/rest/reference/actions#self-hosted-runners
  */
 class SelfHostedRunners extends AbstractApi
 {
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-self-hosted-runners-for-a-repository
+     * @link https://docs.github.com/en/rest/reference/actions#list-self-hosted-runners-for-a-repository
      *
      * @param string $username
      * @param string $repository
@@ -23,7 +23,7 @@ class SelfHostedRunners extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-self-hosted-runner-for-a-repository
+     * @link https://docs.github.com/en/rest/reference/actions#get-a-self-hosted-runner-for-a-repository
      *
      * @param string $username
      * @param string $repository
@@ -37,7 +37,7 @@ class SelfHostedRunners extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-a-self-hosted-runner-from-a-repository
+     * @link https://docs.github.com/en/rest/reference/actions#delete-a-self-hosted-runner-from-a-repository
      *
      * @param string $username
      * @param string $repository
@@ -51,7 +51,7 @@ class SelfHostedRunners extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-runner-applications-for-a-repository
+     * @link https://docs.github.com/en/rest/reference/actions#list-runner-applications-for-a-repository
      *
      * @param string $username
      * @param string $repository

--- a/lib/Github/Api/Repository/Actions/WorkflowJobs.php
+++ b/lib/Github/Api/Repository/Actions/WorkflowJobs.php
@@ -5,12 +5,12 @@ namespace Github\Api\Repository\Actions;
 use Github\Api\AbstractApi;
 
 /**
- * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#workflow-jobs
+ * @link https://docs.github.com/en/rest/reference/actions#workflow-jobs
  */
 class WorkflowJobs extends AbstractApi
 {
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-jobs-for-a-workflow-run
+     * @link https://docs.github.com/en/rest/reference/actions#list-jobs-for-a-workflow-run
      *
      * @param string $username
      * @param string $repository
@@ -25,7 +25,7 @@ class WorkflowJobs extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-job-for-a-workflow-run
+     * @link https://docs.github.com/en/rest/reference/actions#get-a-job-for-a-workflow-run
      *
      * @param string $username
      * @param string $repository
@@ -39,7 +39,7 @@ class WorkflowJobs extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#download-job-logs-for-a-workflow-run
+     * @link https://docs.github.com/en/rest/reference/actions#download-job-logs-for-a-workflow-run
      *
      * @param string $username
      * @param string $repository

--- a/lib/Github/Api/Repository/Actions/WorkflowRuns.php
+++ b/lib/Github/Api/Repository/Actions/WorkflowRuns.php
@@ -5,12 +5,12 @@ namespace Github\Api\Repository\Actions;
 use Github\Api\AbstractApi;
 
 /**
- * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#workflow-runs
+ * @link https://docs.github.com/en/rest/reference/actions#workflow-runs
  */
 class WorkflowRuns extends AbstractApi
 {
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-runs-for-a-repository
+     * @link https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
      *
      * @param string $username
      * @param string $repository
@@ -24,7 +24,7 @@ class WorkflowRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-runs
+     * @link https://docs.github.com/en/rest/reference/actions#list-workflow-runs
      *
      * @param string $username
      * @param string $repository
@@ -39,7 +39,7 @@ class WorkflowRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-workflow-run
+     * @link https://docs.github.com/en/rest/reference/actions#get-a-workflow-run
      *
      * @param string $username
      * @param string $repository
@@ -54,7 +54,7 @@ class WorkflowRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-a-workflow-run
+     * @link https://docs.github.com/en/rest/reference/actions#delete-a-workflow-run
      *
      * @param string $username
      * @param string $repository
@@ -68,7 +68,7 @@ class WorkflowRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#re-run-a-workflow
+     * @link https://docs.github.com/en/rest/reference/actions#re-run-a-workflow
      *
      * @param string $username
      * @param string $repository
@@ -82,7 +82,7 @@ class WorkflowRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#cancel-a-workflow-run
+     * @link https://docs.github.com/en/rest/reference/actions#cancel-a-workflow-run
      *
      * @param string $username
      * @param string $repository
@@ -96,7 +96,7 @@ class WorkflowRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-workflow-run-usage
+     * @link https://docs.github.com/en/rest/reference/actions#get-workflow-run-usage
      *
      * @param string $username
      * @param string $repository
@@ -110,7 +110,7 @@ class WorkflowRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#download-workflow-run-logs
+     * @link https://docs.github.com/en/rest/reference/actions#download-workflow-run-logs
      *
      * @param string $username
      * @param string $repository
@@ -124,7 +124,7 @@ class WorkflowRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#delete-workflow-run-logs
+     * @link https://docs.github.com/en/rest/reference/actions#delete-workflow-run-logs
      *
      * @param string $username
      * @param string $repository

--- a/lib/Github/Api/Repository/Actions/Workflows.php
+++ b/lib/Github/Api/Repository/Actions/Workflows.php
@@ -5,12 +5,12 @@ namespace Github\Api\Repository\Actions;
 use Github\Api\AbstractApi;
 
 /**
- * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#workflows
+ * @link https://docs.github.com/en/rest/reference/actions#workflows
  */
 class Workflows extends AbstractApi
 {
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-repository-workflows
+     * @link https://docs.github.com/en/rest/reference/actions#list-repository-workflows
      *
      * @param string $username
      * @param string $repository
@@ -24,7 +24,7 @@ class Workflows extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-a-workflow
+     * @link https://docs.github.com/en/rest/reference/actions#get-a-workflow
      *
      * @param string     $username
      * @param string     $repository
@@ -42,7 +42,7 @@ class Workflows extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#get-workflow-usage
+     * @link https://docs.github.com/en/rest/reference/actions#get-workflow-usage
      *
      * @param string     $username
      * @param string     $repository
@@ -60,7 +60,7 @@ class Workflows extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-a-workflow-dispatch-event
+     * @link https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
      *
      * @param string     $username
      * @param string     $repository

--- a/lib/Github/Api/Repository/Checks/CheckRuns.php
+++ b/lib/Github/Api/Repository/Checks/CheckRuns.php
@@ -6,14 +6,14 @@ use Github\Api\AbstractApi;
 use Github\Api\AcceptHeaderTrait;
 
 /**
- * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks
+ * @link https://docs.github.com/en/rest/reference/checks
  */
 class CheckRuns extends AbstractApi
 {
     use AcceptHeaderTrait;
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#create-a-check-run
+     * @link https://docs.github.com/en/rest/reference/checks#create-a-check-run
      *
      * @return array
      */
@@ -25,7 +25,7 @@ class CheckRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#get-a-check-run
+     * @link https://docs.github.com/en/rest/reference/checks#get-a-check-run
      *
      * @return array
      */
@@ -37,7 +37,7 @@ class CheckRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#update-a-check-run
+     * @link https://docs.github.com/en/rest/reference/checks#update-a-check-run
      *
      * @return array
      */
@@ -49,7 +49,7 @@ class CheckRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#list-check-run-annotations
+     * @link https://docs.github.com/en/rest/reference/checks#list-check-run-annotations
      *
      * @return array
      */
@@ -61,7 +61,7 @@ class CheckRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#list-check-runs-in-a-check-suite
+     * @link https://docs.github.com/en/rest/reference/checks#list-check-runs-in-a-check-suite
      *
      * @return array
      */
@@ -73,7 +73,7 @@ class CheckRuns extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#list-check-runs-for-a-git-reference
+     * @link https://docs.github.com/en/rest/reference/checks#list-check-runs-for-a-git-reference
      *
      * @return array
      */

--- a/lib/Github/Api/Repository/Checks/CheckSuites.php
+++ b/lib/Github/Api/Repository/Checks/CheckSuites.php
@@ -6,14 +6,14 @@ use Github\Api\AbstractApi;
 use Github\Api\AcceptHeaderTrait;
 
 /**
- * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks
+ * @link https://docs.github.com/en/rest/reference/checks
  */
 class CheckSuites extends AbstractApi
 {
     use AcceptHeaderTrait;
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#create-a-check-suite
+     * @link https://docs.github.com/en/rest/reference/checks#create-a-check-suite
      *
      * @return array
      */
@@ -25,7 +25,7 @@ class CheckSuites extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#update-repository-preferences-for-check-suites
+     * @link https://docs.github.com/en/rest/reference/checks#update-repository-preferences-for-check-suites
      *
      * @return array
      */
@@ -37,7 +37,7 @@ class CheckSuites extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#get-a-check-suite
+     * @link https://docs.github.com/en/rest/reference/checks#get-a-check-suite
      *
      * @return array
      */
@@ -49,7 +49,7 @@ class CheckSuites extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#rerequest-a-check-suite
+     * @link https://docs.github.com/en/rest/reference/checks#rerequest-a-check-suite
      *
      * @return array
      */
@@ -61,7 +61,7 @@ class CheckSuites extends AbstractApi
     }
 
     /**
-     * @link https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#list-check-suites-for-a-git-reference
+     * @link https://docs.github.com/en/rest/reference/checks#list-check-suites-for-a-git-reference
      *
      * @return array
      */


### PR DESCRIPTION
Remove free-pro-team@latest from the links, as this is no longer used in the online docs.
As promised in #969.