### PR TITLE
Cleanup the accept HTTP header as GitHub no longer versions this

### DIFF
--- a/lib/Github/Api/Apps.php
+++ b/lib/Github/Api/Apps.php
@@ -11,13 +11,6 @@ use Github\Api\App\Hook;
  */
 class Apps extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
-    private function configurePreviewHeader()
-    {
-        $this->acceptHeaderValue = 'application/vnd.github.machine-man-preview+json';
-    }
-
     /**
      * Create an access token for an installation.
      *
@@ -36,8 +29,6 @@ class Apps extends AbstractApi
             $parameters['user_id'] = $userId;
         }
 
-        $this->configurePreviewHeader();
-
         return $this->post('/app/installations/'.$installationId.'/access_tokens', $parameters);
     }
 
@@ -50,8 +41,6 @@ class Apps extends AbstractApi
      */
     public function findInstallations()
     {
-        $this->configurePreviewHeader();
-
         return $this->get('/app/installations');
     }
 
@@ -66,8 +55,6 @@ class Apps extends AbstractApi
      */
     public function getInstallation($installationId)
     {
-        $this->configurePreviewHeader();
-
         return $this->get('/app/installations/'.$installationId);
     }
 
@@ -82,8 +69,6 @@ class Apps extends AbstractApi
      */
     public function getInstallationForOrganization($org)
     {
-        $this->configurePreviewHeader();
-
         return $this->get('/orgs/'.rawurldecode($org).'/installation');
     }
 
@@ -99,8 +84,6 @@ class Apps extends AbstractApi
      */
     public function getInstallationForRepo($owner, $repo)
     {
-        $this->configurePreviewHeader();
-
         return $this->get('/repos/'.rawurldecode($owner).'/'.rawurldecode($repo).'/installation');
     }
 
@@ -115,8 +98,6 @@ class Apps extends AbstractApi
      */
     public function getInstallationForUser($username)
     {
-        $this->configurePreviewHeader();
-
         return $this->get('/users/'.rawurldecode($username).'/installation');
     }
 
@@ -129,8 +110,6 @@ class Apps extends AbstractApi
      */
     public function removeInstallation($installationId)
     {
-        $this->configurePreviewHeader();
-
         $this->delete('/app/installations/'.$installationId);
     }
 
@@ -150,8 +129,6 @@ class Apps extends AbstractApi
             $parameters['user_id'] = $userId;
         }
 
-        $this->configurePreviewHeader();
-
         return $this->get('/installation/repositories', $parameters);
     }
 
@@ -167,8 +144,6 @@ class Apps extends AbstractApi
      */
     public function addRepository($installationId, $repositoryId)
     {
-        $this->configurePreviewHeader();
-
         return $this->put('/installations/'.$installationId.'/repositories/'.$repositoryId);
     }
 
@@ -184,8 +159,6 @@ class Apps extends AbstractApi
      */
     public function removeRepository($installationId, $repositoryId)
     {
-        $this->configurePreviewHeader();
-
         return $this->delete('/installations/'.$installationId.'/repositories/'.$repositoryId);
     }
 

--- a/lib/Github/Api/CurrentUser.php
+++ b/lib/Github/Api/CurrentUser.php
@@ -18,8 +18,6 @@ use Github\Api\CurrentUser\Watchers;
  */
 class CurrentUser extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
     public function show()
     {
         return $this->get('/user');
@@ -173,8 +171,6 @@ class CurrentUser extends AbstractApi
      */
     public function installations(array $params = [])
     {
-        $this->acceptHeaderValue = 'application/vnd.github.machine-man-preview+json';
-
         return $this->get('/user/installations', array_merge(['page' => 1], $params));
     }
 
@@ -186,8 +182,6 @@ class CurrentUser extends AbstractApi
      */
     public function repositoriesByInstallation($installationId, array $params = [])
     {
-        $this->acceptHeaderValue = 'application/vnd.github.machine-man-preview+json';
-
         return $this->get(sprintf('/user/installations/%s/repositories', $installationId), array_merge(['page' => 1], $params));
     }
 }

