### PR TITLE
allow psr/http-message v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "psr/cache": "^1.0|^2.0|^3.0",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0|^2.0",
         "symfony/polyfill-php80": "^1.17",
         "symfony/deprecation-contracts": "^2.2|^3.0"
     },
@@ -58,7 +58,8 @@
     "config": {
         "allow-plugins": {
             "phpstan/extension-installer": true,
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "php-http/discovery": true
         }
     }
 }


### PR DESCRIPTION
Modern frameworks like CakePHP 5 [require psr/http-message v2](https://github.com/cakephp/cakephp/blob/5.x/composer.json#L37)