### PR TITLE
Add the ability to download raw file, needed when size > 1MB

### DIFF
--- a/lib/Github/Api/Repository/Contents.php
+++ b/lib/Github/Api/Repository/Contents.php
@@ -273,11 +273,9 @@ class Contents extends AbstractApi
      *
      * @return string|null content of file, or null in case of base64_decode failure
      */
-    public function download($username, $repository, $path, $reference = null, $bodyType = null)
+    public function download($username, $repository, $path, $reference = null)
     {
-        $file = $this->show($username, $repository, $path, $reference,[
-            'Accept' => 'application/vnd.github.VERSION.raw'
-        ]);
+        $file = $this->show($username, $repository, $path, $reference);
 
         if (!isset($file['type']) || !in_array($file['type'], ['file', 'symlink'], true)) {
             throw new InvalidArgumentException(sprintf('Path "%s" is not a file or a symlink to a file.', $path));

--- a/lib/Github/Api/Repository/Contents.php
+++ b/lib/Github/Api/Repository/Contents.php
@@ -61,11 +61,11 @@ class Contents extends AbstractApi
      *
      * @link http://developer.github.com/v3/repos/contents/
      *
-     * @param string      $username   the user who owns the repository
-     * @param string      $repository the name of the repository
-     * @param string|null $path       path to file or directory
-     * @param string|null $reference  reference to a branch or commit
-     * @param array  $requestHeaders request headers
+     * @param string      $username       the user who owns the repository
+     * @param string      $repository     the name of the repository
+     * @param string|null $path           path to file or directory
+     * @param string|null $reference      reference to a branch or commit
+     * @param array       $requestHeaders request headers
      *
      * @return array|string information for file | information for each item in directory
      */
@@ -297,7 +297,7 @@ class Contents extends AbstractApi
     }
 
     /**
-     * Get the raw content of a file in a repository
+     * Get the raw content of a file in a repository.
      *
      * Use this method instead of the download method if your file is bigger than 1MB
      *
@@ -310,9 +310,10 @@ class Contents extends AbstractApi
      *
      * @return array|string
      */
-    public function rawDownload($username, $repository, $path, $reference = null) {
+    public function rawDownload($username, $repository, $path, $reference = null)
+    {
         return $this->show($username, $repository, $path, $reference, [
-            'Accept' => 'application/vnd.github.VERSION.raw'
+            'Accept' => 'application/vnd.github.VERSION.raw',
         ]);
     }
 }

--- a/test/Github/Tests/Api/Repository/ContentsTest.php
+++ b/test/Github/Tests/Api/Repository/ContentsTest.php
@@ -336,7 +336,6 @@ class ContentsTest extends TestCase
         $this->assertEquals($getValue, $api->rawDownload('KnpLabs', 'php-github-api', 'test/Github/Tests/Api/Repository/ContentsTest.php'));
     }
 
-
     /**
      * @return string
      */

--- a/test/Github/Tests/Api/Repository/ContentsTest.php
+++ b/test/Github/Tests/Api/Repository/ContentsTest.php
@@ -320,6 +320,24 @@ class ContentsTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function shouldRawDownloadForGivenPath()
+    {
+        // The show() method return
+        $getValue = include __DIR__.'/fixtures/ContentsDownloadFixture.php';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/contents/test%2FGithub%2FTests%2FApi%2FRepository%2FContentsTest.php', ['ref' => null])
+            ->will($this->returnValue($getValue));
+
+        $this->assertEquals($getValue, $api->rawDownload('KnpLabs', 'php-github-api', 'test/Github/Tests/Api/Repository/ContentsTest.php'));
+    }
+
+
+    /**
      * @return string
      */
     protected function getApiClass()


### PR DESCRIPTION
API DOC https://docs.github.com/en/rest/repos/contents

The API call to return the content of a file return an empty content if a file is bigger than 1MB. 
To be able to download that file, we need to provide the header `application/vnd.github.VERSION.raw`. 
When doing so, the API return a the raw file, instead of a JSON object with some attributes + the file content. 

Because the API has a different behavior, I preferred to create a dedicated method as opposed to provide accept more option in the download method and having a bunch of if/else.


Note: a 3rd behavior exists for that API call when downloading markdown and passing the `application/vnd.github.VERSION.html` header, which is not supported by this code change.