--- a/lib/Github/Api/CurrentUser/Starring.php
+++ b/lib/Github/Api/CurrentUser/Starring.php
@@ -26,7 +26,7 @@ class Starring extends AbstractApi
     public function configure($bodyType = null)
     {
         if ('star' === $bodyType) {
-            $this->acceptHeaderValue = sprintf('application/vnd.github.%s.star+json', $this->getApiVersion());
+            $this->acceptHeaderValue = 'application/vnd.github.star+json';
         }
 
         return $this;

--- a/lib/Github/Api/Deployment.php
+++ b/lib/Github/Api/Deployment.php
@@ -13,8 +13,6 @@ use Github\Exception\MissingArgumentException;
  */
 class Deployment extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
     /**
      * List deployments for a particular repository.
      *
@@ -105,15 +103,6 @@ class Deployment extends AbstractApi
     {
         if (!isset($params['state'])) {
             throw new MissingArgumentException(['state']);
-        }
-
-        // adjust media-type per github docs
-        // https://docs.github.com/en/rest/reference/repos#create-a-deployment-status
-        if ($params['state'] === 'inactive') {
-            $this->acceptHeaderValue = 'application/vnd.github.ant-man-preview+json';
-        }
-        if ($params['state'] === 'in_progress' || $params['state'] === 'queued') {
-            $this->acceptHeaderValue = 'application/vnd.github.flash-preview+json';
         }
 
         return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments/'.$id.'/statuses', $params);

--- a/lib/Github/Api/Gist/Comments.php
+++ b/lib/Github/Api/Gist/Comments.php
@@ -29,7 +29,7 @@ class Comments extends AbstractApi
             $bodyType = 'raw';
         }
 
-        $this->acceptHeaderValue = sprintf('application/vnd.github.%s.%s+json', $this->getApiVersion(), $bodyType);
+        $this->acceptHeaderValue = sprintf('application/vnd.github.%s+json', $bodyType);
 
         return $this;
     }

--- a/lib/Github/Api/Gists.php
+++ b/lib/Github/Api/Gists.php
@@ -32,7 +32,7 @@ class Gists extends AbstractApi
             $bodyType = 'raw';
         }
 
-        $this->acceptHeaderValue = sprintf('application/vnd.github.%s.%s', $this->getApiVersion(), $bodyType);
+        $this->acceptHeaderValue = sprintf('application/vnd.github.%s', $bodyType);
 
         return $this;
     }

--- a/lib/Github/Api/GitData/Blobs.php
+++ b/lib/Github/Api/GitData/Blobs.php
@@ -26,7 +26,7 @@ class Blobs extends AbstractApi
     public function configure($bodyType = null)
     {
         if ('raw' === $bodyType) {
-            $this->acceptHeaderValue = sprintf('application/vnd.github.%s.raw', $this->getApiVersion());
+            $this->acceptHeaderValue = 'application/vnd.github.raw';
         }
 
         return $this;

--- a/lib/Github/Api/GraphQL.php
+++ b/lib/Github/Api/GraphQL.php
@@ -22,7 +22,7 @@ class GraphQL extends AbstractApi
      *
      * @return array
      */
-    public function execute($query, array $variables = [], string $acceptHeaderValue = 'application/vnd.github.v4+json')
+    public function execute($query, array $variables = [], string $acceptHeaderValue = 'application/vnd.github+json')
     {
         $this->acceptHeaderValue = $acceptHeaderValue;
         $params = [

--- a/lib/Github/Api/Issue.php
+++ b/lib/Github/Api/Issue.php
@@ -37,7 +37,7 @@ class Issue extends AbstractApi
             $bodyType = 'raw';
         }
 
-        $this->acceptHeaderValue = sprintf('application/vnd.github.%s.%s+json', $this->getApiVersion(), $bodyType);
+        $this->acceptHeaderValue = sprintf('application/vnd.github.%s+json', $bodyType);
 
         return $this;
     }

--- a/lib/Github/Api/Issue/Comments.php
+++ b/lib/Github/Api/Issue/Comments.php
@@ -31,7 +31,7 @@ class Comments extends AbstractApi
             $bodyType = 'full';
         }
 
-        $this->acceptHeaderValue = sprintf('application/vnd.github.%s.%s+json', $this->getApiVersion(), $bodyType);
+        $this->acceptHeaderValue = sprintf('application/vnd.github.%s+json', $bodyType);
 
         return $this;
     }

--- a/lib/Github/Api/Issue/Timeline.php
+++ b/lib/Github/Api/Issue/Timeline.php
@@ -3,19 +3,9 @@
 namespace Github\Api\Issue;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 
 class Timeline extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
