### PR TITLE
Add create a repository using a template endpoint

### DIFF
--- a/doc/repos.md
+++ b/doc/repos.md
@@ -370,3 +370,14 @@ Example when you want to configure custom github action workflows.
 ```php
 $client->api('repo')->dispatch('KnpLabs', 'php-github-api', 'acme-event', ['foo'=>'bar']);
 ```
+
+### Create a repository using a template
+
+Create a new repository using a repository template.
+
+```php
+$client->api('repo')->createFromTemplate('template-owner', 'template-repo', [
+    'name' => 'name-of-new-repo',
+    'owner' => 'name-of-new-repo-owner', // can be user or org
+]);
+```

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -793,4 +793,30 @@ class Repo extends AbstractApi
     {
         return $this->post('/repos/'.rawurldecode($username).'/'.rawurldecode($repository).'/transfer', ['new_owner' => $newOwner, 'team_id' => $teamId]);
     }
+
+    /**
+     * Create a repository using a template.
+     *
+     * @link https://developer.github.com/v3/repos/#create-a-repository-using-a-template
+     *
+     * @param string      $templateOwner
+     * @param string      $templateRepo
+     * @param string      $name
+     * @param string|null $owner
+     * @param string|null $description
+     * @param bool|null   $includeAllBranches
+     * @param bool|null   $private
+     *
+     * @return array
+     */
+    public function createFromTemplate($templateOwner, $templateRepo, $name, $owner = null, $description = null, $includeAllBranches = false, $private = null)
+    {
+        return $this->post('/repos/'.rawurldecode($templateOwner).'/'.rawurldecode($templateRepo).'/generate', array_filter([
+            'name' => $name,
+            'owner' => $owner,
+            'description' => $description,
+            'include_all_branches' => $includeAllBranches,
+            'private' => $private,
+        ]));
+    }
 }

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -799,13 +799,9 @@ class Repo extends AbstractApi
      *
      * @link https://developer.github.com/v3/repos/#create-a-repository-using-a-template
      *
-     * @param string $templateOwner
-     * @param string $templateRepo
-     * @param array  $parameters
-     *
      * @return array
      */
-    public function createFromTemplate($templateOwner, $templateRepo, array $parameters = [])
+    public function createFromTemplate(string $templateOwner, string $templateRepo, array $parameters = [])
     {
         return $this->post('/repos/'.rawurldecode($templateOwner).'/'.rawurldecode($templateRepo).'/generate', $parameters);
     }

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -799,24 +799,14 @@ class Repo extends AbstractApi
      *
      * @link https://developer.github.com/v3/repos/#create-a-repository-using-a-template
      *
-     * @param string      $templateOwner
-     * @param string      $templateRepo
-     * @param string      $name
-     * @param string|null $owner
-     * @param string|null $description
-     * @param bool|null   $includeAllBranches
-     * @param bool|null   $private
+     * @param string $templateOwner
+     * @param string $templateRepo
+     * @param array  $parameters
      *
      * @return array
      */
-    public function createFromTemplate($templateOwner, $templateRepo, $name, $owner = null, $description = null, $includeAllBranches = false, $private = null)
+    public function createFromTemplate($templateOwner, $templateRepo, array $parameters = [])
     {
-        return $this->post('/repos/'.rawurldecode($templateOwner).'/'.rawurldecode($templateRepo).'/generate', array_filter([
-            'name' => $name,
-            'owner' => $owner,
-            'description' => $description,
-            'include_all_branches' => $includeAllBranches,
-            'private' => $private,
-        ]));
+        return $this->post('/repos/'.rawurldecode($templateOwner).'/'.rawurldecode($templateRepo).'/generate', $parameters);
     }
 }

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -646,80 +646,10 @@ class RepoTest extends TestCase
             ])
             ->will($this->returnValue($expectedArray));
 
