### PR TITLE
Pull requests Merge SHA property is optional

### DIFF
--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -182,7 +182,7 @@ class PullRequest extends AbstractApi
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/'.rawurlencode($id).'/merge');
     }
 
-    public function merge($username, $repository, $id, $message, $sha, $mergeMethod = 'merge', $title = null)
+    public function merge($username, $repository, $id, $message, $sha = null, $mergeMethod = 'merge', $title = null)
     {
         if (is_bool($mergeMethod)) {
             $mergeMethod = $mergeMethod ? 'squash' : 'merge';
@@ -194,10 +194,12 @@ class PullRequest extends AbstractApi
 
         $params = [
             'commit_message' => $message,
-            'sha' => $sha,
             'merge_method' => $mergeMethod,
         ];
 
+        if (is_string($sha)) {
+            $params['sha'] = $sha;
+        }
         if (is_string($title)) {
             $params['commit_title'] = $title;
         }


### PR DESCRIPTION
[Merge a pull request API](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#merge-a-pull-request) endpoint accepts `sha` property, but it's optional. This PR makes the `$sha` property optional without introducing breaking changes