### PR TITLE
feat: add reactions support

### DIFF
--- a/lib/Github/Api/AbstractReactionsApi.php
+++ b/lib/Github/Api/AbstractReactionsApi.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Github\Api;
+
+use Github\Exception\MissingArgumentException;
+
+abstract class AbstractReactionsApi extends AbstractApi
+{
+    /**
+     * List reactions for a resource.
+     *
+     * @param string $username
+     * @param string $repository
+     * @param string $id
+     * @param array  $params
+     *
+     * @return array
+     */
+    public function all($username, $repository, $id, array $params = [])
+    {
+        return $this->get($this->getReactionsPath($username, $repository, $id), $params);
+    }
+
+    /**
+     * Create a reaction for a resource.
+     *
+     * @param string $username
+     * @param string $repository
+     * @param string $id
+     * @param array  $params
+     *
+     * @throws MissingArgumentException
+     *
+     * @return array
+     */
+    public function create($username, $repository, $id, array $params)
+    {
+        if (!isset($params['content'])) {
+            throw new MissingArgumentException('content');
+        }
+
+        return $this->post($this->getReactionsPath($username, $repository, $id), $params);
+    }
+
+    /**
+     * Delete a reaction from a resource.
+     *
+     * @param string $username
+     * @param string $repository
+     * @param string $id
+     * @param string $reaction
+     *
+     * @return array|string
+     */
+    public function remove($username, $repository, $id, $reaction)
+    {
+        return $this->delete($this->getReactionsPath($username, $repository, $id).'/'.rawurlencode($reaction));
+    }
+
+    /**
+     * @param string $username
+     * @param string $repository
+     * @param string $id
+     *
+     * @return string
+     */
+    abstract protected function getReactionsPath($username, $repository, $id);
+}

--- a/lib/Github/Api/Issue.php
+++ b/lib/Github/Api/Issue.php
@@ -7,6 +7,7 @@ use Github\Api\Issue\Comments;
 use Github\Api\Issue\Events;
 use Github\Api\Issue\Labels;
 use Github\Api\Issue\Milestones;
+use Github\Api\Issue\Reactions;
 use Github\Api\Issue\Timeline;
 use Github\Exception\MissingArgumentException;
 
@@ -177,6 +178,18 @@ class Issue extends AbstractApi
     public function comments()
     {
         return new Comments($this->getClient());
+    }
+
+    /**
+     * Manage issue reactions.
+     *
+     * @link https://docs.github.com/en/rest/reactions/reactions#list-reactions-for-an-issue
+     *
+     * @return Reactions
+     */
+    public function reactions()
+    {
+        return new Reactions($this->getClient());
     }
 
     /**

--- a/lib/Github/Api/Issue/Comments.php
+++ b/lib/Github/Api/Issue/Comments.php
@@ -4,6 +4,7 @@ namespace Github\Api\Issue;
 
 use Github\Api\AbstractApi;
 use Github\Api\AcceptHeaderTrait;
+use Github\Api\Issue\Comments\Reactions;
 use Github\Exception\MissingArgumentException;
 
 /**
@@ -129,5 +130,17 @@ class Comments extends AbstractApi
     public function remove($username, $repository, $comment)
     {
         return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/comments/'.$comment);
+    }
+
+    /**
+     * Manage issue comment reactions.
+     *
+     * @link https://docs.github.com/en/rest/reactions/reactions#list-reactions-for-an-issue-comment
+     *
+     * @return Reactions
+     */
+    public function reactions()
+    {
+        return new Reactions($this->getClient());
     }
 }

--- a/lib/Github/Api/Issue/Comments/Reactions.php
+++ b/lib/Github/Api/Issue/Comments/Reactions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Github\Api\Issue\Comments;
+
+use Github\Api\AbstractReactionsApi;
+
+class Reactions extends AbstractReactionsApi
+{
+    /**
+     * @param string $username
+     * @param string $repository
+     * @param string $id
+     *
+     * @return string
+     */
+    protected function getReactionsPath($username, $repository, $id)
+    {
+        return '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/comments/'.rawurlencode($id).'/reactions';
+    }
+}

--- a/lib/Github/Api/Issue/Reactions.php
+++ b/lib/Github/Api/Issue/Reactions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Github\Api\Issue;
+
+use Github\Api\AbstractReactionsApi;
+
+class Reactions extends AbstractReactionsApi
+{
+    /**
+     * @param string $username
+     * @param string $repository
+     * @param string $id
+     *
+     * @return string
+     */
+    protected function getReactionsPath($username, $repository, $id)
+    {
+        return '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/issues/'.rawurlencode($id).'/reactions';
+    }
+}

