### PR TITLE
Fix detection of secondary rate limit

### DIFF
--- a/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
+++ b/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php
@@ -128,7 +128,7 @@ final class GithubExceptionThrower implements Plugin
             }
 
             $reset = (int) ResponseMediator::getHeader($response, 'X-RateLimit-Reset');
-            if ((403 === $response->getStatusCode()) && 0 < $reset && isset($content['message']) && (0 === strpos($content['message'], 'You have exceeded a secondary rate limit.'))) {
+            if ((403 === $response->getStatusCode()) && 0 < $reset && isset($content['message']) && (0 === strpos($content['message'], 'You have exceeded a secondary rate limit'))) {
                 $limit = (int) ResponseMediator::getHeader($response, 'X-RateLimit-Limit');
 
                 throw new ApiLimitExceedException($limit, $reset);

--- a/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
+++ b/test/Github/Tests/HttpClient/Plugin/GithubExceptionThrowerTest.php
@@ -103,7 +103,7 @@ class GithubExceptionThrowerTest extends TestCase
                     ],
                     json_encode(
                         [
-                            'message' => 'You have exceeded a secondary rate limit. Please wait a few minutes before you try again.',
+                            'message' => 'You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later. If you reach out to GitHub Support for help, please include the request ID #xxxxxxx.',
                         ]
                     )
                 ),


### PR DESCRIPTION
Actual error message is "You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later. If you reach out to GitHub Support for help, please include the request ID [...]"