### PR TITLE
Allow fetching repo readme for a specific ref

### DIFF
--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -257,12 +257,13 @@ class Repo extends AbstractApi
      * @param string $username   the user who owns the repository
      * @param string $repository the name of the repository
      * @param string $format     one of formats: "raw", "html", or "v3+json"
+     * @param array  $params     additional query params like "ref" to fetch readme for branch/tag
      *
      * @return string|array the readme content
      */
-    public function readme($username, $repository, $format = 'raw')
+    public function readme($username, $repository, $format = 'raw', $params = [])
     {
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/readme', [], [
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/readme', $params, [
             'Accept' => "application/vnd.github.$format",
         ]);
     }


### PR DESCRIPTION
As per Github's API it is possible to fetch a readme file for specific branch or tag

https://docs.github.com/en/rest/reference/repos#get-a-repository-readme