-    public function configure()
-    {
-        $this->acceptHeaderValue = 'application/vnd.github.mockingbird-preview';
-
-        return $this;
-    }
-
     /**
      * Get all events for a specific issue.
      *

--- a/lib/Github/Api/Miscellaneous/CodeOfConduct.php
+++ b/lib/Github/Api/Miscellaneous/CodeOfConduct.php
@@ -3,19 +3,9 @@
 namespace Github\Api\Miscellaneous;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 
 class CodeOfConduct extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
-    public function configure()
-    {
-        $this->acceptHeaderValue = 'application/vnd.github.scarlet-witch-preview+json';
-
-        return $this;
-    }
-
     /**
      * List all codes of conduct.
      *

--- a/lib/Github/Api/Project/AbstractProjectApi.php
+++ b/lib/Github/Api/Project/AbstractProjectApi.php
@@ -3,26 +3,9 @@
 namespace Github\Api\Project;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 
 abstract class AbstractProjectApi extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
-    /**
-     * Configure the accept header for Early Access to the projects api.
-     *
-     * @see https://developer.github.com/v3/repos/projects/#projects
-     *
-     * @return $this
-     */
-    public function configure()
-    {
-        $this->acceptHeaderValue = 'application/vnd.github.inertia-preview+json';
-
-        return $this;
-    }
-
     public function show($id, array $params = [])
     {
         return $this->get('/projects/'.rawurlencode($id), array_merge(['page' => 1], $params));

--- a/lib/Github/Api/Project/Cards.php
+++ b/lib/Github/Api/Project/Cards.php
@@ -3,27 +3,10 @@
 namespace Github\Api\Project;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 use Github\Exception\MissingArgumentException;
 
 class Cards extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
-    /**
-     * Configure the accept header for Early Access to the projects api.
-     *
-     * @see https://developer.github.com/v3/repos/projects/#projects
-     *
-     * @return $this
-     */
-    public function configure()
-    {
-        $this->acceptHeaderValue = 'application/vnd.github.inertia-preview+json';
-
-        return $this;
-    }
-
     public function all($columnId, array $params = [])
     {
         return $this->get('/projects/columns/'.rawurlencode($columnId).'/cards', array_merge(['page' => 1], $params));

--- a/lib/Github/Api/Project/Columns.php
+++ b/lib/Github/Api/Project/Columns.php
@@ -3,27 +3,10 @@
 namespace Github\Api\Project;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 use Github\Exception\MissingArgumentException;
 
 class Columns extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
-    /**
-     * Configure the accept header for Early Access to the projects api.
-     *
-     * @see https://developer.github.com/v3/repos/projects/#projects
-     *
-     * return self
-     */
-    public function configure()
-    {
-        $this->acceptHeaderValue = 'application/vnd.github.inertia-preview+json';
-
-        return $this;
-    }
-
     public function all($projectId, array $params = [])
     {
         return $this->get('/projects/'.rawurlencode($projectId).'/columns', array_merge(['page' => 1], $params));

--- a/lib/Github/Api/PullRequest.php
+++ b/lib/Github/Api/PullRequest.php
@@ -31,10 +31,6 @@ class PullRequest extends AbstractApi
      */
     public function configure($bodyType = null, $apiVersion = null)
     {
-        if (null === $apiVersion) {
-            $apiVersion = $this->getApiVersion();
-        }
-
         if (!in_array($bodyType, ['text', 'html', 'full', 'diff', 'patch'])) {
             $bodyType = 'raw';
         }
@@ -43,7 +39,7 @@ class PullRequest extends AbstractApi
             $bodyType .= '+json';
         }
 
-        $this->acceptHeaderValue = sprintf('application/vnd.github.%s.%s', $apiVersion, $bodyType);
+        $this->acceptHeaderValue = sprintf('application/vnd.github.%s', $bodyType);
 
         return $this;
     }

--- a/lib/Github/Api/PullRequest/Comments.php
+++ b/lib/Github/Api/PullRequest/Comments.php
@@ -35,7 +35,7 @@ class Comments extends AbstractApi
             $bodyType = 'raw';
         }
 
-        $this->acceptHeaderValue = sprintf('application/vnd.github.%s.%s+json', $apiVersion, $bodyType);
+        $this->acceptHeaderValue = sprintf('application/vnd.github.%s+json', $bodyType);
 
         return $this;
     }

--- a/lib/Github/Api/PullRequest/Review.php
+++ b/lib/Github/Api/PullRequest/Review.php
@@ -3,7 +3,6 @@
 namespace Github\Api\PullRequest;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 use Github\Exception\InvalidArgumentException;
 use Github\Exception\MissingArgumentException;
 
