### PR TITLE
fixed php warning in GithubExceptionThrower

### DIFF
--- a/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
+++ b/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
@@ -59,7 +59,12 @@ class GithubExceptionThrower implements Plugin
                 if (422 === $response->getStatusCode() && isset($content['errors'])) {
                     $errors = [];
                     foreach ($content['errors'] as $error) {
-                        switch ($error['code']) {
+                        $code = null;
+                        if (isset($error['code'])) {
+                            $code = $error['code'];
+                        }
+
+                        switch ($code) {
                             case 'missing':
                                 $errors[] = sprintf('The %s %s does not exist, for resource "%s"', $error['field'], $error['value'], $error['resource']);
                                 break;

--- a/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
+++ b/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
@@ -81,6 +81,12 @@ class GithubExceptionThrower implements Plugin
                                 break;
 
                             default:
+                                if (is_string($error)) {
+                                    $errors[] = $error;
+
+                                    break;
+                                }
+
                                 if (isset($error['message'])) {
                                     $errors[] = $error['message'];
                                 }

--- a/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
+++ b/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
@@ -59,11 +59,6 @@ class GithubExceptionThrower implements Plugin
                 if (422 === $response->getStatusCode() && isset($content['errors'])) {
                     $errors = [];
                     foreach ($content['errors'] as $error) {
-                        $code = null;
-                        if (isset($error['code'])) {
-                            $code = $error['code'];
-                        }
-
                         switch ($error['code'] ?? null) {
                             case 'missing':
                                 $errors[] = sprintf('The %s %s does not exist, for resource "%s"', $error['field'], $error['value'], $error['resource']);

--- a/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
+++ b/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
@@ -64,7 +64,7 @@ class GithubExceptionThrower implements Plugin
                             $code = $error['code'];
                         }
 
-                        switch ($code) {
+                        switch ($error['code'] ?? null) {
                             case 'missing':
                                 $errors[] = sprintf('The %s %s does not exist, for resource "%s"', $error['field'], $error['value'], $error['resource']);
                                 break;

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -206,7 +206,7 @@ class GithubExceptionThrowerTest extends TestCase
                         [
                             'message' => 'Validation Failed',
                             'errors' => ['We cannot delete an active deployment unless it is the only deployment in a given environment.'],
-                            'documentation_url' => 'https://docs.github.com/rest/reference/repos#delete-a-deployment'
+                            'documentation_url' => 'https://docs.github.com/rest/reference/repos#delete-a-deployment',
                         ]
                     )
                 ),

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -37,7 +37,7 @@ class GithubExceptionThrowerTest extends TestCase
         if ($exception) {
             $this->expectException(get_class($exception));
             $this->expectExceptionCode($exception->getCode());
-            $this->expectExceptionMessage($exception->getMessage());
+            $this->expectExceptionMessageRegExp('/'.preg_quote($exception->getMessage(), '/').'$/');
         }
 
         $plugin->doHandleRequest(
@@ -210,7 +210,7 @@ class GithubExceptionThrowerTest extends TestCase
                         ]
                     )
                 ),
-                'exception' => new \Github\Exception\ValidationFailedException('Validation Failed', 422),
+                'exception' => new \Github\Exception\ValidationFailedException('Validation Failed: We cannot delete an active deployment unless it is the only deployment in a given environment.', 422),
             ],
         ];
     }

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -196,6 +196,22 @@ class GithubExceptionThrowerTest extends TestCase
                 ),
                 'exception' => new \Github\Exception\RuntimeException('This endpoint requires you to be authenticated.', 401),
             ],
+            'Cannot delete active deployment' => [
+                'response' => new Response(
+                    422,
+                    [
+                        'content-type' => 'application/json',
+                    ],
+                    json_encode(
+                        [
+                            'message' => 'Validation Failed',
+                            'errors' => ['We cannot delete an active deployment unless it is the only deployment in a given environment.'],
+                            'documentation_url' => 'https://docs.github.com/rest/reference/repos#delete-a-deployment'
+                        ]
+                    )
+                ),
+                'exception' => new \Github\Exception\ValidationFailedException('Validation Failed', 422),
+            ],
         ];
     }
 }


### PR DESCRIPTION
fixes
```
Warning: Illegal string offset 'code' in GithubExceptionThrower.php on line 59
```
when deleting a deployment which is not yet set to inactive, see https://github.com/KnpLabs/php-github-api/pull/991

I guess the warning beeing fixed is not explicitly related to the new endpoint added in #991 but I experienced it in this case.