### PR TITLE
Handle case of GitHub returning 204 No Content in some scenarios

### DIFF
--- a/lib/Github/ResultPager.php
+++ b/lib/Github/ResultPager.php
@@ -86,6 +86,10 @@ class ResultPager implements ResultPagerInterface
         $api = $closure($api);
         $result = $api->$method(...$parameters);
 
+        if ($result === "" && $this->client->getLastResponse()->getStatusCode() === 204) {
+            $result = [];
+        }
+
         $this->postFetch(true);
 
         return $result;

--- a/lib/Github/ResultPager.php
+++ b/lib/Github/ResultPager.php
@@ -86,7 +86,7 @@ class ResultPager implements ResultPagerInterface
         $api = $closure($api);
         $result = $api->$method(...$parameters);
 
-        if ($result === "" && $this->client->getLastResponse()->getStatusCode() === 204) {
+        if ($result === '' && $this->client->getLastResponse()->getStatusCode() === 204) {
             $result = [];
         }
 

--- a/test/Github/Tests/ResultPagerTest.php
+++ b/test/Github/Tests/ResultPagerTest.php
@@ -187,7 +187,7 @@ class ResultPagerTest extends \PHPUnit\Framework\TestCase
             'sha' => '43068834af7e501778708ed13106de95f782328c',
         ];
 
-        $response = new Response(200, ['Content-Type'=>'application/json'], Utils::streamFor(json_encode($content)));
+        $response = new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor(json_encode($content)));
 
         // httpClient mock
         $httpClientMock = $this->getMockBuilder(HttpClient::class)

--- a/test/Github/Tests/ResultPagerTest.php
+++ b/test/Github/Tests/ResultPagerTest.php
@@ -6,6 +6,7 @@ use Github\Api\Issue;
 use Github\Api\Organization\Members;
 use Github\Api\Repository\Statuses;
 use Github\Api\Search;
+use Github\Api\Repo;
 use Github\Client;
 use Github\ResultPager;
 use Github\Tests\Mock\PaginatedResponse;
@@ -116,6 +117,40 @@ class ResultPagerTest extends \PHPUnit\Framework\TestCase
         $this->assertCount($amountLoops * count($content['items']), $result);
     }
 
+    /**
+     * @test 
+     */
+    public function shouldHandleEmptyContributorListWith204Header()
+    {
+        // Set up a 204 response with an empty body
+        $response = new Response(204, [], '');
+        $username = 'testuser';
+        $reponame = 'testrepo';
+
+        // Mock the HttpClient to return the empty response
+        $httpClientMock = $this->getMockBuilder(HttpClient::class)
+            ->onlyMethods(['sendRequest'])
+            ->getMock();
+        $httpClientMock
+            ->method('sendRequest')
+            ->willReturn($response);
+
+        $client = Client::createWithHttpClient($httpClientMock);
+
+        $repoApi = new Repo($client);
+
+        $paginator = $this->getMockBuilder(ResultPager::class)
+            ->setConstructorArgs([$client]) // Pass the Client in the constructor
+            ->onlyMethods(['fetchAll'])
+            ->getMock();
+        $paginator->expects($this->once())
+            ->method('fetchAll')
+            ->with($repoApi, 'contributors', [$username, $reponame])
+            ->willReturn([]);
+
+        $this->assertEquals([], $paginator->fetchAll($repoApi, 'contributors', [$username, $reponame]));
+    }
+
     public function testFetch()
     {
         $result = ['foo'];
@@ -174,6 +209,34 @@ class ResultPagerTest extends \PHPUnit\Framework\TestCase
     }
 
     public function testFetchAllWithoutKeys()
+    {
+        $content = [
+            ['title' => 'issue 1'],
+            ['title' => 'issue 2'],
+            ['title' => 'issue 3'],
+        ];
+
+        $response = new PaginatedResponse(3, $content);
+
+        // httpClient mock
+        $httpClientMock = $this->getMockBuilder(HttpClient::class)
+            ->onlyMethods(['sendRequest'])
+            ->getMock();
+        $httpClientMock
+            ->expects($this->exactly(3))
+            ->method('sendRequest')
+            ->willReturn($response);
+
+        $client = Client::createWithHttpClient($httpClientMock);
+
+        $api = new Issue($client);
+        $paginator = new ResultPager($client);
+        $result = $paginator->fetchAll($api, 'all', ['knplabs', 'php-github-api']);
+
+        $this->assertCount(9, $result);
+    }
+
+    public function testFetchAll()
     {
         $content = [
             ['title' => 'issue 1'],

--- a/test/Github/Tests/ResultPagerTest.php
+++ b/test/Github/Tests/ResultPagerTest.php
@@ -4,9 +4,9 @@ namespace Github\Tests;
 
 use Github\Api\Issue;
 use Github\Api\Organization\Members;
+use Github\Api\Repo;
 use Github\Api\Repository\Statuses;
 use Github\Api\Search;
-use Github\Api\Repo;
 use Github\Client;
 use Github\ResultPager;
 use Github\Tests\Mock\PaginatedResponse;
@@ -118,7 +118,7 @@ class ResultPagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @test 
+     * @test
      */
     public function shouldHandleEmptyContributorListWith204Header()
     {


### PR DESCRIPTION
ResultPager breaks because no array is returned (it's an empty string) - issue ResultPager::get() can return string #1091