@@ -16,15 +15,6 @@ use Github\Exception\MissingArgumentException;
  */
 class Review extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
-    public function configure()
-    {
-        trigger_deprecation('KnpLabs/php-github-api', '3.2', 'The "%s" is deprecated and will be removed.', __METHOD__);
-
-        return $this;
-    }
-
     /**
      * Get a listing of a pull request's reviews by the username, repository and pull request number.
      *

--- a/lib/Github/Api/PullRequest/ReviewRequest.php
+++ b/lib/Github/Api/PullRequest/ReviewRequest.php
@@ -3,22 +3,12 @@
 namespace Github\Api\PullRequest;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 
 /**
  * @link https://developer.github.com/v3/pulls/review_requests/
  */
 class ReviewRequest extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
-    public function configure()
-    {
-        trigger_deprecation('KnpLabs/php-github-api', '3.2', 'The "%s" is deprecated and will be removed.', __METHOD__);
-
-        return $this;
-    }
-
     /**
      * @link https://developer.github.com/v3/pulls/review_requests/#list-review-requests
      *

--- a/lib/Github/Api/Repo.php
+++ b/lib/Github/Api/Repo.php
@@ -40,8 +40,6 @@ use Github\Api\Repository\Traffic;
  */
 class Repo extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
     /**
      * List all public repositories.
      *
@@ -700,8 +698,6 @@ class Repo extends AbstractApi
      */
     public function enableAutomatedSecurityFixes(string $username, string $repository)
     {
-        $this->acceptHeaderValue = 'application/vnd.github.london-preview+json';
-
         return $this->put('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/automated-security-fixes');
     }
 
@@ -715,8 +711,6 @@ class Repo extends AbstractApi
      */
     public function disableAutomatedSecurityFixes(string $username, string $repository)
     {
-        $this->acceptHeaderValue = 'application/vnd.github.london-preview+json';
-
         return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/automated-security-fixes');
     }
 
@@ -761,9 +755,6 @@ class Repo extends AbstractApi
      */
     public function communityProfile($username, $repository)
     {
-        //This api is in preview mode, so set the correct accept-header
-        $this->acceptHeaderValue = 'application/vnd.github.black-panther-preview+json';
-
         return $this->get('/repos/'.rawurldecode($username).'/'.rawurldecode($repository).'/community/profile');
     }
 
@@ -779,9 +770,6 @@ class Repo extends AbstractApi
      */
     public function codeOfConduct($username, $repository)
     {
-        //This api is in preview mode, so set the correct accept-header
-        $this->acceptHeaderValue = 'application/vnd.github.scarlet-witch-preview+json';
-
         return $this->get('/repos/'.rawurldecode($username).'/'.rawurldecode($repository).'/community/code_of_conduct');
     }
 
@@ -797,9 +785,6 @@ class Repo extends AbstractApi
      */
     public function topics($username, $repository)
     {
-        //This api is in preview mode, so set the correct accept-header
-        $this->acceptHeaderValue = 'application/vnd.github.mercy-preview+json';
-
         return $this->get('/repos/'.rawurldecode($username).'/'.rawurldecode($repository).'/topics');
     }
 
@@ -816,9 +801,6 @@ class Repo extends AbstractApi
      */
     public function replaceTopics($username, $repository, array $topics)
     {
-        //This api is in preview mode, so set the correct accept-header
-        $this->acceptHeaderValue = 'application/vnd.github.mercy-preview+json';
-
         return $this->put('/repos/'.rawurldecode($username).'/'.rawurldecode($repository).'/topics', ['names' => $topics]);
     }
 
@@ -848,9 +830,6 @@ class Repo extends AbstractApi
      */
     public function createFromTemplate(string $templateOwner, string $templateRepo, array $parameters = [])
     {
-        //This api is in preview mode, so set the correct accept-header
-        $this->acceptHeaderValue = 'application/vnd.github.baptiste-preview+json';
-
         return $this->post('/repos/'.rawurldecode($templateOwner).'/'.rawurldecode($templateRepo).'/generate', $parameters);
     }
 

