### PR TITLE
Add vulnerability alerts endpoints

### DIFF
--- a/doc/repos.md
+++ b/doc/repos.md
@@ -390,3 +390,27 @@ $client->api('repo')->createFromTemplate('template-owner', 'template-repo', [
     'owner' => 'name-of-new-repo-owner', // can be user or org
 ]);
 ```
+
+### Check if vulnerability alerts (dependabot alerts) are enabled for a repository
+
+https://developer.github.com/v3/repos/#check-if-vulnerability-alerts-are-enabled-for-a-repository
+
+```php
+$client->api('repo')->isVulnerabilityAlertsEnabled('KnpLabs', 'php-github-api');
+```
+
+### Enable vulnerability alerts (dependabot alerts)
+
+https://developer.github.com/v3/repos/#enable-vulnerability-alerts
+
+```php
+$client->api('repo')->enableVulnerabilityAlerts('KnpLabs', 'php-github-api');
+```
+
+### Disable vulnerability alerts (dependabot alerts)
+
+https://developer.github.com/v3/repos/#disable-vulnerability-alerts
+
+```php
+$client->api('repo')->disableVulnerabilityAlerts('KnpLabs', 'php-github-api');
+```

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -843,4 +843,49 @@ class Repo extends AbstractApi
 
         return $this->post('/repos/'.rawurldecode($templateOwner).'/'.rawurldecode($templateRepo).'/generate', $parameters);
     }
+
+    /**
+     * Check if vulnerability alerts are enabled for a repository.
+     *
+     * @link https://developer.github.com/v3/repos/#check-if-vulnerability-alerts-are-enabled-for-a-repository
+     *
+     * @param string $username   the username
+     * @param string $repository the repository
+     *
+     * @return array|string
+     */
+    public function isVulnerabilityAlertsEnabled(string $username, string $repository)
+    {
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/vulnerability-alerts');
+    }
+
+    /**
+     * Enable vulnerability alerts for a repository.
+     *
+     * @link https://developer.github.com/v3/repos/#enable-vulnerability-alerts
+     *
+     * @param string $username   the username
+     * @param string $repository the repository
+     *
+     * @return array|string
+     */
+    public function enableVulnerabilityAlerts(string $username, string $repository)
+    {
+        return $this->put('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/vulnerability-alerts');
+    }
+
+    /**
+     * Disable vulnerability alerts for a repository.
+     *
+     * @link https://developer.github.com/v3/repos/#disable-vulnerability-alerts
+     *
+     * @param string $username   the username
+     * @param string $repository the repository
+     *
+     * @return array|string
+     */
+    public function disableVulnerabilityAlerts(string $username, string $repository)
+    {
+        return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/vulnerability-alerts');
+    }
 }

--- a/test/Github/Tests/Api/RepoTest.php
+++ b/test/Github/Tests/Api/RepoTest.php
@@ -722,4 +722,58 @@ class RepoTest extends TestCase
     {
         return \Github\Api\Repo::class;
     }
+
+    /**
+     * @test
+     */
+    public function shouldCheckVulnerabilityAlertsEnabled()
+    {
+        $expectedResponse = '';
+
+        $api = $this->getApiMock();
+
+        $api
+            ->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/vulnerability-alerts')
+            ->will($this->returnValue($expectedResponse));
+
+        $this->assertEquals($expectedResponse, $api->isVulnerabilityAlertsEnabled('KnpLabs', 'php-github-api'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldEnableVulnerabilityAlerts()
+    {
+        $expectedResponse = '';
+
+        $api = $this->getApiMock();
+
+        $api
+            ->expects($this->once())
+            ->method('put')
+            ->with('/repos/KnpLabs/php-github-api/vulnerability-alerts')
+            ->will($this->returnValue($expectedResponse));
+
+        $this->assertEquals($expectedResponse, $api->enableVulnerabilityAlerts('KnpLabs', 'php-github-api'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldDisableVulnerabilityAlerts()
+    {
+        $expectedResponse = '';
+
+        $api = $this->getApiMock();
+
+        $api
+            ->expects($this->once())
+            ->method('delete')
+            ->with('/repos/KnpLabs/php-github-api/vulnerability-alerts')
+            ->will($this->returnValue($expectedResponse));
+
+        $this->assertEquals($expectedResponse, $api->disableVulnerabilityAlerts('KnpLabs', 'php-github-api'));
+    }
 }


### PR DESCRIPTION
Add vulnerability alerts endpoints:

- [x] Check if vulnerability alerts (dependabot alerts) are enabled for a repository (https://developer.github.com/v3/repos/#check-if-vulnerability-alerts-are-enabled-for-a-repository).
- [x] Enable vulnerability alerts (dependabot alerts) for a repository (https://developer.github.com/v3/repos/#enable-vulnerability-alerts).
- [x] Disable vulnerability alerts (dependabot alerts) for a repository (https://developer.github.com/v3/repos/#disable-vulnerability-alerts).
