### PR TITLE
Allow binary content downloads of assets

### DIFF
--- a/doc/repo/assets.md
+++ b/doc/repo/assets.md
@@ -13,6 +13,12 @@ $assets = $client->api('repo')->releases()->assets()->all('twbs', 'bootstrap', $
 $asset = $client->api('repo')->releases()->assets()->show('twbs', 'bootstrap', $assetId);
 ```
 
+### Download binary content of asset
+
+```php
+$asset = $client->api('repo')->releases()->assets()->show('twbs', 'bootstrap', $assetId, true);
+```
+
 ### Create an asset
 
 ```php

--- a/lib/Github/Api/Repository/Assets.php
+++ b/lib/Github/Api/Repository/Assets.php
@@ -3,6 +3,7 @@
 namespace Github\Api\Repository;
 
 use Github\Api\AbstractApi;
+use Github\Api\AcceptHeaderTrait;
 use Github\Exception\ErrorException;
 use Github\Exception\MissingArgumentException;
 
@@ -13,6 +14,8 @@ use Github\Exception\MissingArgumentException;
  */
 class Assets extends AbstractApi
 {
+    use AcceptHeaderTrait;
+
     /**
      * Get all release's assets in selected repository
      * GET /repos/:owner/:repo/releases/:id/assets.
@@ -36,10 +39,14 @@ class Assets extends AbstractApi
      * @param string $repository the name of the repo
      * @param int    $id         the id of the asset
      *
-     * @return array
+     * @return array|string
      */
-    public function show($username, $repository, $id)
+    public function show($username, $repository, $id, bool $returnBinaryContent = false)
     {
+        if ($returnBinaryContent) {
+            $this->acceptHeaderValue = 'application/octet-stream';
+        }
+
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/assets/'.$id);
     }
 

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -119,6 +119,7 @@ class Client
     {
         $this->responseHistory = new History();
         $this->httpClientBuilder = $builder = $httpClientBuilder ?? new Builder();
+        $this->apiVersion = $apiVersion ?: 'v3';
 
         $builder->addPlugin(new GithubExceptionThrower());
         $builder->addPlugin(new Plugin\HistoryPlugin($this->responseHistory));
@@ -126,10 +127,8 @@ class Client
         $builder->addPlugin(new Plugin\AddHostPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.github.com')));
         $builder->addPlugin(new Plugin\HeaderDefaultsPlugin([
             'User-Agent' => 'php-github-api (http://github.com/KnpLabs/php-github-api)',
+            'Accept' => sprintf('application/vnd.github.%s+json', $this->apiVersion),
         ]));
-
-        $this->apiVersion = $apiVersion ?: 'v3';
-        $builder->addHeaderValue('Accept', sprintf('application/vnd.github.%s+json', $this->apiVersion));
 
         if ($enterpriseUrl) {
             $this->setEnterpriseUrl($enterpriseUrl);


### PR DESCRIPTION
For this to work I also had to change the way the default accept header, previously the header was appended which produced actually an incorrect accept header.

Previously is produced this (this was the same with preview headers being set):

```
Host: api.github.com
Accept: application/octet-stream
Accept: application/vnd.github.v3+json
User-Agent: php-github-api (http://github.com/KnpLabs/php-github-api)
```

With the default headers plugin being used
```
Host: api.github.com
Accept: application/octet-stream
User-Agent: php-github-api (http://github.com/KnpLabs/php-github-api)
```

Fixes #320 