### PR TITLE
backported #979 into 2.x

### DIFF
--- a/lib/Github/Api/Deployment.php
+++ b/lib/Github/Api/Deployment.php
@@ -11,6 +11,8 @@ use Github\Exception\MissingArgumentException;
  */
 class Deployment extends AbstractApi
 {
+    use AcceptHeaderTrait;
+
     /**
      * List deployments for a particular repository.
      *
@@ -86,6 +88,15 @@ class Deployment extends AbstractApi
     {
         if (!isset($params['state'])) {
             throw new MissingArgumentException(['state']);
+        }
+
+        // adjust media-type per github docs
+        // https://docs.github.com/en/rest/reference/repos#create-a-deployment-status
+        if ($params['state'] === 'inactive') {
+            $this->acceptHeaderValue = 'application/vnd.github.ant-man-preview+json';
+        }
+        if ($params['state'] === 'in_progress' || $params['state'] === 'queued') {
+            $this->acceptHeaderValue = 'application/vnd.github.flash-preview+json';
         }
 
         return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments/'.$id.'/statuses', $params);


### PR DESCRIPTION
Deployments: use proper media-type for in_progress/queued, inactive state

as discussed in https://github.com/KnpLabs/php-github-api/pull/979#issuecomment-807435518