### PR TITLE
Allow costume accept headers for GraphQL Endpoint.

### DIFF
--- a/doc/graphql.md
+++ b/doc/graphql.md
@@ -19,6 +19,19 @@ $client->authenticate($token, null, Github\Client::AUTH_ACCESS_TOKEN);
 $result = $client->api('graphql')->execute($query);
 ```
 
+#### Use different `Accept` Headers
+You can preview upcoming features and changes to the GitHub GraphQL schema before they are added to the GitHub GraphQL API.
+To access a schema preview, you'll need to provide a custom media type in the Accept header for your requests. Feature documentation for each preview specifies which custom media type to provide. More info about [Schema Previews](https://docs.github.com/en/graphql/overview/schema-previews).
+
+To use [GitHub v4 API (GraphQL API)](http://developer.github.com/v4/) with different `Accept` header you can pass third argument to execute method.
+
+```php
+$result = $client->api('graphql')->execute($query, [], 'application/vnd.github.starfox-preview+json')
+```
+> default accept header is `application/vnd.github.v4+json`  
+
+
+
 #### Use variables
 
 [Variables](https://developer.github.com/v4/guides/forming-calls/#working-with-variables) allow specifying of requested data without dynamical change of a query on a client side.

--- a/lib/Github/Api/GraphQL.php
+++ b/lib/Github/Api/GraphQL.php
@@ -22,7 +22,7 @@ class GraphQL extends AbstractApi
      *
      * @return array
      */
-    public function execute($query, array $variables = [], $acceptHeaderValue = 'application/vnd.github.v4+json')
+    public function execute($query, array $variables = [], string $acceptHeaderValue = 'application/vnd.github.v4+json')
     {
         $this->acceptHeaderValue = $acceptHeaderValue;
         $params = [

--- a/lib/Github/Api/GraphQL.php
+++ b/lib/Github/Api/GraphQL.php
@@ -21,9 +21,9 @@ class GraphQL extends AbstractApi
      *
      * @return array
      */
-    public function execute($query, array $variables = [])
+    public function execute($query, array $variables = [], $acceptHeaderValue = 'application/vnd.github.v4+json')
     {
-        $this->acceptHeaderValue = 'application/vnd.github.v4+json';
+        $this->acceptHeaderValue = $acceptHeaderValue;
         $params = [
             'query' => $query,
         ];

--- a/lib/Github/Api/GraphQL.php
+++ b/lib/Github/Api/GraphQL.php
@@ -18,6 +18,7 @@ class GraphQL extends AbstractApi
     /**
      * @param string $query
      * @param array  $variables
+     * @param string $acceptHeaderValue
      *
      * @return array
      */


### PR DESCRIPTION
Github has multiple different accept headers for different purposes.  Currently, there's no easy way to add/remove the `Accept` header to the client. 

ref: https://docs.github.com/en/graphql/overview/schema-previews