### PR TITLE
Fix Client URL Prepending For GraphQL Endpoint on Enterprise

### DIFF
--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -346,7 +346,14 @@ class Client
         $builder->removePlugin(PathPrepend::class);
 
         $builder->addPlugin(new Plugin\AddHostPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri($enterpriseUrl)));
-        $builder->addPlugin(new PathPrepend(sprintf('/api/%s', $this->getApiVersion())));
+
+        // For GHE, v4 API endpoint is at `api/graphql` so we don't want to add the version number
+        // For earlier versions add the version number after /api
+        if ($this->getApiVersion() === 'v4') {
+            $builder->addPlugin(new PathPrepend('/api'));
+        } else {
+            $builder->addPlugin(new PathPrepend(sprintf('/api/%s', $this->getApiVersion())));
+        }
     }
 
     /**

--- a/test/Github/Tests/ClientTest.php
+++ b/test/Github/Tests/ClientTest.php
@@ -225,7 +225,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Make sure that the prepend is correct when using the v4 endpoint on Enterprise
+     * Make sure that the prepend is correct when using the v4 endpoint on Enterprise.
      */
     public function testEnterprisePrependGraphQLV4()
     {

--- a/test/Github/Tests/ClientTest.php
+++ b/test/Github/Tests/ClientTest.php
@@ -223,4 +223,25 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $client = new Client($httpClientBuilder, null, 'https://foobar.com');
         $client->enterprise()->stats()->show('all');
     }
+
+    /**
+     * Make sure that the prepend is correct when using the v4 endpoint on Enterprise
+     */
+    public function testEnterprisePrependGraphQLV4()
+    {
+        $httpClientMock = $this->getMockBuilder(ClientInterface::class)
+            ->setMethods(['sendRequest'])
+            ->getMock();
+
+        $httpClientMock->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request) {
+                return (string) $request->getUri() === 'https://foobar.com/api/graphql';
+            }))
+            ->willReturn(new Response(200, [], '[]'));
+
+        $httpClientBuilder = new Builder($httpClientMock);
+        $client = new Client($httpClientBuilder, 'v4', 'https://foobar.com');
+        $client->graphql()->execute('query');
+    }
 }


### PR DESCRIPTION
fixes #1047 

This checks if `v4` is passed into the Client and an Enterprise URL is set then the prepend will only be `/api`.  (The class default is `v3` if no version is provided so can't just pass an empty string).

TL;DR - this now allows this package to run GraphQL calls on Enterprise `$client = new Client(null, 'v4', 'https://enterpriseurl');`