### PR TITLE
Allow to get labels per page

### DIFF
--- a/lib/Github/Api/Repository/Labels.php
+++ b/lib/Github/Api/Repository/Labels.php
@@ -12,9 +12,11 @@ use Github\Exception\MissingArgumentException;
  */
 class Labels extends AbstractApi
 {
-    public function all($username, $repository)
+    public function all($username, $repository, array $params = [])
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels');
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels', array_merge([
+            'page' => 1,
+        ], $params));
     }
 
     public function show($username, $repository, $label)

--- a/test/Github/Tests/Api/Repository/LabelsTest.php
+++ b/test/Github/Tests/Api/Repository/LabelsTest.php
@@ -10,14 +10,14 @@ class LabelsTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetAllRepositoryLabelss()
+    public function shouldGetAllRepositoryLabels()
     {
         $expectedValue = [['name' => 'label']];
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/repos/KnpLabs/php-github-api/labels')
+            ->with('/repos/KnpLabs/php-github-api/labels', ['page' => 1])
             ->will($this->returnValue($expectedValue));
 
         $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api'));


### PR DESCRIPTION
GitHub repository labels is a paginated endpoint. Allow to get labels per page passing parameters into request. 