--- a/lib/Github/Api/PullRequest/Comments.php
+++ b/lib/Github/Api/PullRequest/Comments.php
@@ -4,6 +4,7 @@ namespace Github\Api\PullRequest;
 
 use Github\Api\AbstractApi;
 use Github\Api\AcceptHeaderTrait;
+use Github\Api\PullRequest\Comments\Reactions;
 use Github\Exception\MissingArgumentException;
 
 /**
@@ -149,5 +150,17 @@ class Comments extends AbstractApi
     public function remove($username, $repository, $comment)
     {
         return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/comments/'.$comment);
+    }
+
+    /**
+     * Manage pull request review comment reactions.
+     *
+     * @link https://docs.github.com/en/rest/reactions/reactions#list-reactions-for-a-pull-request-review-comment
+     *
+     * @return Reactions
+     */
+    public function reactions()
+    {
+        return new Reactions($this->getClient());
     }
 }

--- a/lib/Github/Api/PullRequest/Comments/Reactions.php
+++ b/lib/Github/Api/PullRequest/Comments/Reactions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Github\Api\PullRequest\Comments;
+
+use Github\Api\AbstractReactionsApi;
+
+class Reactions extends AbstractReactionsApi
+{
+    /**
+     * @param string $username
+     * @param string $repository
+     * @param string $id
+     *
+     * @return string
+     */
+    protected function getReactionsPath($username, $repository, $id)
+    {
+        return '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/pulls/comments/'.rawurlencode($id).'/reactions';
+    }
+}

--- a/lib/Github/Api/Repository/Comments.php
+++ b/lib/Github/Api/Repository/Comments.php
@@ -4,6 +4,7 @@ namespace Github\Api\Repository;
 
 use Github\Api\AbstractApi;
 use Github\Api\AcceptHeaderTrait;
+use Github\Api\Repository\Comments\Reactions;
 use Github\Exception\MissingArgumentException;
 
 /**
@@ -71,5 +72,17 @@ class Comments extends AbstractApi
     public function remove($username, $repository, $comment)
     {
         return $this->delete('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/comments/'.rawurlencode($comment));
+    }
+
+    /**
+     * Manage commit comment reactions.
+     *
+     * @link https://docs.github.com/en/rest/reactions/reactions#list-reactions-for-a-commit-comment
+     *
+     * @return Reactions
+     */
+    public function reactions()
+    {
+        return new Reactions($this->getClient());
     }
 }

--- a/lib/Github/Api/Repository/Comments/Reactions.php
+++ b/lib/Github/Api/Repository/Comments/Reactions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Github\Api\Repository\Comments;
+
+use Github\Api\AbstractReactionsApi;
+
+class Reactions extends AbstractReactionsApi
+{
+    /**
+     * @param string $username
+     * @param string $repository
+     * @param string $id
+     *
+     * @return string
+     */
+    protected function getReactionsPath($username, $repository, $id)
+    {
+        return '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/comments/'.rawurlencode($id).'/reactions';
+    }
+}

--- a/lib/Github/Api/Repository/Releases.php
+++ b/lib/Github/Api/Repository/Releases.php
@@ -3,6 +3,7 @@
 namespace Github\Api\Repository;
 
 use Github\Api\AbstractApi;
+use Github\Api\Repository\Releases\Reactions;
 use Github\Exception\MissingArgumentException;
 
 /**
@@ -137,5 +138,17 @@ class Releases extends AbstractApi
     public function assets()
     {
         return new Assets($this->getClient());
+    }
+
+    /**
+     * Manage release reactions.
+     *
+     * @link https://docs.github.com/en/rest/reactions/reactions#list-reactions-for-a-release
+     *
+     * @return Reactions
+     */
+    public function reactions()
+    {
+        return new Reactions($this->getClient());
     }
 }

--- a/lib/Github/Api/Repository/Releases/Reactions.php
+++ b/lib/Github/Api/Repository/Releases/Reactions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Github\Api\Repository\Releases;
+
+use Github\Api\AbstractReactionsApi;
+
+class Reactions extends AbstractReactionsApi
+{
+    /**
+     * @param string $username
+     * @param string $repository
+     * @param string $id
+     *
+     * @return string
+     */
+    protected function getReactionsPath($username, $repository, $id)
+    {
+        return '/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/releases/'.rawurlencode($id).'/reactions';
+    }
+}

