### PR TITLE
Improved bc check

### DIFF
--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -1,0 +1,18 @@
+name: "BC check"
+
+on:
+    pull_request:
+
+jobs:
+    roave_bc_check:
+        name: "Roave BC check"
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+                with:
+                    fetch-depth: 0
+
+            -   name: Roave BC Check
+                uses: docker://nyholm/roave-bc-check-ga
+                with:
+                    args: --from=${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,6 @@ jobs:
             - name: Run phpunit
               run: vendor/bin/phpunit --verbose
 
-    roave_bc_check:
-        name: Roave BC Check
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-
-            - name: Roave BC Check
-              uses: docker://nyholm/roave-bc-check-ga
-
     phpstan:
         name: PHPStan
         runs-on: ubuntu-latest


### PR DESCRIPTION
Only run the BC check on PR's and use the PR base branch as target branch to check the BC breaks against, this won't make the BC check fail false-positive on 2.x pr's