### PR TITLE
Added params argument for Labels and Search

### DIFF
--- a/lib/Github/Api/Issue/Labels.php
+++ b/lib/Github/Api/Issue/Labels.php
@@ -21,10 +21,11 @@ class Labels extends AbstractApi
      * @param string   $username
      * @param string   $repository
      * @param int|null $issue
+     * @param array  $params
      *
      * @return array
      */
-    public function all($username, $repository, $issue = null)
+    public function all($username, $repository, $issue = null, array $params = [])
     {
         if ($issue === null) {
             $path = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/labels';
@@ -32,7 +33,7 @@ class Labels extends AbstractApi
             $path = '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.$issue.'/labels';
         }
 
-        return $this->get($path);
+        return $this->get($path, $params);
     }
 
     /**

--- a/lib/Github/Api/Search.php
+++ b/lib/Github/Api/Search.php
@@ -21,12 +21,13 @@ class Search extends AbstractApi
      * @param string $q     the filter
      * @param string $sort  the sort field
      * @param string $order asc/desc
+     * @param array  $params
      *
      * @return array list of repositories found
      */
-    public function repositories($q, $sort = 'updated', $order = 'desc')
+    public function repositories($q, $sort = 'updated', $order = 'desc', array $params = [])
     {
-        return $this->get('/search/repositories', ['q' => $q, 'sort' => $sort, 'order' => $order]);
+        return $this->get('/search/repositories', array_merge(['q' => $q, 'sort' => $sort, 'order' => $order], $params));
     }
 
     /**
@@ -37,12 +38,13 @@ class Search extends AbstractApi
      * @param string $q     the filter
      * @param string $sort  the sort field
      * @param string $order asc/desc
+     * @param array  $params
      *
      * @return array list of issues found
      */
-    public function issues($q, $sort = 'updated', $order = 'desc')
+    public function issues($q, $sort = 'updated', $order = 'desc', array $params = [])
     {
-        return $this->get('/search/issues', ['q' => $q, 'sort' => $sort, 'order' => $order]);
+        return $this->get('/search/issues', array_merge(['q' => $q, 'sort' => $sort, 'order' => $order], $params));
     }
 
     /**
@@ -53,12 +55,13 @@ class Search extends AbstractApi
      * @param string $q     the filter
      * @param string $sort  the sort field
      * @param string $order asc/desc
+     * @param array  $params
      *
      * @return array list of code found
      */
-    public function code($q, $sort = 'updated', $order = 'desc')
+    public function code($q, $sort = 'updated', $order = 'desc', array $params = [])
     {
-        return $this->get('/search/code', ['q' => $q, 'sort' => $sort, 'order' => $order]);
+        return $this->get('/search/code', array_merge(['q' => $q, 'sort' => $sort, 'order' => $order], $params));
     }
 
     /**
@@ -69,12 +72,13 @@ class Search extends AbstractApi
      * @param string $q     the filter
      * @param string $sort  the sort field
      * @param string $order asc/desc
+     * @param array  $params
      *
      * @return array list of users found
      */
-    public function users($q, $sort = 'updated', $order = 'desc')
+    public function users($q, $sort = 'updated', $order = 'desc', array $params = [])
     {
-        return $this->get('/search/users', ['q' => $q, 'sort' => $sort, 'order' => $order]);
+        return $this->get('/search/users', array_merge(['q' => $q, 'sort' => $sort, 'order' => $order], $params));
     }
 
     /**
@@ -85,15 +89,16 @@ class Search extends AbstractApi
      * @param string $q     the filter
      * @param string $sort  the sort field
      * @param string $order sort order. asc/desc
+     * @param array  $params
      *
      * @return array
      */
-    public function commits($q, $sort = null, $order = 'desc')
+    public function commits($q, $sort = null, $order = 'desc', array $params = [])
     {
         // This api is in preview mode, so set the correct accept-header
         $this->acceptHeaderValue = 'application/vnd.github.cloak-preview';
 
-        return $this->get('/search/commits', ['q' => $q, 'sort' => $sort, 'order' => $order]);
+        return $this->get('/search/commits', array_merge(['q' => $q, 'sort' => $sort, 'order' => $order], $params));
     }
 
     /**
@@ -102,14 +107,15 @@ class Search extends AbstractApi
      * @link https://developer.github.com/v3/search/#search-topics
      *
      * @param string $q the filter
+     * @param array  $params
      *
      * @return array
      */
-    public function topics($q)
+    public function topics($q, array $params = [])
     {
         // This api is in preview mode, so set the correct accept-header
         $this->acceptHeaderValue = 'application/vnd.github.mercy-preview+json';
 
-        return $this->get('/search/topics', ['q' => $q]);
+        return $this->get('/search/topics', array_merge(['q' => $q], $params));
     }
 }


### PR DESCRIPTION
Since we cannot use `setPerPage()` in 3.0, we need to be able to specify the `per_page` parameter without using a pager. 