--- a/lib/Github/Api/Repository/Checks/CheckRuns.php
+++ b/lib/Github/Api/Repository/Checks/CheckRuns.php
@@ -3,15 +3,12 @@
 namespace Github\Api\Repository\Checks;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 
 /**
  * @link https://docs.github.com/en/rest/reference/checks
  */
 class CheckRuns extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
     /**
      * @link https://docs.github.com/en/rest/reference/checks#create-a-check-run
      *
@@ -19,8 +16,6 @@ class CheckRuns extends AbstractApi
      */
     public function create(string $username, string $repository, array $params = [])
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs', $params);
     }
 
@@ -31,8 +26,6 @@ class CheckRuns extends AbstractApi
      */
     public function show(string $username, string $repository, int $checkRunId)
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs/'.$checkRunId);
     }
 
@@ -43,8 +36,6 @@ class CheckRuns extends AbstractApi
      */
     public function update(string $username, string $repository, int $checkRunId, array $params = [])
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs/'.$checkRunId, $params);
     }
 
@@ -55,8 +46,6 @@ class CheckRuns extends AbstractApi
      */
     public function annotations(string $username, string $repository, int $checkRunId)
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs/'.$checkRunId.'/annotations');
     }
 
@@ -67,8 +56,6 @@ class CheckRuns extends AbstractApi
      */
     public function allForCheckSuite(string $username, string $repository, int $checkSuiteId, array $params = [])
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-suites/'.$checkSuiteId.'/check-runs', $params);
     }
 
@@ -79,8 +66,6 @@ class CheckRuns extends AbstractApi
      */
     public function allForReference(string $username, string $repository, string $ref, array $params = [])
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($ref).'/check-runs', $params);
     }
 

--- a/lib/Github/Api/Repository/Checks/CheckSuites.php
+++ b/lib/Github/Api/Repository/Checks/CheckSuites.php
@@ -3,15 +3,12 @@
 namespace Github\Api\Repository\Checks;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 
 /**
  * @link https://docs.github.com/en/rest/reference/checks
  */
 class CheckSuites extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
     /**
      * @link https://docs.github.com/en/rest/reference/checks#create-a-check-suite
      *
@@ -19,8 +16,6 @@ class CheckSuites extends AbstractApi
      */
     public function create(string $username, string $repository, array $params = [])
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-suites', $params);
     }
 
@@ -31,8 +26,6 @@ class CheckSuites extends AbstractApi
      */
     public function updatePreferences(string $username, string $repository, array $params = [])
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-suites/preferences', $params);
     }
 
@@ -43,8 +36,6 @@ class CheckSuites extends AbstractApi
      */
     public function getCheckSuite(string $username, string $repository, int $checkSuiteId)
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-suites/'.$checkSuiteId);
     }
 
@@ -55,8 +46,6 @@ class CheckSuites extends AbstractApi
      */
     public function rerequest(string $username, string $repository, int $checkSuiteId)
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-suites/'.$checkSuiteId.'/rerequest');
     }
 
@@ -67,8 +56,6 @@ class CheckSuites extends AbstractApi
      */
     public function allForReference(string $username, string $repository, string $ref, array $params = [])
     {
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/commits/'.rawurlencode($ref).'/check-suites', $params);
     }
 }

--- a/lib/Github/Api/Repository/Comments.php
+++ b/lib/Github/Api/Repository/Comments.php
@@ -31,7 +31,7 @@ class Comments extends AbstractApi
             $bodyType = 'full';
         }
 
-        $this->acceptHeaderValue = sprintf('application/vnd.github.%s.%s+json', $this->getApiVersion(), $bodyType);
+        $this->acceptHeaderValue = sprintf('application/vnd.github.%s+json', $bodyType);
 
         return $this;
     }

--- a/lib/Github/Api/Repository/Contents.php
+++ b/lib/Github/Api/Repository/Contents.php
@@ -33,7 +33,7 @@ class Contents extends AbstractApi
             $bodyType = 'raw';
         }
 
-        $this->acceptHeaderValue = sprintf('application/vnd.github.%s.%s', $this->getApiVersion(), $bodyType);
+        $this->acceptHeaderValue = sprintf('application/vnd.github.%s+json', $bodyType);
 
         return $this;
     }

