### PR TITLE
Boolean private needed to create private repo!

### DIFF
--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -205,6 +205,7 @@ class Repo extends AbstractApi
             'name'          => $name,
             'description'   => $description,
             'homepage'      => $homepage,
+            'private'       => ($visibility ?? ($public ? 'public' : 'private')) === 'private',
             'visibility'    => $visibility ?? ($public ? 'public' : 'private'),
             'has_issues'    => $hasIssues,
             'has_wiki'      => $hasWiki,

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -96,6 +96,7 @@ class RepoTest extends TestCase
                 'description'   => '',
                 'homepage'      => '',
                 'visibility'    => 'public',
+                'private'       => false,
                 'has_issues'    => false,
                 'has_wiki'      => false,
                 'has_downloads' => false,
@@ -122,6 +123,7 @@ class RepoTest extends TestCase
                 'description'   => '',
                 'homepage'      => '',
                 'visibility'    => 'public',
+                'private'       => false,
                 'has_issues'    => false,
                 'has_wiki'      => false,
                 'has_downloads' => false,
@@ -153,6 +155,7 @@ class RepoTest extends TestCase
                 'auto_init'     => false,
                 'has_projects'  => true,
                 'visibility'    => 'internal',
+                'private'       => false,
             ])
             ->will($this->returnValue($expectedArray));
 
@@ -372,6 +375,7 @@ class RepoTest extends TestCase
                 'description'   => 'test',
                 'homepage'      => 'http://l3l0.eu',
                 'visibility'    => 'private',
+                'private'       => true,
                 'has_issues'    => false,
                 'has_wiki'      => false,
                 'has_downloads' => false,


### PR DESCRIPTION
Apparently there was an GitHub API change. When private is not set to `true` the visibility `private` is ignored