### PR TITLE
Fix type error in ResultPager::fetch

### DIFF
--- a/lib/Github/ResultPager.php
+++ b/lib/Github/ResultPager.php
@@ -86,7 +86,7 @@ class ResultPager implements ResultPagerInterface
         $api = $closure($api);
         $result = $api->$method(...$parameters);
 
-        if ($result === '' && $this->client->getLastResponse()->getStatusCode() === 204) {
+        if ($result === '') {
             $result = [];
         }
 

--- a/test/Github/Tests/ResultPagerTest.php
+++ b/test/Github/Tests/ResultPagerTest.php
@@ -7,6 +7,7 @@ use Github\Api\Organization\Members;
 use Github\Api\Repo;
 use Github\Api\Repository\Statuses;
 use Github\Api\Search;
+use Github\Api\User;
 use Github\Client;
 use Github\ResultPager;
 use Github\Tests\Mock\PaginatedResponse;
@@ -174,6 +175,29 @@ class ResultPagerTest extends \PHPUnit\Framework\TestCase
             ->method('postFetch');
 
         $this->assertEquals($result, $paginator->fetch($api, $method, $parameters));
+    }
+
+    public function testEmptyFetch()
+    {
+        $parameters = ['username'];
+        $api = $this->getMockBuilder(User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['events'])
+            ->getMock();
+        $api->expects($this->once())
+            ->method('events')
+            ->with(...$parameters)
+            ->willReturn('');
+
+        $paginator = $this->getMockBuilder(ResultPager::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['postFetch'])
+            ->getMock();
+
+        $paginator->expects($this->once())
+            ->method('postFetch');
+
+        $this->assertEquals([], $paginator->fetch($api, 'events', $parameters));
     }
 
     public function testFetchAllPreserveKeys()


### PR DESCRIPTION
When using etags, the reply from github may be empty and the underlying APIs will return an empty string. We need to flip those to empty arrays.
e.g.:
```php
$github_builder
  ->addPlugin(new Http\Client\Common\Plugin\HeaderSetPlugin([
    'If-None-Match' => $etag,
  ]));

$api       = $github_client->user('user');
$paginator = new \Github\ResultPager($github_client);
$data      = $paginator->fetch($api, 'events', [$username]);
// $data should be [] if $etag is the latest
```