### PR TITLE
Add method to use generate release notes endpoint

### DIFF
--- a/lib/Github/Api/Repository/Releases.php
+++ b/lib/Github/Api/Repository/Releases.php
@@ -69,6 +69,20 @@ class Releases extends AbstractApi
     }
 
     /**
+     * Generate release notes content for a release.
+     *
+     * @param string $username
+     * @param string $repository
+     * @param array  $params
+     *
+     * @return array
+     */
+    public function generateNotes($username, $repository, array $params)
+    {
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/generate-notes', $params);
+    }
+
+    /**
      * Create new release in selected repository.
      *
      * @param string $username

--- a/test/Github/Tests/Api/Repository/ReleasesTest.php
+++ b/test/Github/Tests/Api/Repository/ReleasesTest.php
@@ -79,6 +79,26 @@ class ReleasesTest extends TestCase
     /**
      * @test
      */
+    public function shouldGenerateReleaseNotes()
+    {
+        $expectedValue = [
+            'name' => 'Release v1.0.0 is now available!',
+            'body' => '##Changes in Release v1.0.0 ... ##Contributors @monalisa',
+        ];
+        $data = ['tag_name' => 'some-tag'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/KnpLabs/php-github-api/releases/generate-notes')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->generateNotes('KnpLabs', 'php-github-api', $data));
+    }
+
+    /**
+     * @test
+     */
     public function shouldCreateRepositoryRelease()
     {
         $expectedValue = ['newReleaseData'];


### PR DESCRIPTION
Adds a method for https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release