### PR TITLE
Update integration authentication documentation for usage with lcobucci/jwt ^4

### DIFF
--- a/doc/security.md
+++ b/doc/security.md
@@ -37,11 +37,12 @@ and installation access token which is then usable with `Github\Client::AUTH_ACC
 authentication docs](https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-a-github-app) describe the flow in detail.
 It´s important for integration requests to use the custom Accept header `application/vnd.github.machine-man-preview`.
 
-The following sample code authenticates as an installation using [lcobucci/jwt 3.4](https://github.com/lcobucci/jwt/tree/3.4)
+The following sample code authenticates as an installation using [lcobucci/jwt 4.1](https://github.com/lcobucci/jwt/tree/4.1.x)
 to generate a JSON Web Token (JWT).
 
 ```php
 use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Encoding\ChainedFormatter;
 use Lcobucci\JWT\Signer\Key\LocalFileReference;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 
@@ -53,14 +54,14 @@ $config = Configuration::forSymmetricSigner(
 );
 
 $now = new \DateTimeImmutable();
-$jwt = $config->builder()
+$jwt = $config->builder(ChainedFormatter::withUnixTimestampDates())
     ->issuedBy($integrationId)
     ->issuedAt($now)
     ->expiresAt($now->modify('+1 minute'))
     ->getToken($config->signer(), $config->signingKey())
 ;
 
-$github->authenticate($jwt, null, Github\Client::AUTH_JWT)
+$github->authenticate($jwt->toString(), null, Github\Client::AUTH_JWT)
 ```
 
 The `$integrationId` you can find in the about section of your github app.

--- a/doc/security.md
+++ b/doc/security.md
@@ -41,10 +41,13 @@ The following sample code authenticates as an installation using [lcobucci/jwt 4
 to generate a JSON Web Token (JWT).
 
 ```php
+use Github\HttpClient\Builder;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Encoding\ChainedFormatter;
 use Lcobucci\JWT\Signer\Key\LocalFileReference;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
+
+$builder = new Builder();
 
 $github = new Github\Client($builder, 'machine-man-preview');
 


### PR DESCRIPTION
The security docs were mentioning `lcobucci/jwt:^3.4` which doesn't support php 8. Updated the security docs to reflect all necessary changes to work with `lcobucci/jwt:^4.1`

Passing `ChainedFormatter::withUnixTimestampDates()` to the builder method is necessary because otherwise all dates will be format via `$date->format('U.u')` as microseconds. GitHub expects unix timestamps and will return a 401 response with `'Expiration time' claim ('exp') must be a numeric value representing the future time at which the assertion expires`.