### PR TITLE
allow assigning role to organisation members

### DIFF
--- a/lib/Github/Api/Organization/Members.php
+++ b/lib/Github/Api/Organization/Members.php
@@ -58,9 +58,13 @@ class Members extends AbstractApi
     /*
      * Add user to organization
      */
-    public function add($organization, $username)
+    public function add($organization, $username, array $params = [])
     {
-        return $this->put('/orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username));
+        if (isset($params['role']) && !in_array($params['role'], ['admin', 'member'])) {
+            $params['role'] = 'member';
+        }
+
+        return $this->put('/orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username), $params);
     }
 
     public function addMember($organization, $username)

--- a/lib/Github/Api/Organization/Members.php
+++ b/lib/Github/Api/Organization/Members.php
@@ -60,10 +60,6 @@ class Members extends AbstractApi
      */
     public function add($organization, $username, array $params = [])
     {
-        if (isset($params['role']) && !in_array($params['role'], ['admin', 'member'])) {
-            $params['role'] = 'member';
-        }
-
         return $this->put('/orgs/'.rawurlencode($organization).'/memberships/'.rawurlencode($username), $params);
     }
 


### PR DESCRIPTION
This PR allows you to assign the `admin` role to new members of the organisation.

Ref: https://docs.github.com/en/rest/reference/orgs#set-organization-membership-for-a-user