### PR TITLE
Add comment on AbstractApi::$perPage()

### DIFF
--- a/lib/Github/Api/AbstractApi.php
+++ b/lib/Github/Api/AbstractApi.php
@@ -20,7 +20,7 @@ abstract class AbstractApi
     private $client;
 
     /**
-     * The per page parameter.
+     * The per page parameter. It is used by the ResultPager.
      *
      * @var int|null
      */

--- a/test/Github/Tests/Integration/ResultPagerTest.php
+++ b/test/Github/Tests/Integration/ResultPagerTest.php
@@ -11,24 +11,6 @@ class ResultPagerTest extends TestCase
 {
     /**
      * @test
-     */
-    public function shouldPaginateGetRequests()
-    {
-        $repositoriesApi = $this->client->api('user');
-        $repositoriesApi->setPerPage(10);
-
-        $pager = $this->createPager();
-
-        $repositories = $pager->fetch($repositoriesApi, 'repositories', ['KnpLabs']);
-        $this->assertCount(10, $repositories);
-
-        $repositoriesApi->setPerPage(20);
-        $repositories = $pager->fetch($repositoriesApi, 'repositories', ['KnpLabs']);
-        $this->assertCount(20, $repositories);
-    }
-
-    /**
-     * @test
      *
      * response in a search api has different format:
      *
@@ -43,10 +25,8 @@ class ResultPagerTest extends TestCase
     public function shouldGetAllResultsFromSearchApi()
     {
         $searchApi = $this->client->search();
-        $searchApi->setPerPage(10);
 
         $pager = $this->createPager();
-
         $users = $pager->fetch($searchApi, 'users', ['location:Kyiv']);
         $this->assertCount(10, $users);
     }


### PR DESCRIPTION
The `AbstractApi::setPerPage()` was removed in the 3.0. I cannot find what PR that removed it. 

However, we kept `AbstractApi::$perPage` and we do use it on a few places.. Im not sure if we should remove the property or add back the method. 

Also note, some integration tests are using `setPerPage()`. 