### PR TITLE
Include optional params parameter for Commits compare method

### DIFF
--- a/lib/Github/Api/Repository/Commits.php
+++ b/lib/Github/Api/Repository/Commits.php
@@ -16,14 +16,14 @@ class Commits extends AbstractApi
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits', $params);
     }
 
-    public function compare($username, $repository, $base, $head, $mediaType = null)
+    public function compare($username, $repository, $base, $head, $mediaType = null, array $params = [])
     {
         $headers = [];
         if (null !== $mediaType) {
             $headers['Accept'] = $mediaType;
         }
 
-        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/compare/'.rawurlencode($base).'...'.rawurlencode($head), [], $headers);
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/compare/'.rawurlencode($base).'...'.rawurlencode($head), $params, $headers);
     }
 
     public function show($username, $repository, $sha)


### PR DESCRIPTION
The Github compare API limits the response to only [250 commits](https://docs.github.com/en/rest/reference/commits#compare-two-commits). I have been testing this library and I have not been able to paginate the compare call without using the params array and adding the `per_page` key. Without it, I always got only 250 commits in the diff.

When the `$params` is included, I have managed to get paginate all the commits from the Github API.

Unfortunately, I cannot easily use the `all` call with the `since` parameter because I only have the base and head available.

I think this change would be valuable in general, it should not break any existing behaviour and it will enable pagination for compare calls.

Thank you very much for the review and considering this change, it would help a lot to our team.