--- a/test/Github/Tests/Api/Issue/Comments/ReactionsTest.php
+++ b/test/Github/Tests/Api/Issue/Comments/ReactionsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Github\Tests\Api\Issue\Comments;
+
+use Github\Exception\MissingArgumentException;
+use Github\Tests\Api\TestCase;
+
+class ReactionsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllIssueCommentReactions()
+    {
+        $expectedValue = [['reaction1data'], ['reaction2data']];
+        $parameters = ['content' => 'rocket'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/issues/comments/123/reactions', $parameters)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', 123, $parameters));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotCreateIssueCommentReactionWithoutContent()
+    {
+        $this->expectException(MissingArgumentException::class);
+
+        $api = $this->getApiMock();
+        $api->expects($this->never())
+            ->method('post');
+
+        $api->create('KnpLabs', 'php-github-api', 123, []);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateIssueCommentReaction()
+    {
+        $expectedValue = ['reaction1data'];
+        $data = ['content' => 'rocket'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/KnpLabs/php-github-api/issues/comments/123/reactions', $data)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', 123, $data));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRemoveIssueCommentReaction()
+    {
+        $expectedValue = ['someOutput'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('/repos/KnpLabs/php-github-api/issues/comments/123/reactions/456')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123, 456));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass()
+    {
+        return \Github\Api\Issue\Comments\Reactions::class;
+    }
+}

--- a/test/Github/Tests/Api/Issue/CommentsTest.php
+++ b/test/Github/Tests/Api/Issue/CommentsTest.php
@@ -138,6 +138,16 @@ class CommentsTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function shouldGetReactionsApiObject()
+    {
+        $api = $this->getApiMock();
+
+        $this->assertInstanceOf(\Github\Api\Issue\Comments\Reactions::class, $api->reactions());
+    }
+
+    /**
      * @return string
      */
     protected function getApiClass()

--- a/test/Github/Tests/Api/Issue/ReactionsTest.php
+++ b/test/Github/Tests/Api/Issue/ReactionsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Github\Tests\Api\Issue;
+
+use Github\Exception\MissingArgumentException;
+use Github\Tests\Api\TestCase;
+
+class ReactionsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllIssueReactions()
+    {
+        $expectedValue = [['reaction1data'], ['reaction2data']];
+        $parameters = ['content' => 'heart'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/issues/123/reactions', $parameters)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', 123, $parameters));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotCreateIssueReactionWithoutContent()
+    {
+        $this->expectException(MissingArgumentException::class);
+
+        $api = $this->getApiMock();
+        $api->expects($this->never())
+            ->method('post');
+
+        $api->create('KnpLabs', 'php-github-api', 123, []);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateIssueReaction()
+    {
+        $expectedValue = ['reaction1data'];
+        $data = ['content' => 'heart'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/KnpLabs/php-github-api/issues/123/reactions', $data)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', 123, $data));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRemoveIssueReaction()
+    {
+        $expectedValue = ['someOutput'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('/repos/KnpLabs/php-github-api/issues/123/reactions/456')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123, 456));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass()
+    {
+        return \Github\Api\Issue\Reactions::class;
+    }
+}

