### PR TITLE
Allow psr/cache 2.0 as well as 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php-http/discovery": "^1.12",
         "php-http/httplug": "^2.2",
         "php-http/multipart-stream-builder": "^1.1.2",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0|^2.0",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
Updates the composer.json file to allow for `psr/cache` version 2.0 which is the default installed alongside frameworks like Symfony 5.3. As far as I can tell it's API compatible and the test suite passes with 2.0 installed.

Could also extend the versions to allow 3.0 (which is what projects like `doctrine/persistence`) do but not sure what 3.0 brings to the table.