### PR TITLE
App: add hook endpoints

### DIFF
--- a/lib/Github/Api/App/Hook.php
+++ b/lib/Github/Api/App/Hook.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Github\Api\App;
+
+use Github\Api\AbstractApi;
+
+class Hook extends AbstractApi
+{
+    /**
+     * Show the app hook configuration.
+     *
+     * @link https://docs.github.com/en/rest/apps/webhooks#get-a-webhook-configuration-for-an-app
+     *
+     * @return array
+     */
+    public function showConfig()
+    {
+        return $this->get('/app/hook/config');
+    }
+
+    /**
+     * Update the hook configuration of an app.
+     *
+     * @link https://docs.github.com/en/rest/apps/webhooks#update-a-webhook-configuration-for-an-app
+     *
+     * @param array $params
+     *
+     * @return array
+     */
+    public function updateConfig(array $params)
+    {
+        return $this->patch('/app/hook/config', $params);
+    }
+
+    /**
+     * List deliveries for an app webhook.
+     *
+     * @link https://docs.github.com/en/rest/apps/webhooks#list-deliveries-for-an-app-webhook
+     *
+     * @return array
+     */
+    public function deliveries()
+    {
+        return $this->get('/app/hook/deliveries');
+    }
+
+    /**
+     * Get a delivery for an app webhook.
+     *
+     * @link https://docs.github.com/en/rest/apps/webhooks#get-a-delivery-for-an-app-webhook
+     *
+     * @param int $delivery
+     *
+     * @return array
+     */
+    public function delivery($delivery)
+    {
+        return $this->get('/app/hook/deliveries/'.$delivery);
+    }
+
+    /**
+     * Redeliver a delivery for an app webhook.
+     *
+     * @link https://docs.github.com/en/rest/apps/webhooks#redeliver-a-delivery-for-an-app-webhook
+     *
+     * @param int $delivery
+     *
+     * @return array
+     */
+    public function redeliver($delivery)
+    {
+        return $this->post('/app/hook/deliveries/'.$delivery.'/attempts');
+    }
+}

--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -2,6 +2,8 @@
 
 namespace Github\Api;
 
+use Github\Api\App\Hook;
+
 /**
  * @link   https://developer.github.com/v3/apps/
  *
@@ -197,5 +199,17 @@ class Apps extends AbstractApi
     public function getAuthenticatedApp()
     {
         return $this->get('/app');
+    }
+
+    /**
+     * Manage the hook of an app.
+     *
+     * @link https://docs.github.com/en/rest/apps/webhooks
+     *
+     * @return Hook
+     */
+    public function hook()
+    {
+        return new Hook($this->getClient());
     }
 }

--- a/test/Github/Tests/Api/App/HookTest.php
+++ b/test/Github/Tests/Api/App/HookTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Github\Api\App;
+
+use Github\Tests\Api\TestCase;
+
+class HookTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldShowHookConfiguration()
+    {
+        $result = [
+            'content_type' => 'json',
+            'insecure_ssl' => 0,
+            'secret' => '********',
+            'url' => 'https://localhost/',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/app/hook/config', [])
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->showConfig());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUpdateHookConfiguration()
+    {
+        $parameters = [
+            'content_type' => 'json',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('patch')
+            ->with('/app/hook/config', $parameters)
+            ->willReturn([]);
+
+        $this->assertEquals([], $api->updateConfig($parameters));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldListHookDelivieries()
+    {
+        $result = [];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/app/hook/deliveries', [])
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->deliveries());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldListHookDeliviery()
+    {
+        $result = [];
+
+        $delivery = 1234567;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/app/hook/deliveries/'.$delivery, [])
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->delivery($delivery));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRedeliveryHook()
+    {
+        $result = [];
+
+        $delivery = 1234567;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/app/hook/deliveries/'.$delivery.'/attempts', [])
+            ->willReturn($result);
+
+        $this->assertEquals($result, $api->redeliver($delivery));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass()
+    {
+        return \Github\Api\App\Hook::class;
+    }
+}


### PR DESCRIPTION
A GitHub app can have a single webhook configured. Add endpoints to manage the hook to the API client https://docs.github.com/en/rest/apps/webhooks