### PR TITLE
Able to pass per_page and page params to current user repos

### DIFF
--- a/lib/Github/Api/CurrentUser.php
+++ b/lib/Github/Api/CurrentUser.php
@@ -118,10 +118,12 @@ class CurrentUser extends AbstractApi
      * @param string $direction   direction of sort, asc or desc
      * @param string $visibility  visibility of repository
      * @param string $affiliation relationship to repository
+     * @param int    $perPage     results per page
+     * @param int    $page        page number of the results to fetch
      *
      * @return array
      */
-    public function repositories($type = 'owner', $sort = 'full_name', $direction = 'asc', $visibility = null, $affiliation = null)
+    public function repositories($type = 'owner', $sort = 'full_name', $direction = 'asc', $visibility = null, $affiliation = null, $perPage = null, $page = null)
     {
         $params = [
             'type' => $type,
@@ -137,6 +139,14 @@ class CurrentUser extends AbstractApi
         if (null !== $affiliation) {
             unset($params['type']);
             $params['affiliation'] = $affiliation;
+        }
+
+        if (null !== $perPage) {
+            $params['per_page'] = $perPage;
+        }
+
+        if (null !== $page) {
+            $params['page'] = $page;
         }
 
         return $this->get('/user/repos', $params);


### PR DESCRIPTION
For the current user I need to be able to paginate through the results because one of my users have a lot of repos. This would allow my to do that.

What do you think of instead having an `array $params` where the developer can pass params by themselves. It's not as safe as having individual params but who knows?