### PR TITLE
Fix internal doc link

### DIFF
--- a/doc/graphql.md
+++ b/doc/graphql.md
@@ -11,7 +11,7 @@ $rateLimits = $client->api('graphql')->execute($query);
 
 #### Authentication
 
-To use [GitHub v4 API (GraphQL API)](http://developer.github.com/v4/) requests must [authenticated]((../security.md)).
+To use [GitHub v4 API (GraphQL API)](http://developer.github.com/v4/) requests must [authenticated](security.md).
 
 ```php
 $client->authenticate($token, null, Github\AuthMethod::ACCESS_TOKEN);


### PR DESCRIPTION
`security.md` is in the same directory and one pair of brackets needs to be removed.