### PR TITLE
Update security.md

### DIFF
--- a/doc/security.md
+++ b/doc/security.md
@@ -58,7 +58,7 @@ $jwt = $config->builder()
     ->issuedAt($now)
     ->expiresAt($now->modify('+1 minute'))
     ->getToken($config->signer(), $config->signingKey())
-;
+    ->payload();
 
 $github->authenticate($jwt, null, Github\Client::AUTH_JWT)
 ```


### PR DESCRIPTION
### TLDR

Small fix for the authentication docs. The example from the docs currently doesn't work.

### Details

In the latest version of the Lcobucci\JWT package `getToken()` method returns `Lcobucci\JWT\Token\Plain` object. `authenticate()` method expects first parameter to be a string. `Plain` class doesn't have `__toString()` method implemented, so passing an instance of the `Plain` class to the `authenticate()` method throws an exception.

Apparently Lcobucci introduced a new method called `payload()` to the `Plain` class, so in order to get a string representation of the JWT token we need to call it explicitly.