### PR TITLE
Fix user class repository method

### DIFF
--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -159,23 +159,16 @@ class User extends AbstractApi
      *
      * @link https://developer.github.com/v3/repos/#list-user-repositories
      *
-     * @param string $username    the username
-     * @param string $type        role in the repository
-     * @param string $sort        sort by
-     * @param string $direction   direction of sort, asc or desc
-     * @param string $visibility  visibility of repository
-     * @param string $affiliation relationship to repository
-     *
      * @return array list of the user repositories
      */
-    public function repositories($username, $type = 'owner', $sort = 'full_name', $direction = 'asc', $visibility = 'all', $affiliation = 'owner,collaborator,organization_member')
+    public function repositories(string $username, string $type = 'owner', string $sort = 'full_name', string $direction = 'asc', int $perPage = 30, int $page = 1)
     {
         return $this->get('/users/'.rawurlencode($username).'/repos', [
             'type' => $type,
             'sort' => $sort,
             'direction' => $direction,
-            'visibility' => $visibility,
-            'affiliation' => $affiliation,
+            'per_page' => $perPage,
+            'page' => $page,
         ]);
     }
 

--- a/test/Github/Tests/Api/UserTest.php
+++ b/test/Github/Tests/Api/UserTest.php
@@ -191,7 +191,7 @@ class UserTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/users/l3l0/repos', ['type' => 'owner', 'sort' => 'full_name', 'direction' => 'asc', 'visibility' => 'all', 'affiliation' => 'owner,collaborator,organization_member'])
+            ->with('/users/l3l0/repos', ['type' => 'owner', 'sort' => 'full_name', 'direction' => 'asc', 'per_page' => 30, 'page' => 1])
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->repositories('l3l0'));


### PR DESCRIPTION
If I understand correctly, the method for this api
https://docs.github.com/en/rest/repos/repos#list-repositories-for-a-user