### PR TITLE
Symfony: allow deprecation-contracts version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/http-factory-implementation": "^1.0",
         "psr/http-message": "^1.0",
         "symfony/polyfill-php80": "^1.17",
-        "symfony/deprecation-contracts": "^2.2"
+        "symfony/deprecation-contracts": "^2.2|^3.0"
     },
     "require-dev": {
         "symfony/cache": "^5.1.8",


### PR DESCRIPTION
Version 3 was released with added type hints. No need to update anything.