-        $this->assertEquals($expectedArray, $api->createFromTemplate('acme', 'template', 'newrepo', 'johndoe'));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldCreateRepositoryUsingTemplateWithDescription()
-    {
-        $expectedArray = [
-            'id' => 1,
+        $this->assertEquals($expectedArray, $api->createFromTemplate('acme', 'template', [
             'name' => 'newrepo',
-            'full_name' => 'johndoe/newrepo',
-            'description' => 'Lorem ipsum',
-        ];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('post')
-            ->with('/repos/acme/template/generate', [
-                'name' => 'newrepo',
-                'owner' => 'johndoe',
-                'description' => 'Lorem ipsum',
-            ])
-            ->will($this->returnValue($expectedArray));
-
-        $this->assertEquals($expectedArray, $api->createFromTemplate('acme', 'template', 'newrepo', 'johndoe', 'Lorem ipsum'));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldCreateRepositoryUsingTemplateWithAllBranches()
-    {
-        $expectedArray = [
-            'id' => 1,
-            'name' => 'newrepo',
-            'full_name' => 'johndoe/newrepo',
-        ];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('post')
-            ->with('/repos/acme/template/generate', [
-                'name' => 'newrepo',
-                'owner' => 'johndoe',
-                'include_all_branches' => true,
-            ])
-            ->will($this->returnValue($expectedArray));
-
-        $this->assertEquals($expectedArray, $api->createFromTemplate('acme', 'template', 'newrepo', 'johndoe', null, true));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldCreatePrivateRepositoryUsingTemplate()
-    {
-        $expectedArray = [
-            'id' => 1,
-            'name' => 'newrepo',
-            'full_name' => 'johndoe/newrepo',
-        ];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('post')
-            ->with('/repos/acme/template/generate', [
-                'name' => 'newrepo',
-                'owner' => 'johndoe',
-                'private' => true,
-            ])
-            ->will($this->returnValue($expectedArray));
-
-        $this->assertEquals($expectedArray, $api->createFromTemplate('acme', 'template', 'newrepo', 'johndoe', null, false, true));
+            'owner' => 'johndoe',
+        ]));
     }
 
     /**

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -627,6 +627,102 @@ class RepoTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function shouldCreateRepositoryUsingTemplate()
+    {
+        $expectedArray = [
+            'id' => 1,
+            'name' => 'newrepo',
+            'full_name' => 'johndoe/newrepo',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/acme/template/generate', [
+                'name' => 'newrepo',
+                'owner' => 'johndoe',
+            ])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->createFromTemplate('acme', 'template', 'newrepo', 'johndoe'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateRepositoryUsingTemplateWithDescription()
+    {
+        $expectedArray = [
+            'id' => 1,
+            'name' => 'newrepo',
+            'full_name' => 'johndoe/newrepo',
+            'description' => 'Lorem ipsum',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/acme/template/generate', [
+                'name' => 'newrepo',
+                'owner' => 'johndoe',
+                'description' => 'Lorem ipsum',
+            ])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->createFromTemplate('acme', 'template', 'newrepo', 'johndoe', 'Lorem ipsum'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateRepositoryUsingTemplateWithAllBranches()
+    {
+        $expectedArray = [
+            'id' => 1,
+            'name' => 'newrepo',
+            'full_name' => 'johndoe/newrepo',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/acme/template/generate', [
+                'name' => 'newrepo',
+                'owner' => 'johndoe',
+                'include_all_branches' => true,
+            ])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->createFromTemplate('acme', 'template', 'newrepo', 'johndoe', null, true));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreatePrivateRepositoryUsingTemplate()
+    {
+        $expectedArray = [
+            'id' => 1,
+            'name' => 'newrepo',
+            'full_name' => 'johndoe/newrepo',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/acme/template/generate', [
+                'name' => 'newrepo',
+                'owner' => 'johndoe',
+                'private' => true,
+            ])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->createFromTemplate('acme', 'template', 'newrepo', 'johndoe', null, false, true));
+    }
+
+    /**
      * @return string
      */
     protected function getApiClass()


### PR DESCRIPTION
Adds methods to [create a repository using a template][1], and also contributes a few test cases for the various options.

Resolves #976

[1]: https://docs.github.com/en/rest/reference/repos#create-a-repository-using-a-template