### PR TITLE
Update readme and add example for different http client usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # PHP GitHub API
 
-[![Build Status](https://travis-ci.org/KnpLabs/php-github-api.svg?branch=master)](https://travis-ci.org/KnpLabs/php-github-api)
+![Build Status](https://github.com/KnpLabs/php-github-api/actions/workflows/ci.yml/badge.svg)
 [![StyleCI](https://styleci.io/repos/3948501/shield?style=flat)](https://styleci.io/repos/3948501)
 [![Latest Stable Version](https://poser.pugx.org/knplabs/github-api/v/stable)](https://packagist.org/packages/knplabs/github-api)
 [![Total Downloads](https://poser.pugx.org/knplabs/github-api/downloads)](https://packagist.org/packages/knplabs/github-api)
-[![Latest Unstable Version](https://poser.pugx.org/knplabs/github-api/v/unstable)](https://packagist.org/packages/knplabs/github-api)
 [![Monthly Downloads](https://poser.pugx.org/knplabs/github-api/d/monthly)](https://packagist.org/packages/knplabs/github-api)
 [![Daily Downloads](https://poser.pugx.org/knplabs/github-api/d/daily)](https://packagist.org/packages/knplabs/github-api)
 
@@ -19,34 +18,46 @@ Uses [GitHub API v3](http://developer.github.com/v3/) & supports [GitHub API v4]
 
 ## Requirements
 
-* PHP >= 7.1
+* PHP >= 7.2
 * A [PSR-17 implementation](https://packagist.org/providers/psr/http-factory-implementation)
 * A [PSR-18 implementation](https://packagist.org/providers/psr/http-client-implementation)
 
-## Install
+## Quick install
 
 Via [Composer](https://getcomposer.org).
 
-### PHP 7.1+:
-
-```bash
-composer require knplabs/github-api:^3.0 php-http/guzzle6-adapter:^2.0.1 http-interop/http-factory-guzzle:^1.0
-```
-
-### PHP 7.2+:
+This command will get you up and running quickly with a guzzle http client.
 
 ```bash
 composer require knplabs/github-api:^3.0 guzzlehttp/guzzle:^7.0.1 http-interop/http-factory-guzzle:^1.0
 ```
 
-### Laravel 6+:
+## Advanced install
+
+We are decoupled from any HTTP messaging client with help by [HTTPlug](https://httplug.io). 
+
+### Using a different http client
 
 ```bash
-composer require graham-campbell/github:^10.0 guzzlehttp/guzzle:^7.0.1 http-interop/http-factory-guzzle:^1.0
+composer require knplabs/github-api:^3.0 symfony/http-client nyholm/psr7
 ```
 
-We are decoupled from any HTTP messaging client with help by [HTTPlug](http://httplug.io). Read about clients in our [docs](doc/customize.md). [graham-campbell/github](https://github.com/GrahamCampbell/Laravel-GitHub) is by [Graham Campbell](https://github.com/GrahamCampbell).
+To set up the github client with this http client
 
+```php
+use Github\Client;
+use Symfony\Component\HttpClient\HttplugClient;
+
+$client = Client::createWithHttpClient(new HttplugClient());
+```
+
+Read more about [using different clients in our docs](doc/customize.md).
+
+## Framework integrations
+
+### Laravel
+
+To integrate this library in laravel [Graham Campbell](https://github.com/GrahamCampbell) created [graham-campbell/github](https://github.com/GrahamCampbell/Laravel-GitHub). See the [installation instructions](https://github.com/GrahamCampbell/Laravel-GitHub#installation) to get started in laravel.
 
 ## Basic usage of `php-github-api` client
 
@@ -60,7 +71,7 @@ $client = new \Github\Client();
 $repositories = $client->api('user')->repositories('ornicar');
 ```
 
-From `$client` object, you can access to all GitHub.
+From `$client` object, you have access to all available GitHub api endpoints.
 
 ## Cache usage
 
@@ -105,18 +116,18 @@ See the [`doc` directory](doc/) for more detailed documentation.
 Please read [this post](https://knplabs.com/en/blog/news-for-our-foss-projects-maintenance) first.
 
 This library is maintained by the following people (alphabetically sorted) :
-- @acrobat
-- @Nyholm
+- [@acrobat](https://github.com/acrobat)
+- [@Nyholm](https://github.com/Nyholm)
 
 ## Contributors
 
-- Thanks to [Thibault Duplessis aka. ornicar](http://github.com/ornicar) for his first version of this library.
-- Thanks to [Joseph Bielawski aka. stloyd](http://github.com/stloyd) for his contributions and support.
-- Thanks to [noloh](http://github.com/noloh) for his contribution on the Object API.
-- Thanks to [bshaffer](http://github.com/bshaffer) for his contribution on the Repo API.
-- Thanks to [Rolf van de Krol](http://github.com/rolfvandekrol) for his countless contributions.
-- Thanks to [Nicolas Pastorino](http://github.com/jeanvoye) for his contribution on the Pull Request API.
-- Thanks to [Edoardo Rivello](http://github.com/erivello) for his contribution on the Gists API.
+- Thanks to [Thibault Duplessis aka. ornicar](https://github.com/ornicar) for his first version of this library.
+- Thanks to [Joseph Bielawski aka. stloyd](https://github.com/stloyd) for his contributions and support.
+- Thanks to [noloh](https://github.com/noloh) for his contribution on the Object API.
+- Thanks to [bshaffer](https://github.com/bshaffer) for his contribution on the Repo API.
+- Thanks to [Rolf van de Krol](https://github.com/rolfvandekrol) for his countless contributions.
+- Thanks to [Nicolas Pastorino](https://github.com/jeanvoye) for his contribution on the Pull Request API.
+- Thanks to [Edoardo Rivello](https://github.com/erivello) for his contribution on the Gists API.
 - Thanks to [Miguel Piedrafita](https://github.com/m1guelpf) for his contribution to the v4 & Apps API.
 - Thanks to [Emre DEGER](https://github.com/lexor) for his contribution to the Actions API.
 

--- a/doc/customize.md
+++ b/doc/customize.md
@@ -4,14 +4,31 @@
 
 ### Inject a new HTTP client instance
 
-`php-github-api` relies on `php-http/discovery` to find an installed HTTP client. You may specify a HTTP client
-yourself by calling `\Github\Client::setHttpClient`. A HTTP client must implement `Http\Client\HttpClient`. A list of
+`php-github-api` relies on `php-http/discovery` to find an installed HTTP client. You may specify an HTTP client
+yourself by calling `\Github\Client::setHttpClient`. An HTTP client must implement `Http\Client\HttpClient`. A list of
 community provided clients is found here: https://packagist.org/providers/php-http/client-implementation
 
-You can inject a HTTP client through the `Github\Client` constructor:
+You can inject an HTTP client through the `Github\Client` constructor:
 
 ```php
 $client = Github\Client::createWithHttpClient(new Http\Adapter\Guzzle6\Client());
+```
+
+#### Example
+
+To use the symfony http client
+
+```bash
+composer require symfony/http-client nyholm/psr7
+```
+
+To set up the github client with this http client
+
+```php
+use Github\Client;
+use Symfony\Component\HttpClient\HttplugClient;
+
+$client = Client::createWithHttpClient(new HttplugClient());
 ```
 
 ### Configure the HTTP client


### PR DESCRIPTION
I've updated the README a bit so it's more structured and clear also a reference is added to use a different http client (symfony/http-client in this example)

Closes #999