--- a/lib/Github/Api/Repository/Pages.php
+++ b/lib/Github/Api/Repository/Pages.php
@@ -3,7 +3,6 @@
 namespace Github\Api\Repository;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 
 /**
  * @link   https://developer.github.com/v3/repos/pages/
@@ -12,8 +11,6 @@ use Github\Api\AcceptHeaderTrait;
  */
 class Pages extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
     public function show($username, $repository)
     {
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pages');
@@ -21,15 +18,11 @@ class Pages extends AbstractApi
 
     public function enable($username, $repository, array $params = [])
     {
-        $this->acceptHeaderValue = 'application/vnd.github.switcheroo-preview+json';
-
         return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pages', $params);
     }
 
     public function disable($username, $repository)
     {
-        $this->acceptHeaderValue = 'application/vnd.github.switcheroo-preview+json';
-
         return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pages');
     }
 

--- a/lib/Github/Api/Repository/Protection.php
+++ b/lib/Github/Api/Repository/Protection.php
@@ -3,7 +3,6 @@
 namespace Github\Api\Repository;
 
 use Github\Api\AbstractApi;
-use Github\Api\AcceptHeaderTrait;
 
 /**
  * @link   https://developer.github.com/v3/repos/branches/
@@ -12,8 +11,6 @@ use Github\Api\AcceptHeaderTrait;
  */
 class Protection extends AbstractApi
 {
-    use AcceptHeaderTrait;
-
     /**
      * Retrieves configured protection for the provided branch.
      *
@@ -27,9 +24,6 @@ class Protection extends AbstractApi
      */
     public function show($username, $repository, $branch)
     {
-        // Preview endpoint
-        $this->acceptHeaderValue = 'application/vnd.github.luke-cage-preview+json';
-
         return $this->get('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/branches/'.rawurlencode($branch).'/protection');
     }
 
@@ -47,9 +41,6 @@ class Protection extends AbstractApi
      */
     public function update($username, $repository, $branch, array $params = [])
     {
-        // Preview endpoint
-        $this->acceptHeaderValue = 'application/vnd.github.luke-cage-preview+json';
-
         return $this->put('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/branches/'.rawurlencode($branch).'/protection', $params);
     }
 

--- a/lib/Github/Api/Repository/Stargazers.php
+++ b/lib/Github/Api/Repository/Stargazers.php
@@ -27,7 +27,7 @@ class Stargazers extends AbstractApi
     public function configure($bodyType = null)
     {
         if ('star' === $bodyType) {
-            $this->acceptHeaderValue = sprintf('application/vnd.github.%s.star+json', $this->getApiVersion());
+            $this->acceptHeaderValue = 'application/vnd.github.star+json';
         }
 
         return $this;

--- a/lib/Github/Api/Search.php
+++ b/lib/Github/Api/Search.php
@@ -71,7 +71,7 @@ class Search extends AbstractApi
      */
     public function codeWithMatch(string $q, string $sort = 'updated', string $order = 'desc'): array
     {
-        $this->acceptHeaderValue = 'application/vnd.github.v3.text-match+json';
+        $this->acceptHeaderValue = 'application/vnd.github.text-match+json';
 
         return $this->code($q, $sort, $order);
     }
@@ -105,9 +105,6 @@ class Search extends AbstractApi
      */
     public function commits($q, $sort = null, $order = 'desc')
     {
-        // This api is in preview mode, so set the correct accept-header
-        $this->acceptHeaderValue = 'application/vnd.github.cloak-preview';
-
         return $this->get('/search/commits', ['q' => $q, 'sort' => $sort, 'order' => $order]);
     }
 
@@ -122,9 +119,6 @@ class Search extends AbstractApi
      */
     public function topics($q)
     {
-        // This api is in preview mode, so set the correct accept-header
-        $this->acceptHeaderValue = 'application/vnd.github.mercy-preview+json';
-
         return $this->get('/search/topics', ['q' => $q]);
     }
 }

--- a/lib/Github/Client.php
+++ b/lib/Github/Client.php
@@ -135,7 +135,7 @@ class Client
         $builder->addPlugin(new Plugin\AddHostPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.github.com')));
         $builder->addPlugin(new Plugin\HeaderDefaultsPlugin([
             'User-Agent' => 'php-github-api (http://github.com/KnpLabs/php-github-api)',
-            'Accept' => sprintf('application/vnd.github.%s+json', $this->apiVersion),
+            'Accept' => 'application/vnd.github+json',
         ]));
 
         if ($enterpriseUrl) {


### PR DESCRIPTION
See this: https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#media-types

GitHub not longer versions the accept header. It uses this instead: https://docs.github.com/en/rest/about-the-rest-api/api-versions?apiVersion=2022-11-28
But since GitHub is only exposing a single API right now, there's no need for versioning. Plus, all the exported functions are available and are not in preview anymore.