### PR TITLE
Add API to rerequest a check run

### DIFF
--- a/doc/repo/check_runs.md
+++ b/doc/repo/check_runs.md
@@ -62,6 +62,10 @@ $params = [/*...*/];
 $checks = $client->api('repo')->checkRuns()->allForReference('KnpLabs', 'php-github-api', $reference, $params);
 ```
 
+### Rerequest a check run
 
+https://docs.github.com/en/rest/reference/checks#rerequest-a-check-run
 
-
+```php
+$checks = $client->api('repo')->checkRuns()->rerequest('KnpLabs', 'php-github-api', $checkRunId);
+```

--- a/lib/Github/Api/Repository/Checks/CheckRuns.php
+++ b/lib/Github/Api/Repository/Checks/CheckRuns.php
@@ -83,4 +83,14 @@ class CheckRuns extends AbstractApi
 
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($ref).'/check-runs', $params);
     }
+
+    /**
+     * @link https://docs.github.com/en/rest/reference/checks#rerequest-a-check-run
+     *
+     * @return array
+     */
+    public function rerequest(string $username, string $repository, int $checkRunId)
+    {
+        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs/'.$checkRunId.'/rerequest');
+    }
 }

--- a/test/Github/Tests/Api/Repository/Checks/CheckRunsTest.php
+++ b/test/Github/Tests/Api/Repository/Checks/CheckRunsTest.php
@@ -102,6 +102,20 @@ class CheckRunsTest extends TestCase
         $api->allForReference('KnpLabs', 'php-github-api', 'cb4abc15424c0015b4468d73df55efb8b60a4a3d', $params);
     }
 
+    /**
+     * @test
+     */
+    public function shouldRerequestCheckRun()
+    {
+        /** @var CheckRuns|MockObject $api */
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/KnpLabs/php-github-api/check-runs/123/rerequest');
+
+        $api->rerequest('KnpLabs', 'php-github-api', 123);
+    }
+
     protected function getApiClass(): string
     {
         return CheckRuns::class;


### PR DESCRIPTION
This change adds a new method to rerequest a check run (see also https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#rerequest-a-check-run).