### PR TITLE
List pull requests associated with a commit

### DIFF
--- a/doc/commits.md
+++ b/doc/commits.md
@@ -35,3 +35,11 @@ $commit = $client->api('repo')->commits()->compare('KnpLabs', 'php-github-api', 
 ```
 
 Returns an array of commits.
+
+### List pull requests associated with a commit
+
+```php
+$commit = $client->api('repo')->commits()->pulls('KnpLabs', 'php-github-api', '839e5185da9434753db47959bee16642bb4f2ce4');
+```
+
+Returns an array of pull requests.

--- a/lib/Github/Api/Repository/Commits.php
+++ b/lib/Github/Api/Repository/Commits.php
@@ -30,4 +30,9 @@ class Commits extends AbstractApi
     {
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha));
     }
+
+    public function pulls($username, $repository, $sha, array $params = [])
+    {
+        return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($sha).'/pulls', $params);
+    }
 }

--- a/test/Github/Tests/Api/Repository/CommitsTest.php
+++ b/test/Github/Tests/Api/Repository/CommitsTest.php
@@ -56,6 +56,25 @@ class CommitsTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function shouldGetPullRequestsWithSha()
+    {
+        $expectedValue = [
+            ['number' => '1', 'title' => 'My first PR'],
+            ['number' => '2', 'title' => 'Another PR'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/commits/123/pulls')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->pulls('KnpLabs', 'php-github-api', 123));
+    }
+
+    /**
      * @return string
      */
     protected function getApiClass()

--- a/test/Github/Tests/Api/Repository/CommitsTest.php
+++ b/test/Github/Tests/Api/Repository/CommitsTest.php
@@ -58,7 +58,7 @@ class CommitsTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetPullRequestsWithSha()
+    public function shouldGetAllPullRequestsUsingSha()
     {
         $expectedValue = [
             ['number' => '1', 'title' => 'My first PR'],


### PR DESCRIPTION
Added missing `pulls` method to repository commits to allow fetching of pull requests for a commit sha.

[List pull requests associated with a commit](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-pull-requests-associated-with-a-commit)