### PR TITLE
Add accept header for creating repo from template

### DIFF
--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -805,6 +805,9 @@ class Repo extends AbstractApi
      */
     public function createFromTemplate(string $templateOwner, string $templateRepo, array $parameters = [])
     {
+        //This api is in preview mode, so set the correct accept-header
+        $this->acceptHeaderValue = 'application/vnd.github.baptiste-preview+json';
+        
         return $this->post('/repos/'.rawurldecode($templateOwner).'/'.rawurldecode($templateRepo).'/generate', $parameters);
     }
 }

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -807,7 +807,7 @@ class Repo extends AbstractApi
     {
         //This api is in preview mode, so set the correct accept-header
         $this->acceptHeaderValue = 'application/vnd.github.baptiste-preview+json';
-        
+
         return $this->post('/repos/'.rawurldecode($templateOwner).'/'.rawurldecode($templateRepo).'/generate', $parameters);
     }
 }


### PR DESCRIPTION
This still requires an accept header as per the docs: https://docs.github.com/en/rest/reference/repos#create-a-repository-using-a-template-preview-notices