### PR TITLE
Add deprecations to the PR review methods to allow cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "psr/http-message": "^1.0",
-        "symfony/polyfill-php80": "^1.17"
+        "symfony/polyfill-php80": "^1.17",
+        "symfony/deprecation-contracts": "^2.2"
     },
     "require-dev": {
         "symfony/cache": "^5.1.8",

--- a/lib/Github/Api/PullRequest/Review.php
+++ b/lib/Github/Api/PullRequest/Review.php
@@ -20,6 +20,8 @@ class Review extends AbstractApi
 
     public function configure()
     {
+        trigger_deprecation('KnpLabs/php-github-api', '3.2', 'The "%s" is deprecated and will be removed.', __METHOD__);
+
         return $this;
     }
 
@@ -37,6 +39,10 @@ class Review extends AbstractApi
      */
     public function all($username, $repository, $pullRequest, array $params = [])
     {
+        if (!empty($params)) {
+            trigger_deprecation('KnpLabs/php-github-api', '3.2', 'The "$params" parameter is deprecated, to paginate the results use the "ResultPager" instead.');
+        }
+
         $parameters = array_merge([
             'page' => 1,
             'per_page' => 30,

--- a/lib/Github/Api/PullRequest/ReviewRequest.php
+++ b/lib/Github/Api/PullRequest/ReviewRequest.php
@@ -14,6 +14,8 @@ class ReviewRequest extends AbstractApi
 
     public function configure()
     {
+        trigger_deprecation('KnpLabs/php-github-api', '3.2', 'The "%s" is deprecated and will be removed.', __METHOD__);
+
         return $this;
     }
 
@@ -29,6 +31,10 @@ class ReviewRequest extends AbstractApi
      */
     public function all($username, $repository, $pullRequest, array $params = [])
     {
+        if (!empty($params)) {
+            trigger_deprecation('KnpLabs/php-github-api', '3.2', 'The "$params" parameter is deprecated, to paginate the results use the "ResultPager" instead.');
+        }
+
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.$pullRequest.'/requested_reviewers', $params);
     }
 


### PR DESCRIPTION
Fixes #621

This PR adds some deprecations so we can cleanup these classes (unused parameters/methods) in 4.0.