### PR TITLE
fix: minor bugs and doc update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
     "config": {
         "allow-plugins": {
             "phpstan/extension-installer": true,
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "php-http/discovery": true
         }
     }
 }

--- a/doc/pull_requests.md
+++ b/doc/pull_requests.md
@@ -90,3 +90,11 @@ $pullRequest = $client->api('pull_request')->create('ezsystems', 'ezpublish', ar
 ```
 
 This returns the details of the pull request.
+
+### Merge a Pull Request
+
+> Requires [authentication](security.md)
+
+```php
+$client->api('pull_request')->merge('KnpLabs', 'php-github-api', $pullNumber, $commitMessage, $sha, $mergeMethod, $commitTitle);
+```

--- a/doc/users.md
+++ b/doc/users.md
@@ -188,3 +188,16 @@ $emails = $client->api('current_user')->emails()->remove(array('first@provider.o
 ```
 
 Return an array of the authenticated user emails.
+
+### List repositories for the user
+
+> Requires [authentication](security.md) for authenticated user
+
+```php
+$repos = $client->api('current_user')->repositories();
+$repos = $client->api('users')->repositories();
+```
+
+> Note: Following arguments `$type`, `$sort`, `$direction`, `$visibility` and `$affiliation` are deprecated and a new array argument is added `$parameters` which can be used to pass all these existing arguments as well as parameters like `per_page` which was not supported earlier.
+
+Return an array of the authenticated user repos.

--- a/lib/Github/Api/CurrentUser.php
+++ b/lib/Github/Api/CurrentUser.php
@@ -113,16 +113,30 @@ class CurrentUser extends AbstractApi
     /**
      * @link https://docs.github.com/en/rest/reference/repos#list-repositories-for-the-authenticated-user
      *
-     * @param string $type        role in the repository
-     * @param string $sort        sort by
-     * @param string $direction   direction of sort, asc or desc
-     * @param string $visibility  visibility of repository
-     * @param string $affiliation relationship to repository
+     * @param string $type        role in the repository (Deprecated)
+     * @param string $sort        sort by (Deprecated)
+     * @param string $direction   direction of sort, asc or desc  (Deprecated)
+     * @param string $visibility  visibility of repository  (Deprecated)
+     * @param string $affiliation relationship to repository  (Deprecated)
+     * @param array  $parameters  e.g. [
+     *                            'type' => 'owner',
+     *                            'sort' => 'full_name',
+     *                            'direction'=> 'asc',
+     *                            'visibility' => null,
+     *                            'affiliation' => null,
+     *                            'per_page' => 50,
+     *                            ]
      *
      * @return array
      */
-    public function repositories($type = 'owner', $sort = 'full_name', $direction = 'asc', $visibility = null, $affiliation = null)
-    {
+    public function repositories(
+        $type = 'owner',
+        $sort = 'full_name',
+        $direction = 'asc',
+        $visibility = null,
+        $affiliation = null,
+        array $parameters = []
+    ) {
         $params = [
             'type' => $type,
             'sort' => $sort,
@@ -139,7 +153,7 @@ class CurrentUser extends AbstractApi
             $params['affiliation'] = $affiliation;
         }
 
-        return $this->get('/user/repos', $params);
+        return $this->get('/user/repos', array_merge($params, $parameters));
     }
 
     /**

--- a/lib/Github/Api/User.php
+++ b/lib/Github/Api/User.php
@@ -2,6 +2,7 @@
 
 namespace Github\Api;
 
+
 /**
  * Searching users, getting user information.
  *
@@ -160,23 +161,38 @@ class User extends AbstractApi
      * @link https://developer.github.com/v3/repos/#list-user-repositories
      *
      * @param string $username    the username
-     * @param string $type        role in the repository
-     * @param string $sort        sort by
-     * @param string $direction   direction of sort, asc or desc
-     * @param string $visibility  visibility of repository
-     * @param string $affiliation relationship to repository
+     * @param string $type        role in the repository (Deprecated)
+     * @param string $sort        sort by (Deprecated)
+     * @param string $direction   direction of sort, asc or desc (Deprecated)
+     * @param string $visibility  visibility of repository (Deprecated)
+     * @param string $affiliation relationship to repository (Deprecated)
+     * @param array  $params      e.g. e.g. [
+     *                            'type' => 'owner',
+     *                            'sort' => 'full_name',
+     *                            'direction'=> 'asc',
+     *                            'visibility' => 'all',
+     *                            'affiliation' => 'owner,collaborator,organization_member',
+     *                            'per_page' => 50,
+     *                            ]
      *
      * @return array list of the user repositories
      */
-    public function repositories($username, $type = 'owner', $sort = 'full_name', $direction = 'asc', $visibility = 'all', $affiliation = 'owner,collaborator,organization_member')
-    {
-        return $this->get('/users/'.rawurlencode($username).'/repos', [
+    public function repositories(
+        string $username,
+        $type = 'owner',
+        $sort = 'full_name',
+        $direction = 'asc',
+        $visibility = 'all',
+        $affiliation = 'owner,collaborator,organization_member',
+        array $params = []
+    ) {
+        return $this->get('/users/'.rawurlencode($username).'/repos', array_merge([
             'type' => $type,
             'sort' => $sort,
             'direction' => $direction,
             'visibility' => $visibility,
             'affiliation' => $affiliation,
-        ]);
+        ], $params));
     }
 
     /**

--- a/test/Github/Tests/Api/CurrentUserTest.php
+++ b/test/Github/Tests/Api/CurrentUserTest.php
@@ -2,6 +2,9 @@
 
 namespace Github\Tests\Api;
 
+use Github\Api\CurrentUser;
+use PHPUnit\Framework\MockObject\MockObject;
+
 class CurrentUserTest extends TestCase
 {
     /**
@@ -158,6 +161,32 @@ class CurrentUserTest extends TestCase
         $api = $this->getApiMock();
 
         $this->assertInstanceOf(\Github\Api\CurrentUser\Starring::class, $api->starring());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetRepositories()
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'dummy project'],
+            ['id' => 2, 'name' => 'awesome another project'],
+            ['id' => 3, 'name' => 'fork of php'],
+            ['id' => 4, 'name' => 'fork of php-cs'],
+        ];
+
+        /** @var CurrentUser|MockObject $api */
+        $api = $this->getApiMock();
+
+        $api
+            ->expects($this->once())
+            ->method('get')
+            ->with('/user/repos')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->repositories('owner', 'full_name', 'asc', null, null, [
+            'per_page' => 10,
+        ]));
     }
 
     /**

--- a/test/Github/Tests/Api/UserTest.php
+++ b/test/Github/Tests/Api/UserTest.php
@@ -2,6 +2,9 @@
 
 namespace Github\Tests\Api;
 
+use Github\Api\User;
+use PHPUnit\Framework\MockObject\MockObject;
+
 class UserTest extends TestCase
 {
     /**
@@ -188,13 +191,21 @@ class UserTest extends TestCase
     {
         $expectedArray = [['id' => 1, 'name' => 'l3l0repo']];
 
+        /** @var User|MockObject $api */
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('/users/l3l0/repos', ['type' => 'owner', 'sort' => 'full_name', 'direction' => 'asc', 'visibility' => 'all', 'affiliation' => 'owner,collaborator,organization_member'])
+            ->with('/users/l3l0/repos')
             ->will($this->returnValue($expectedArray));
 
-        $this->assertEquals($expectedArray, $api->repositories('l3l0'));
+        $this->assertEquals($expectedArray, $api->repositories('l3l0', 'owner', 'full_name', '', '', '', [
+            'direction' => 'asc',
+            'visibility' => 'all',
+            'affiliation' => 'owner,collaborator,organization_member',
+            'params' => [
+                'per_page' => 1,
+            ],
+        ]));
     }
 
     /**


### PR DESCRIPTION
Fixes:

- Add array parameter to `repositories` method of **CurrentUser** and **User** Api to pass additional parameters like `per_page` and makes the method future proof if GitHub decides to add more options and deprecate existing arguments in support of this new argument. (Ref: https://github.com/KnpLabs/php-github-api/issues/799#issuecomment-518367905)

Doc:
- Update repositories method in CurrentUser and User doc
- Add PR Merge in doc

Closes #1057, Closes #866, Closes #799 