### PR TITLE
refs #955: deprecate Client::AUTH_* constants and replace them with AuthMethod::AUTH_* const

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -15,7 +15,7 @@
 
 ### Authentication methods
 
-* `Github\Client::AUTH_URL_TOKEN` use `Github\Client::AUTH_ACCESS_TOKEN` instead.
-* `Github\Client::AUTH_URL_CLIENT_ID` use `Github\Client::AUTH_CLIENT_ID` instead.
-* `Github\Client::AUTH_HTTP_TOKEN` use `Github\Client::AUTH_ACCESS_TOKEN` instead.
-* `Github\Client::AUTH_HTTP_PASSWORD` use `Github\Client::AUTH_ACCESS_TOKEN` instead.
+* `Github\Client::AUTH_ACCESS_TOKEN`  use `Github\AuthMethod::AUTH_ACCESS_TOKEN` instead.
+* `Github\Client::AUTH_CLIENT_ID`  use `Github\AuthMethod::AUTH_CLIENT_ID` instead.
+* `Github\Client::AUTH_ACCESS_TOKEN`  use `Github\AuthMethod::AUTH_ACCESS_TOKEN` instead.
+* `Github\Client::AUTH_ACCESS_TOKEN`  use `Github\AuthMethod::AUTH_ACCESS_TOKEN` instead.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -15,7 +15,7 @@
 
 ### Authentication methods
 
-* `Github\Client::AUTH_ACCESS_TOKEN`  use `Github\AuthMethod::AUTH_ACCESS_TOKEN` instead.
-* `Github\Client::AUTH_CLIENT_ID`  use `Github\AuthMethod::AUTH_CLIENT_ID` instead.
-* `Github\Client::AUTH_ACCESS_TOKEN`  use `Github\AuthMethod::AUTH_ACCESS_TOKEN` instead.
-* `Github\Client::AUTH_ACCESS_TOKEN`  use `Github\AuthMethod::AUTH_ACCESS_TOKEN` instead.
+* `Github\Client::AUTH_URL_TOKEN` use `Github\Client::AUTH_ACCESS_TOKEN` instead.
+* `Github\Client::AUTH_URL_CLIENT_ID` use `Github\Client::AUTH_CLIENT_ID` instead.
+* `Github\Client::AUTH_HTTP_TOKEN` use `Github\Client::AUTH_ACCESS_TOKEN` instead.
+* `Github\Client::AUTH_HTTP_PASSWORD` use `Github\Client::AUTH_ACCESS_TOKEN` instead.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -3,3 +3,9 @@
 ### ResultPager
 
 * `\Github\ResultPagerInterface::postFetch` is deprecated, and the method will be removed from the ResultPager interface/class.
+
+### Authentication methods
+
+* `Github\Client::AUTH_CLIENT_ID` is deprecated, use `Github\AuthMethod::CLIENT_ID` instead.
+* `Github\Client::AUTH_ACCESS_TOKEN` is deprecated, use `Github\AuthMethod::ACCESS_TOKEN` instead.
+* `Github\Client::AUTH_JWT` is deprecated, use `Github\AuthMethod::JWT` instead.

--- a/doc/currentuser/repositories.md
+++ b/doc/currentuser/repositories.md
@@ -19,12 +19,12 @@ There are three values that can be passed into the `repositories` method: `type`
 | sort          | `full_name` | `created`, `updated`, `pushed`, `full_name`
 | direction     | `asc`       | `asc`, `desc`
 
-> See https://developer.github.com/v3/repos/#list-your-repositories for possible values and additional information 
+> See https://developer.github.com/v3/repos/#list-your-repositories for possible values and additional information
 
 #### Code Example:
 
 ```php
-$client = new \Github\Client(); 
-$client->authenticate($github_token, null, \Github\Client::AUTH_ACCESS_TOKEN);
+$client = new \Github\Client();
+$client->authenticate($github_token, null, \Github\AuthMethod::AUTH_ACCESS_TOKEN);
 $client->currentUser()->repositories();
 ```

