### PR TITLE
Events list per authenticated user for all repos

### DIFF
--- a/doc/activity.md
+++ b/doc/activity.md
@@ -31,6 +31,13 @@ $activity = $client->api('current_user')->starring()->all();
 ```
 Returns an array of starred repos.
 
+### Get list of private and public events for an authenticated user for all repos
+
+```php
+$activity = $client->api('user')->events('ornicar');
+```
+Returns an array of private and public events created for all repos related to the user.
+
 ### Get repos that a authenticated user has starred with creation date
 
 Support for getting the star creation timestamp in the response, using the custom `Accept: application/vnd.github.v3.star+json` header.

--- a/doc/users.md
+++ b/doc/users.md
@@ -148,6 +148,17 @@ $users = $client->api('current_user')->starring()->all();
 
 Returns an array of starred repos.
 
+### Get the authenticated user activity
+
+> Requires [authentication](security.md).
+
+```php
+$activity = $client->api('user')->events('ornicar');
+```
+
+Returns an array of private and public events created for all repos related to the user.
+> See [more](activity.md).
+
 ### Get the authenticated user emails
 
 > Requires [authentication](security.md).

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -234,4 +234,23 @@ class User extends AbstractApi
     {
         return $this->get('/users/'.rawurlencode($username).'/events/public');
     }
+
+    /**
+     * List events performed by an authenticated user.
+     *
+     * @link https://docs.github.com/en/rest/reference/activity#list-events-for-the-authenticated-user
+     *
+     * @param string $username
+     * @param int    $page      the page number of the paginated result set
+     * @param int    $perPage   the number of results per page
+     *
+     * @return array
+     */
+    public function events($username, $page = 1, $perPage = 30)
+    {
+        return $this->get('/users/'.rawurlencode($username).'/events', [
+            'page' => $page,
+            'per_page' => $perPage,
+        ]);
+    }
 }

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -241,8 +241,8 @@ class User extends AbstractApi
      * @link https://docs.github.com/en/rest/reference/activity#list-events-for-the-authenticated-user
      *
      * @param string $username
-     * @param int    $page    the page number of the paginated result set
-     * @param int    $perPage the number of results per page
+     * @param int    $page     the page number of the paginated result set
+     * @param int    $perPage  the number of results per page
      *
      * @return array
      */

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -240,17 +240,10 @@ class User extends AbstractApi
      *
      * @link https://docs.github.com/en/rest/reference/activity#list-events-for-the-authenticated-user
      *
-     * @param string $username
-     * @param int    $page     the page number of the paginated result set
-     * @param int    $perPage  the number of results per page
-     *
      * @return array
      */
-    public function events($username, $page = 1, $perPage = 30)
+    public function events(string $username)
     {
-        return $this->get('/users/'.rawurlencode($username).'/events', [
-            'page' => $page,
-            'per_page' => $perPage,
-        ]);
+        return $this->get('/users/'.rawurlencode($username).'/events');
     }
 }

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -241,8 +241,8 @@ class User extends AbstractApi
      * @link https://docs.github.com/en/rest/reference/activity#list-events-for-the-authenticated-user
      *
      * @param string $username
-     * @param int    $page      the page number of the paginated result set
-     * @param int    $perPage   the number of results per page
+     * @param int    $page    the page number of the paginated result set
+     * @param int    $perPage the number of results per page
      *
      * @return array
      */

--- a/test/Github/Tests/Api/UserTest.php
+++ b/test/Github/Tests/Api/UserTest.php
@@ -229,6 +229,29 @@ class UserTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function shouldGetAuthorizedUserEvents()
+    {
+        $expectedArray = [
+            [
+                'id' => 1,
+                'actor' => [
+                    'id' => 1,
+                    'login' => 'l3l0',
+                ],
+            ],
+        ];
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/users/l3l0/events')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->events('l3l0'));
+    }
+
+    /**
      * @return string
      */
     protected function getApiClass()

--- a/test/Github/Tests/Integration/UserTest.php
+++ b/test/Github/Tests/Integration/UserTest.php
@@ -138,4 +138,25 @@ class UserTest extends TestCase
         $this->assertArrayHasKey('git_url', $repo);
         $this->assertArrayHasKey('svn_url', $repo);
     }
+
+    /**
+     * @test
+     */
+    public function shouldGetEventsForAuthenticatedUserBeignWatched()
+    {
+        $username = 'l3l0';
+
+        $events = $this->client->api('user')->events($username);
+        $event = array_pop($events);
+
+        $this->assertArrayHasKey('id', $event);
+        $this->assertArrayHasKey('type', $event);
+        $this->assertArrayHasKey('actor', $event);
+        $this->assertArrayHasKey('login', $event['actor']);
+        $this->assertArrayHasKey('repo', $event);
+        $this->assertArrayHasKey('name', $event['repo']);
+        $this->assertArrayHasKey('payload', $event);
+        $this->assertArrayHasKey('public', $event);
+        $this->assertArrayHasKey('created_at', $event);
+    }
 }


### PR DESCRIPTION
This change add a list of events for all repos for an authenticated user: https://docs.github.com/en/rest/reference/activity#list-events-for-the-authenticated-user.
It is pretty useful if you want to get a list of different [types of events](https://docs.github.com/en/developers/webhooks-and-events/github-event-types) without specify any repo.