--- a/test/Github/Tests/Api/IssueTest.php
+++ b/test/Github/Tests/Api/IssueTest.php
@@ -169,6 +169,16 @@ class IssueTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetReactionsApiObject()
+    {
+        $api = $this->getApiMock();
+
+        $this->assertInstanceOf(\Github\Api\Issue\Reactions::class, $api->reactions());
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetEventsApiObject()
     {
         $api = $this->getApiMock();

--- a/test/Github/Tests/Api/PullRequest/Comments/ReactionsTest.php
+++ b/test/Github/Tests/Api/PullRequest/Comments/ReactionsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Github\Tests\Api\PullRequest\Comments;
+
+use Github\Exception\MissingArgumentException;
+use Github\Tests\Api\TestCase;
+
+class ReactionsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllPullRequestReviewCommentReactions()
+    {
+        $expectedValue = [['reaction1data'], ['reaction2data']];
+        $parameters = ['content' => 'eyes'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/pulls/comments/123/reactions', $parameters)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', 123, $parameters));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotCreatePullRequestReviewCommentReactionWithoutContent()
+    {
+        $this->expectException(MissingArgumentException::class);
+
+        $api = $this->getApiMock();
+        $api->expects($this->never())
+            ->method('post');
+
+        $api->create('KnpLabs', 'php-github-api', 123, []);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreatePullRequestReviewCommentReaction()
+    {
+        $expectedValue = ['reaction1data'];
+        $data = ['content' => 'eyes'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/KnpLabs/php-github-api/pulls/comments/123/reactions', $data)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', 123, $data));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRemovePullRequestReviewCommentReaction()
+    {
+        $expectedValue = ['someOutput'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('/repos/KnpLabs/php-github-api/pulls/comments/123/reactions/456')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123, 456));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass()
+    {
+        return \Github\Api\PullRequest\Comments\Reactions::class;
+    }
+}

--- a/test/Github/Tests/Api/PullRequest/CommentsTest.php
+++ b/test/Github/Tests/Api/PullRequest/CommentsTest.php
@@ -488,6 +488,16 @@ class CommentsTest extends TestCase
         $api->remove('octocat', 'Hello-World', 1);
     }
 
+    /**
+     * @test
+     */
+    public function shouldGetReactionsApiObject()
+    {
+        $api = $this->getApiMock();
+
+        $this->assertInstanceOf(\Github\Api\PullRequest\Comments\Reactions::class, $api->reactions());
+    }
+
     protected function getApiClass()
     {
         return Comments::class;

--- a/test/Github/Tests/Api/Repository/Comments/ReactionsTest.php
+++ b/test/Github/Tests/Api/Repository/Comments/ReactionsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Github\Tests\Api\Repository\Comments;
+
+use Github\Exception\MissingArgumentException;
+use Github\Tests\Api\TestCase;
+
+class ReactionsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllCommitCommentReactions()
+    {
+        $expectedValue = [['reaction1data'], ['reaction2data']];
+        $parameters = ['content' => 'hooray'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/comments/123/reactions', $parameters)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', 123, $parameters));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotCreateCommitCommentReactionWithoutContent()
+    {
+        $this->expectException(MissingArgumentException::class);
+
+        $api = $this->getApiMock();
+        $api->expects($this->never())
+            ->method('post');
+
+        $api->create('KnpLabs', 'php-github-api', 123, []);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateCommitCommentReaction()
+    {
+        $expectedValue = ['reaction1data'];
+        $data = ['content' => 'hooray'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/KnpLabs/php-github-api/comments/123/reactions', $data)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', 123, $data));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRemoveCommitCommentReaction()
+    {
+        $expectedValue = ['someOutput'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('/repos/KnpLabs/php-github-api/comments/123/reactions/456')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123, 456));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass()
+    {
+        return \Github\Api\Repository\Comments\Reactions::class;
+    }
+
+    /**
+     * @return \Github\Api\Repository\Comments\Reactions|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getApiMock()
+    {
+        return parent::getApiMock();
+    }
+}

--- a/test/Github/Tests/Api/Repository/CommentsTest.php
+++ b/test/Github/Tests/Api/Repository/CommentsTest.php
@@ -151,6 +151,16 @@ class CommentsTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function shouldGetReactionsApiObject()
+    {
+        $api = $this->getApiMock();
+
+        $this->assertInstanceOf(\Github\Api\Repository\Comments\Reactions::class, $api->reactions());
+    }
+
+    /**
      * @return string
      */
     protected function getApiClass()

--- a/test/Github/Tests/Api/Repository/Releases/ReactionsTest.php
+++ b/test/Github/Tests/Api/Repository/Releases/ReactionsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Github\Tests\Api\Repository\Releases;
+
+use Github\Exception\MissingArgumentException;
+use Github\Tests\Api\TestCase;
+
+class ReactionsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllReleaseReactions()
+    {
+        $expectedValue = [['reaction1data'], ['reaction2data']];
+        $parameters = ['content' => 'laugh'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('/repos/KnpLabs/php-github-api/releases/123/reactions', $parameters)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->all('KnpLabs', 'php-github-api', 123, $parameters));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotCreateReleaseReactionWithoutContent()
+    {
+        $this->expectException(MissingArgumentException::class);
+
+        $api = $this->getApiMock();
+        $api->expects($this->never())
+            ->method('post');
+
+        $api->create('KnpLabs', 'php-github-api', 123, []);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateReleaseReaction()
+    {
+        $expectedValue = ['reaction1data'];
+        $data = ['content' => 'laugh'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/KnpLabs/php-github-api/releases/123/reactions', $data)
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->create('KnpLabs', 'php-github-api', 123, $data));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRemoveReleaseReaction()
+    {
+        $expectedValue = ['someOutput'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('/repos/KnpLabs/php-github-api/releases/123/reactions/456')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->remove('KnpLabs', 'php-github-api', 123, 456));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass()
+    {
+        return \Github\Api\Repository\Releases\Reactions::class;
+    }
+}

--- a/test/Github/Tests/Api/Repository/ReleasesTest.php
+++ b/test/Github/Tests/Api/Repository/ReleasesTest.php
@@ -174,6 +174,16 @@ class ReleasesTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function shouldGetReactionsApiObject()
+    {
+        $api = $this->getApiMock();
+
+        $this->assertInstanceOf('Github\Api\Repository\Releases\Reactions', $api->reactions());
+    }
+
+    /**
      * @return string
      */
     protected function getApiClass()


### PR DESCRIPTION
Adds support for https://docs.github.com/en/rest/reactions/reactions#about-reactions

This increases commits, release, issues and more

closes: #1129

let me know if you need me to make any changes :)