--- a/doc/currentuser/repositories.md
+++ b/doc/currentuser/repositories.md
@@ -25,6 +25,6 @@ There are three values that can be passed into the `repositories` method: `type`
 
 ```php
 $client = new \Github\Client();
-$client->authenticate($github_token, null, \Github\AuthMethod::AUTH_ACCESS_TOKEN);
+$client->authenticate($github_token, null, \Github\AuthMethod::ACCESS_TOKEN);
 $client->currentUser()->repositories();
 ```

--- a/doc/graphql.md
+++ b/doc/graphql.md
@@ -14,7 +14,7 @@ $rateLimits = $client->api('graphql')->execute($query);
 To use [GitHub v4 API (GraphQL API)](http://developer.github.com/v4/) requests must [authenticated]((../security.md)).
 
 ```php
-$client->authenticate($token, null, Github\AuthMethod::AUTH_ACCESS_TOKEN);
+$client->authenticate($token, null, Github\AuthMethod::ACCESS_TOKEN);
 
 $result = $client->api('graphql')->execute($query);
 ```
@@ -51,7 +51,7 @@ $variables = [
     'organizationLogin' => 'KnpLabs'
 ];
 
-$client->authenticate('<your-token>', null, Github\AuthMethod::AUTH_ACCESS_TOKEN);
+$client->authenticate('<your-token>', null, Github\AuthMethod::ACCESS_TOKEN);
 
 $orgInfo = $client->api('graphql')->execute($query, $variables);
 ```

--- a/doc/graphql.md
+++ b/doc/graphql.md
@@ -14,7 +14,7 @@ $rateLimits = $client->api('graphql')->execute($query);
 To use [GitHub v4 API (GraphQL API)](http://developer.github.com/v4/) requests must [authenticated]((../security.md)).
 
 ```php
-$client->authenticate($token, null, Github\Client::AUTH_ACCESS_TOKEN);
+$client->authenticate($token, null, Github\AuthMethod::AUTH_ACCESS_TOKEN);
 
 $result = $client->api('graphql')->execute($query);
 ```
@@ -28,7 +28,7 @@ To use [GitHub v4 API (GraphQL API)](http://developer.github.com/v4/) with diffe
 ```php
 $result = $client->api('graphql')->execute($query, [], 'application/vnd.github.starfox-preview+json')
 ```
-> default accept header is `application/vnd.github.v4+json`  
+> default accept header is `application/vnd.github.v4+json`
 
 
 
@@ -51,7 +51,7 @@ $variables = [
     'organizationLogin' => 'KnpLabs'
 ];
 
-$client->authenticate('<your-token>', null, Github\Client::AUTH_ACCESS_TOKEN);
+$client->authenticate('<your-token>', null, Github\AuthMethod::AUTH_ACCESS_TOKEN);
 
 $orgInfo = $client->api('graphql')->execute($query, $variables);
 ```

--- a/doc/security.md
+++ b/doc/security.md
@@ -17,23 +17,23 @@ $client->authenticate($usernameOrToken, $password, $method);
 and guess what should contain `$password`. The `$method` can contain one of the three allowed values:
 
 #### Supported methods
-* `Github\AuthMethod::AUTH_CLIENT_ID` - https://developer.github.com/v3/#oauth2-keysecret
-* `Github\AuthMethod::AUTH_ACCESS_TOKEN` - https://developer.github.com/v3/#oauth2-token-sent-in-a-header
-* `Github\AuthMethod::AUTH_JWT` - https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app
+* `Github\AuthMethod::CLIENT_ID` - https://developer.github.com/v3/#oauth2-keysecret
+* `Github\AuthMethod::ACCESS_TOKEN` - https://developer.github.com/v3/#oauth2-token-sent-in-a-header
+* `Github\AuthMethod::JWT` - https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app
 
-The required value of `$password` depends on the chosen `$method`. For `Github\AuthMethod::AUTH_ACCESS_TOKEN`, `Github\Client::AUTH_ACCESS_TOKEN` and
-`Github\Client::JWT` methods you should provide the API token in `$usernameOrToken` variable (`$password` is omitted in
+The required value of `$password` depends on the chosen `$method`. For `Github\AuthMethod::CLIENT_ID`, `Github\AuthMethod::ACCESS_TOKEN` and
+`Github\AuthMethod::JWT` methods you should provide the API token in `$usernameOrToken` variable (`$password` is omitted in
 this particular case).
 
-The `Github\Client::AUTH_JWT` authentication method sends the specified JSON Web Token in an Authorization header.
+The `Github\AuthMethod::JWT` authentication method sends the specified JSON Web Token in an Authorization header.
 
 After executing the `$client->authenticate($usernameOrToken, $secret, $method);` method using correct credentials, all
 further requests are done as the given user.
 
 ### Authenticating as an Integration
 
-To authenticate as an integration you need to supply a JSON Web Token with `Github\Client::AUTH_JWT` to request
-and installation access token which is then usable with `Github\AuthMethod::AUTH_ACCESS_TOKEN`. [Github´s integration
+To authenticate as an integration you need to supply a JSON Web Token with `Github\AuthMethod::JWT` to request
+and installation access token which is then usable with `Github\AuthMethod::ACCESS_TOKEN`. [Github´s integration
 authentication docs](https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-a-github-app) describe the flow in detail.
 It´s important for integration requests to use the custom Accept header `application/vnd.github.machine-man-preview`.
 
@@ -64,7 +64,7 @@ $jwt = $config->builder(ChainedFormatter::withUnixTimestampDates())
     ->getToken($config->signer(), $config->signingKey())
 ;
 
-$github->authenticate($jwt->toString(), null, Github\Client::AUTH_JWT)
+$github->authenticate($jwt->toString(), null, Github\AuthMethod::JWT)
 ```
 
 The `$integrationId` you can find in the about section of your github app.

--- a/doc/security.md
+++ b/doc/security.md
@@ -17,11 +17,11 @@ $client->authenticate($usernameOrToken, $password, $method);
 and guess what should contain `$password`. The `$method` can contain one of the three allowed values:
 
 #### Supported methods
-* `Github\Client::AUTH_CLIENT_ID` - https://developer.github.com/v3/#oauth2-keysecret
-* `Github\Client::AUTH_ACCESS_TOKEN` - https://developer.github.com/v3/#oauth2-token-sent-in-a-header
-* `Github\Client::AUTH_JWT` - https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app
+* `Github\AuthMethod::AUTH_CLIENT_ID` - https://developer.github.com/v3/#oauth2-keysecret
+* `Github\AuthMethod::AUTH_ACCESS_TOKEN` - https://developer.github.com/v3/#oauth2-token-sent-in-a-header
+* `Github\AuthMethod::AUTH_JWT` - https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app
 
-The required value of `$password` depends on the chosen `$method`. For `Github\Client::AUTH_ACCESS_TOKEN`, `Github\Client::AUTH_ACCESS_TOKEN` and
+The required value of `$password` depends on the chosen `$method`. For `Github\AuthMethod::AUTH_ACCESS_TOKEN`, `Github\Client::AUTH_ACCESS_TOKEN` and
 `Github\Client::JWT` methods you should provide the API token in `$usernameOrToken` variable (`$password` is omitted in
 this particular case).
 
@@ -33,7 +33,7 @@ further requests are done as the given user.
 ### Authenticating as an Integration
 
 To authenticate as an integration you need to supply a JSON Web Token with `Github\Client::AUTH_JWT` to request
-and installation access token which is then usable with `Github\Client::AUTH_ACCESS_TOKEN`. [Github´s integration
+and installation access token which is then usable with `Github\AuthMethod::AUTH_ACCESS_TOKEN`. [Github´s integration
 authentication docs](https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-a-github-app) describe the flow in detail.
 It´s important for integration requests to use the custom Accept header `application/vnd.github.machine-man-preview`.
 

--- a/lib/Github/AuthMethod.php
+++ b/lib/Github/AuthMethod.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Github;
+
+final class AuthMethod
+{
+    /**
+     * Authenticate using a client_id/client_secret combination.
+     *
+     * @var string
+     */
+    const AUTH_CLIENT_ID = 'client_id_header';
+
+    /**
+     * Authenticate using a GitHub access token.
+     *
+     * @var string
+     */
+    const AUTH_ACCESS_TOKEN = 'access_token_header';
+
+    /**
+     * Constant for authentication method.
+     *
+     * Indicates JSON Web Token authentication required for GitHub apps access
+     * to the API.
+     *
+     * @var string
+     */
+    const AUTH_JWT = 'jwt';
+}

--- a/lib/Github/AuthMethod.php
+++ b/lib/Github/AuthMethod.php
@@ -9,14 +9,14 @@ final class AuthMethod
      *
      * @var string
      */
-    const AUTH_CLIENT_ID = 'client_id_header';
+    const CLIENT_ID = 'client_id_header';
 
     /**
      * Authenticate using a GitHub access token.
      *
      * @var string
      */
-    const AUTH_ACCESS_TOKEN = 'access_token_header';
+    const ACCESS_TOKEN = 'access_token_header';
 
     /**
      * Constant for authentication method.
@@ -26,5 +26,5 @@ final class AuthMethod
      *
      * @var string
      */
-    const AUTH_JWT = 'jwt';
+    const JWT = 'jwt';
 }

--- a/lib/Github/AuthMethod.php
+++ b/lib/Github/AuthMethod.php
@@ -9,14 +9,14 @@ final class AuthMethod
      *
      * @var string
      */
-    const CLIENT_ID = 'client_id_header';
+    public const CLIENT_ID = 'client_id_header';
 
     /**
      * Authenticate using a GitHub access token.
      *
      * @var string
      */
-    const ACCESS_TOKEN = 'access_token_header';
+    public const ACCESS_TOKEN = 'access_token_header';
 
     /**
      * Constant for authentication method.
@@ -26,5 +26,5 @@ final class AuthMethod
      *
      * @var string
      */
-    const JWT = 'jwt';
+    public const JWT = 'jwt';
 }

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -70,30 +70,6 @@ use Psr\Http\Message\ResponseInterface;
 class Client
 {
     /**
-     * Authenticate using a client_id/client_secret combination.
-     *
-     * @var string
-     */
-    const AUTH_CLIENT_ID = 'client_id_header';
-
-    /**
-     * Authenticate using a GitHub access token.
-     *
-     * @var string
-     */
-    const AUTH_ACCESS_TOKEN = 'access_token_header';
-
-    /**
-     * Constant for authentication method.
-     *
-     * Indicates JSON Web Token authentication required for GitHub apps access
-     * to the API.
-     *
-     * @var string
-     */
-    const AUTH_JWT = 'jwt';
-
-    /**
      * @var string
      */
     private $apiVersion;
@@ -313,7 +289,7 @@ class Client
      */
     public function authenticate($tokenOrLogin, $password = null, $authMethod = null): void
     {
-        if (null === $authMethod && (self::AUTH_JWT === $password || self::AUTH_ACCESS_TOKEN === $password)) {
+        if (null === $authMethod && (AuthMethod::AUTH_JWT === $password || AuthMethod::AUTH_ACCESS_TOKEN === $password)) {
             $authMethod = $password;
             $password = null;
         }

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -76,7 +76,7 @@ class Client
      *
      * @deprecated Use the AuthMethod const
      */
-    const AUTH_CLIENT_ID = 'client_id_header';
+    const AUTH_CLIENT_ID = AuthMethod::CLIENT_ID;
 
     /**
      * Authenticate using a GitHub access token.
@@ -85,7 +85,7 @@ class Client
      *
      * @deprecated Use the AuthMethod const
      */
-    const AUTH_ACCESS_TOKEN = 'access_token_header';
+    const AUTH_ACCESS_TOKEN = AuthMethod::ACCESS_TOKEN;
 
     /**
      * Constant for authentication method.
@@ -97,7 +97,7 @@ class Client
      *
      * @deprecated Use the AuthMethod const
      */
-    const AUTH_JWT = 'jwt';
+    const AUTH_JWT = AuthMethod::JWT;
 
     /**
      * @var string
@@ -319,7 +319,7 @@ class Client
      */
     public function authenticate($tokenOrLogin, $password = null, $authMethod = null): void
     {
-        if (null === $authMethod && (AuthMethod::AUTH_JWT === $password || AuthMethod::AUTH_ACCESS_TOKEN === $password)) {
+        if (null === $authMethod && (AuthMethod::JWT === $password || AuthMethod::ACCESS_TOKEN === $password)) {
             $authMethod = $password;
             $password = null;
         }

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -70,6 +70,36 @@ use Psr\Http\Message\ResponseInterface;
 class Client
 {
     /**
+     * Authenticate using a client_id/client_secret combination.
+     *
+     * @var string
+     *
+     * @deprecated Use the AuthMethod const
+     */
+    const AUTH_CLIENT_ID = 'client_id_header';
+
+    /**
+     * Authenticate using a GitHub access token.
+     *
+     * @var string
+     *
+     * @deprecated Use the AuthMethod const
+     */
+    const AUTH_ACCESS_TOKEN = 'access_token_header';
+
+    /**
+     * Constant for authentication method.
+     *
+     * Indicates JSON Web Token authentication required for GitHub apps access
+     * to the API.
+     *
+     * @var string
+     *
+     * @deprecated Use the AuthMethod const
+     */
+    const AUTH_JWT = 'jwt';
+
+    /**
      * @var string
      */
     private $apiVersion;

--- a/lib/Github/HttpClient/Plugin/Authentication.php
+++ b/lib/Github/HttpClient/Plugin/Authentication.php
@@ -58,11 +58,11 @@ final class Authentication implements Plugin
     private function getAuthorizationHeader(): string
     {
         switch ($this->method) {
-            case AuthMethod::AUTH_CLIENT_ID:
+            case AuthMethod::CLIENT_ID:
                 return sprintf('Basic %s', base64_encode($this->tokenOrLogin.':'.$this->password));
-            case AuthMethod::AUTH_ACCESS_TOKEN:
+            case AuthMethod::ACCESS_TOKEN:
                 return sprintf('token %s', $this->tokenOrLogin);
-            case AuthMethod::AUTH_JWT:
+            case AuthMethod::JWT:
                 return sprintf('Bearer %s', $this->tokenOrLogin);
             default:
                 throw new RuntimeException(sprintf('%s not yet implemented', $this->method));

--- a/lib/Github/HttpClient/Plugin/Authentication.php
+++ b/lib/Github/HttpClient/Plugin/Authentication.php
@@ -2,7 +2,7 @@
 
 namespace Github\HttpClient\Plugin;
 
-use Github\Client;
+use Github\AuthMethod;
 use Github\Exception\RuntimeException;
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
@@ -58,11 +58,11 @@ final class Authentication implements Plugin
     private function getAuthorizationHeader(): string
     {
         switch ($this->method) {
-            case Client::AUTH_CLIENT_ID:
+            case AuthMethod::AUTH_CLIENT_ID:
                 return sprintf('Basic %s', base64_encode($this->tokenOrLogin.':'.$this->password));
-            case Client::AUTH_ACCESS_TOKEN:
+            case AuthMethod::AUTH_ACCESS_TOKEN:
                 return sprintf('token %s', $this->tokenOrLogin);
-            case Client::AUTH_JWT:
+            case AuthMethod::AUTH_JWT:
                 return sprintf('Bearer %s', $this->tokenOrLogin);
             default:
                 throw new RuntimeException(sprintf('%s not yet implemented', $this->method));

--- a/test/Github/Tests/ClientTest.php
+++ b/test/Github/Tests/ClientTest.php
@@ -3,6 +3,7 @@
 namespace Github\Tests;
 
 use Github\Api;
+use Github\AuthMethod;
 use Github\Client;
 use Github\Exception\BadMethodCallException;
 use Github\Exception\InvalidArgumentException;
@@ -68,9 +69,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     public function getAuthenticationFullData()
     {
         return [
-            ['token', null, Client::AUTH_ACCESS_TOKEN],
-            ['client_id', 'client_secret', Client::AUTH_CLIENT_ID],
-            ['token', null, Client::AUTH_JWT],
+            ['token', null, AuthMethod::AUTH_ACCESS_TOKEN],
+            ['client_id', 'client_secret', AuthMethod::AUTH_CLIENT_ID],
+            ['token', null, AuthMethod::AUTH_JWT],
         ];
     }
 
@@ -84,7 +85,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $builder->expects($this->once())
             ->method('addPlugin')
-            ->with($this->equalTo(new Authentication('token', null, Client::AUTH_ACCESS_TOKEN)));
+            ->with($this->equalTo(new Authentication('token', null, AuthMethod::AUTH_ACCESS_TOKEN)));
 
         $builder->expects($this->once())
             ->method('removePlugin')
@@ -98,7 +99,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ->method('getHttpClientBuilder')
             ->willReturn($builder);
 
-        $client->authenticate('token', Client::AUTH_ACCESS_TOKEN);
+        $client->authenticate('token', AuthMethod::AUTH_ACCESS_TOKEN);
     }
 
     /**

--- a/test/Github/Tests/ClientTest.php
+++ b/test/Github/Tests/ClientTest.php
@@ -69,9 +69,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     public function getAuthenticationFullData()
     {
         return [
-            ['token', null, AuthMethod::AUTH_ACCESS_TOKEN],
-            ['client_id', 'client_secret', AuthMethod::AUTH_CLIENT_ID],
-            ['token', null, AuthMethod::AUTH_JWT],
+            ['token', null, AuthMethod::ACCESS_TOKEN],
+            ['client_id', 'client_secret', AuthMethod::CLIENT_ID],
+            ['token', null, AuthMethod::JWT],
         ];
     }
 
@@ -85,7 +85,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $builder->expects($this->once())
             ->method('addPlugin')
-            ->with($this->equalTo(new Authentication('token', null, AuthMethod::AUTH_ACCESS_TOKEN)));
+            ->with($this->equalTo(new Authentication('token', null, AuthMethod::ACCESS_TOKEN)));
 
         $builder->expects($this->once())
             ->method('removePlugin')
@@ -99,7 +99,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ->method('getHttpClientBuilder')
             ->willReturn($builder);
 
-        $client->authenticate('token', AuthMethod::AUTH_ACCESS_TOKEN);
+        $client->authenticate('token', AuthMethod::ACCESS_TOKEN);
     }
 
     /**

--- a/test/Github/Tests/Functional/CacheTest.php
+++ b/test/Github/Tests/Functional/CacheTest.php
@@ -2,6 +2,7 @@
 
 namespace Github\Tests\Functional;
 
+use Github\AuthMethod;
 use Github\Client;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -25,7 +26,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $github = Client::createWithHttpClient($mockClient);
         $github->addCache(new ArrayAdapter(), ['default_ttl'=>600]);
 
-        $github->authenticate('fake_token_aaa', Client::AUTH_ACCESS_TOKEN);
+        $github->authenticate('fake_token_aaa', AuthMethod::AUTH_ACCESS_TOKEN);
         $userA = $github->currentUser()->show();
         $this->assertEquals('nyholm', $userA['login']);
 
@@ -45,11 +46,11 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $github = Client::createWithHttpClient($mockClient);
         $github->addCache(new ArrayAdapter(), ['default_ttl'=>600]);
 
-        $github->authenticate('fake_token_aaa', Client::AUTH_ACCESS_TOKEN);
+        $github->authenticate('fake_token_aaa', AuthMethod::AUTH_ACCESS_TOKEN);
         $userA = $github->currentUser()->show();
         $this->assertEquals('nyholm', $userA['login']);
 
-        $github->authenticate('fake_token_bbb', Client::AUTH_ACCESS_TOKEN);
+        $github->authenticate('fake_token_bbb', AuthMethod::AUTH_ACCESS_TOKEN);
         $userB = $github->currentUser()->show();
         $this->assertEquals('octocat', $userB['login'], 'We must vary on the Authorization header.');
     }

--- a/test/Github/Tests/Functional/CacheTest.php
+++ b/test/Github/Tests/Functional/CacheTest.php
@@ -26,7 +26,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $github = Client::createWithHttpClient($mockClient);
         $github->addCache(new ArrayAdapter(), ['default_ttl'=>600]);
 
-        $github->authenticate('fake_token_aaa', AuthMethod::AUTH_ACCESS_TOKEN);
+        $github->authenticate('fake_token_aaa', AuthMethod::ACCESS_TOKEN);
         $userA = $github->currentUser()->show();
         $this->assertEquals('nyholm', $userA['login']);
 
@@ -46,11 +46,11 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $github = Client::createWithHttpClient($mockClient);
         $github->addCache(new ArrayAdapter(), ['default_ttl'=>600]);
 
-        $github->authenticate('fake_token_aaa', AuthMethod::AUTH_ACCESS_TOKEN);
+        $github->authenticate('fake_token_aaa', AuthMethod::ACCESS_TOKEN);
         $userA = $github->currentUser()->show();
         $this->assertEquals('nyholm', $userA['login']);
 
-        $github->authenticate('fake_token_bbb', AuthMethod::AUTH_ACCESS_TOKEN);
+        $github->authenticate('fake_token_bbb', AuthMethod::ACCESS_TOKEN);
         $userB = $github->currentUser()->show();
         $this->assertEquals('octocat', $userB['login'], 'We must vary on the Authorization header.');
     }

--- a/test/Github/Tests/HttpClient/Plugin/AuthenticationTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/AuthenticationTest.php
@@ -2,7 +2,7 @@
 
 namespace Github\Tests\HttpClient\Plugin;
 
-use Github\Client;
+use Github\AuthMethod;
 use Github\HttpClient\Plugin\Authentication;
 use GuzzleHttp\Psr7\Request;
 use Http\Promise\FulfilledPromise;
@@ -41,9 +41,9 @@ class AuthenticationTest extends TestCase
     public function getAuthenticationData()
     {
         return [
-            ['access_token', null, Client::AUTH_ACCESS_TOKEN, 'token access_token'],
-            ['client_id', 'client_secret', Client::AUTH_CLIENT_ID, sprintf('Basic %s', base64_encode('client_id'.':'.'client_secret'))],
-            ['jwt_token', null, Client::AUTH_JWT, 'Bearer jwt_token'],
+            ['access_token', null, AuthMethod::AUTH_ACCESS_TOKEN, 'token access_token'],
+            ['client_id', 'client_secret', AuthMethod::AUTH_CLIENT_ID, sprintf('Basic %s', base64_encode('client_id'.':'.'client_secret'))],
+            ['jwt_token', null, AuthMethod::AUTH_JWT, 'Bearer jwt_token'],
         ];
     }
 }

--- a/test/Github/Tests/HttpClient/Plugin/AuthenticationTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/AuthenticationTest.php
@@ -41,9 +41,9 @@ class AuthenticationTest extends TestCase
     public function getAuthenticationData()
     {
         return [
-            ['access_token', null, AuthMethod::AUTH_ACCESS_TOKEN, 'token access_token'],
-            ['client_id', 'client_secret', AuthMethod::AUTH_CLIENT_ID, sprintf('Basic %s', base64_encode('client_id'.':'.'client_secret'))],
-            ['jwt_token', null, AuthMethod::AUTH_JWT, 'Bearer jwt_token'],
+            ['access_token', null, AuthMethod::ACCESS_TOKEN, 'token access_token'],
+            ['client_id', 'client_secret', AuthMethod::CLIENT_ID, sprintf('Basic %s', base64_encode('client_id'.':'.'client_secret'))],
+            ['jwt_token', null, AuthMethod::JWT, 'Bearer jwt_token'],
         ];
     }
 }


### PR DESCRIPTION
Contribution for #955